### PR TITLE
fix(demo data): Add missing . to end of images-demo-data.ttl.

### DIFF
--- a/webapi/_test_data/demo_data/images-demo-data.ttl
+++ b/webapi/_test_data/demo_data/images-demo-data.ttl
@@ -52652,4 +52652,4 @@
                                          knora-base:preferredLanguage "de" ;
 
                                          knora-base:isInProject <http://data.knora.org/projects/images> ,
-                                                                <http://data.knora.org/projects/77275339>
+                                                                <http://data.knora.org/projects/77275339> .

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ResourcesV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ResourcesV1E2ESpec.scala
@@ -72,34 +72,20 @@ class ResourcesV1E2ESpec extends E2ESpec {
 
     "The Resources Endpoint" should {
         "provide a HTML representation of the resource properties " in {
-            /* Dokubib resource */
-            /* Dokubib data is commented out for now because it takes too long to load.
-                       Get("/v1/resources.html/http%3A%2F%2Fdata.knora.org%2F0871f7678dbf?noresedit=true&reqtype=properties") ~> resourcesPath ~> check {
-                           //log.debug("==>> " + responseAs[String])
-                           assert(status === StatusCodes.OK)
-                           assert(responseAs[String] contains("preview"))
-                           assert(responseAs[String] contains("Title"))
-                           assert(responseAs[String] contains("Season"))
-                           assert(responseAs[String] contains("Picture"))
-                           assert(responseAs[String] contains("Description"))
-                       } */
-
             /* Incunabula resource*/
             Get("/v1/resources.html/http%3A%2F%2Fdata.knora.org%2Fc5058f3a?noresedit=true&reqtype=properties") ~> resourcesPath ~> check {
                 //log.debug("==>> " + responseAs[String])
                 assert(status === StatusCodes.OK)
-                assert(responseAs[String] contains ("preview"))
-                assert(responseAs[String] contains ("Phyiscal description"))
-                assert(responseAs[String] contains ("Location"))
-                assert(responseAs[String] contains ("Publication location"))
-                assert(responseAs[String] contains ("URI"))
-                assert(responseAs[String] contains ("Title"))
-                assert(responseAs[String] contains ("Datum der Herausgabe"))
-                assert(responseAs[String] contains ("Citation/reference"))
-                assert(responseAs[String] contains ("Publisher"))
+                assert(responseAs[String] contains "preview")
+                assert(responseAs[String] contains "Phyiscal description")
+                assert(responseAs[String] contains "Location")
+                assert(responseAs[String] contains "Publication location")
+                assert(responseAs[String] contains "URI")
+                assert(responseAs[String] contains "Title")
+                assert(responseAs[String] contains "Datum der Herausgabe")
+                assert(responseAs[String] contains "Citation/reference")
+                assert(responseAs[String] contains "Publisher")
             }
         }
-
     }
-
 }


### PR DESCRIPTION
* Add missing `.` to end of `images-demo-data.ttl` so GraphDB doesn't complain about an unexpected end of file.
* Clean up `ResourcesV1E2ESpec` a bit.