### PR TITLE
Get ontology info from ontology responder, not from search queries

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/v1respondermessages/searchmessages/SearchMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1respondermessages/searchmessages/SearchMessagesV1.scala
@@ -140,7 +140,7 @@ case class SearchPreviewDimensionsV1(nx: Int, ny: Int)
   * @param value (text) value of the first property.
   */
 case class SearchResultRowV1(obj_id: IRI,
-                             preview_path: String,
+                             preview_path: Option[String],
                              iconsrc: Option[String],
                              icontitle: Option[String],
                              iconlabel: Option[String],

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/SearchResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/SearchResponderV1.scala
@@ -160,7 +160,7 @@ class SearchResponderV1 extends ResponderV1 {
                     val attachedToProject = row.rowMap("attachedToProject")
                     val permissionAssertions = row.rowMap("permissionAssertions")
                     val assertions = PermissionUtilV1.parsePermissions(permissionAssertions, attachedToUser, attachedToProject)
-                    val permission = PermissionUtilV1.getUserPermissionV1(row.rowMap("resourceIri"), assertions, searchGetRequest.userProfile)
+                    val permission = PermissionUtilV1.getUserPermissionV1(resourceIri, assertions, searchGetRequest.userProfile)
 
                     // The 'match' column contains the matching literal's value type and value, delimited
                     // by a non-printing delimiter character, Unicode INFORMATION SEPARATOR ONE, that should never occur in data.
@@ -175,7 +175,7 @@ class SearchResponderV1 extends ResponderV1 {
 
                     SearchResultRowV1(
                         obj_id = resourceIri,
-                        preview_path = row.rowMap.get("previewPath"), // TODO (issue 11): If there is no preview, use the resource class icon from teh ontology. Also, make a real Sipi path using ValueUtilV1.makeSipiFileGetUrl.
+                        preview_path = row.rowMap.get("previewPath"), // TODO (issue 11): If there is no preview, use the resource class icon from the ontology. Also, make a real Sipi path using ValueUtilV1.makeSipiFileGetUrl.
                         iconsrc = None, // TODO (issue 11): Get the resource class icon from the ontology. Also, make a real path here, using ValueUtilV1.makeSipiFileGetUrl.
                         iconlabel = None, // TODO (issue 11): Get the resource class icon from the ontology
                         icontitle = None, // TODO (issue 11): Get the resource class icon from the ontology
@@ -404,12 +404,12 @@ class SearchResponderV1 extends ResponderV1 {
 
             subjects = searchResponse.results.bindings.map {
                 row =>
-                    val resourceIri = row.rowMap("resourceIri")
+                    val resourceIri = row.rowMap("resource")
                     val attachedToUser = row.rowMap("attachedToUser")
                     val attachedToProject = row.rowMap("attachedToProject")
                     val permissionAssertions = row.rowMap("permissionAssertions")
                     val assertions = PermissionUtilV1.parsePermissions(permissionAssertions, attachedToUser, attachedToProject)
-                    val permission = PermissionUtilV1.getUserPermissionV1(row.rowMap("resourceIri"), assertions, searchGetRequest.userProfile)
+                    val permission = PermissionUtilV1.getUserPermissionV1(resourceIri, assertions, searchGetRequest.userProfile)
                     val literals = searchCriteria.indices.map(paramNum => row.rowMap(s"literal$paramNum"))
                     val valueTypeIDs = searchCriteria.map(_.valueType)
                     val valueLabels = searchCriteria.map {
@@ -423,13 +423,13 @@ class SearchResponderV1 extends ResponderV1 {
 
                     SearchResultRowV1(
                         obj_id = resourceIri,
-                        preview_path = row.rowMap.getOrElse("previewPath", row.rowMap("resourceClassIcon")), // TODO: get real path here
-                        iconsrc = Some(row.rowMap("resourceClassIcon")),
-                        iconlabel = Some(row.rowMap("resourceClassLabel")),
-                        icontitle = Some(row.rowMap("resourceClassLabel")),
+                        preview_path = row.rowMap.get("previewPath"), // TODO (issue 11): If there is no preview, use the resource class icon from the ontology. Also, make a real Sipi path using ValueUtilV1.makeSipiFileGetUrl.
+                        iconsrc = None, // TODO (issue 11): Get the resource class icon from the ontology. Also, make a real path here, using ValueUtilV1.makeSipiFileGetUrl.
+                        iconlabel = None, // TODO (issue 11): Get the resource class icon from the ontology
+                        icontitle = None, // TODO (issue 11): Get the resource class icon from the ontology
                         valuetype_id = OntologyConstants.Rdfs.Label +: valueTypeIDs,
                         valuelabel = "Label" +: valueLabels,
-                        value = row.rowMap("firstProperty") +: literals,
+                        value = row.rowMap("resourceLabel") +: literals,
                         preview_nx = row.rowMap.get("previewDimX") match {
                             case Some(previewDimX) => previewDimX.toInt
                             case None => settings.defaultIconSizeDimX

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/SipiResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/SipiResponderV1.scala
@@ -76,7 +76,7 @@ class SipiResponderV1 extends ResponderV1 {
             valueProps = valueUtilV1.createValueProps(fileValueIri, rows)
             valueV1 = valueUtilV1.makeValueV1(valueProps)
             path = valueV1 match {
-                case fileValueV1: FileValueV1 => valueUtilV1.makeSipiFileGetUrl(fileValueV1)
+                case fileValueV1: FileValueV1 => valueUtilV1.makeSipiFileGetUrlFromFileValueV1(fileValueV1)
                 case otherValue => throw InconsistentTriplestoreDataException(s"Value $fileValueIri is not a FileValue, it is an instance of ${otherValue.valueTypeIri}")
             }
             permissionCode = PermissionUtilV1.getUserPermissionV1WithValueProps(fileValueIri, valueProps, userProfile)

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ValueUtilV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ValueUtilV1.scala
@@ -123,8 +123,17 @@ class ValueUtilV1(private val settings: SettingsImpl) {
       * @param fileValueV1 the file value that the URL will point to.
       * @return a Sipi URL.
       */
-    def makeSipiFileGetUrl(fileValueV1: FileValueV1): String = {
-        s"${settings.sipiURL}:${settings.sipiPort}/${fileValueV1.internalFilename}"
+    def makeSipiFileGetUrlFromFileValueV1(fileValueV1: FileValueV1): String = {
+        makeSipiFileGetUrlFromFilename(fileValueV1.internalFilename)
+    }
+
+    /**
+      * Creates a URL for accessing a file via Sipi. // TODO: implement this correctly.
+      * @param filename the name of the file that the URL will point to.
+      * @return a Sipi URL.
+      */
+    def makeSipiFileGetUrlFromFilename(filename: String): String = {
+        s"${settings.sipiURL}:${settings.sipiPort}/$filename"
     }
 
     // A Map of MIME types to Knora API v1 binary format name.
@@ -164,7 +173,7 @@ class ValueUtilV1(private val settings: SettingsImpl) {
                     origname = stillImageFileValueV1.originalFilename,
                     nx = Some(stillImageFileValueV1.dimX),
                     ny = Some(stillImageFileValueV1.dimY),
-                    path = makeSipiFileGetUrl(fileValueV1)
+                    path = makeSipiFileGetUrlFromFileValueV1(fileValueV1)
                 )
         }
     }

--- a/webapi/src/main/twirl/queries/sparql/v1/searchExtended.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/searchExtended.scala.txt
@@ -71,13 +71,12 @@ prefix knora-base: <http://www.knora.org/ontology/knora-base#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 
 @if(countResults) {
-SELECT (COUNT(DISTINCT ?resourceIri) as ?count)
+SELECT (COUNT(DISTINCT ?resource) as ?count)
 } else {
 SELECT DISTINCT
-    ?resourceIri
-    ?resourceClassIcon
-    ?resourceClassLabel
-    ?firstProperty
+    ?resource
+    ?resourceLabel
+    ?resourceClass
     ?previewPath
     ?previewDimX
     ?previewDimY
@@ -104,10 +103,10 @@ WHERE {
         *@
 
         @if(searchCriterion.valueType != "http://www.knora.org/ontology/knora-base#Resource") {
-            ?resourceIri <@{searchCriterion.propertyIri}> ?valueObjectIri@index .
+            ?resource <@{searchCriterion.propertyIri}> ?valueObjectIri@index .
 
             MINUS {
-                ?resourceIri knora-base:isDeleted true .
+                ?resource knora-base:isDeleted true .
             }
         }
 
@@ -192,10 +191,10 @@ WHERE {
                 @searchCriterion.valueType match {
                     case "http://www.knora.org/ontology/knora-base#Resource" => {
 
-                        ?resourceIri <@{searchCriterion.propertyIri}> ?targetResource@index .
+                        ?resource <@{searchCriterion.propertyIri}> ?targetResource@index .
 
                         MINUS {
-                            ?resourceIri knora-base:isDeleted true .
+                            ?resource knora-base:isDeleted true .
                         }
 
                         ?targetResource@index rdfs:label ?anyLiteral@index .
@@ -273,10 +272,10 @@ WHERE {
 
                     case "http://www.knora.org/ontology/knora-base#Resource" => {
 
-                        ?resourceIri <@searchCriterion.propertyIri> <@searchCriterion.searchValue> .
+                        ?resource <@searchCriterion.propertyIri> <@searchCriterion.searchValue> .
 
                         MINUS {
-                            ?resourceIri knora-base:isDeleted true .
+                            ?resource knora-base:isDeleted true .
                         }
 
                         <@searchCriterion.searchValue> rdfs:label ?anyLiteral@index .
@@ -337,7 +336,6 @@ WHERE {
                         ?valueObjectIri@index knora-base:valueHasStartJDC ?dateStart@index .
                         ?valueObjectIri@index knora-base:valueHasEndJDC ?dateEnd@index .
                         ?valueObjectIri@index knora-base:valueHasString ?dateString@index .
-                        @* TODO: check the these conditions with the master of disaster Lukas *@
 
                         MINUS {
                             ?valueObjectIri@index knora-base:isDeleted true .
@@ -611,15 +609,15 @@ WHERE {
         }
     }
 
-    ?resourceIri rdfs:label ?firstProperty .
-    ?resourceIri a ?resourceClass .
+    ?resource rdfs:label ?resourceLabel .
+    ?resource a ?resourceClass .
 
 
     @projectIriOption match {
         case Some(projectIri) => {
 
             # filter by projectIri
-            ?resourceIri knora-base:attachedToProject <@projectIri> .
+            ?resource knora-base:attachedToProject <@projectIri> .
 
         }
 
@@ -630,7 +628,7 @@ WHERE {
         case Some(restypeIri) => {
 
             # filter by restypeIri
-            ?resourceIri a <@restypeIri> .
+            ?resource a <@restypeIri> .
         }
 
         case None => {}
@@ -641,33 +639,15 @@ WHERE {
         case Some(ownerIri) => {
 
             # filter by ownerIri
-            ?resourceIri knora-base:attachedToUser <@ownerIri> .
+            ?resource knora-base:attachedToUser <@ownerIri> .
         }
 
         case None => {}
     }
 
-    ?resourceClass knora-base:resourceIcon ?resourceClassIcon .
-
-    OPTIONAL {
-        ?resourceClass rdfs:label ?preferredLanguageResourceClassLabel .
-        FILTER (LANG(?preferredLanguageResourceClassLabel) = ?preferredLanguage) .
-    }
-
-    OPTIONAL {
-        ?resourceClass rdfs:label ?fallbackLanguageResourceClassLabel .
-        FILTER (LANG(?fallbackLanguageResourceClassLabel) = ?fallbackLanguage) .
-    }
-
-    OPTIONAL {
-        ?resourceClass rdfs:label ?anyLanguageResourceClassLabel .
-    }
-
-    BIND(COALESCE(str(?preferredLanguageResourceClassLabel), str(?fallbackLanguageResourceClassLabel), str(?anyLanguageResourceClassLabel)) AS ?resourceClassLabel)
-
     OPTIONAL {
         ?fileValueProp rdfs:subPropertyOf* knora-base:hasFileValue .
-        ?resourceIri ?fileValueProp ?fileValue .
+        ?resource ?fileValueProp ?fileValue .
         ?fileValue a knora-base:StillImageFileValue .
         ?fileValue knora-base:valueIsPreview true .
         ?fileValue knora-base:internalFilename ?previewPath .
@@ -680,31 +660,30 @@ WHERE {
 
     OPTIONAL {
         ?permission rdfs:subPropertyOf+ knora-base:hasPermission .
-        ?resourceIri ?permission ?group .
+        ?resource ?permission ?group .
         BIND(CONCAT(STR(?permission), ",", STR(?group)) as ?permissionAssertion)
     }
 
     OPTIONAL {
-        ?resourceIri knora-base:attachedToUser ?attachedToUser .
+        ?resource knora-base:attachedToUser ?attachedToUser .
     }
 
     OPTIONAL {
-        ?resourceIri knora-base:attachedToProject ?attachedToProject .
+        ?resource knora-base:attachedToProject ?attachedToProject .
     }
 }
 @if(!countResults) {
 GROUP BY
-    ?resourceIri
-    ?resourceClassIcon
-    ?resourceClassLabel
-    ?firstProperty
+    ?resource
+    ?resourceLabel
+    ?resourceClass
     ?previewPath
     ?previewDimX
     ?previewDimY
     ?attachedToUser
     ?attachedToProject
 
-ORDER BY ?resourceIri
+ORDER BY ?resource
 }
 
 @offsetOption match {

--- a/webapi/src/main/twirl/queries/sparql/v1/searchExtended.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/searchExtended.scala.txt
@@ -75,7 +75,7 @@ SELECT (COUNT(DISTINCT ?resource) as ?count)
 } else {
 SELECT DISTINCT
     ?resource
-    ?resourceLabel
+    ?resourceLabel @* The label of a matching resource. This is called "firstprop" in the v1 API. *@
     ?resourceClass
     ?previewPath
     ?previewDimX

--- a/webapi/src/main/twirl/queries/sparql/v1/searchFulltext.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/searchFulltext.scala.txt
@@ -65,7 +65,7 @@ prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix knora-base: <http://www.knora.org/ontology/knora-base#>
 
 @if(countResults) {
-SELECT (COUNT(DISTINCT ?resourceIri) as ?count)
+SELECT (COUNT(DISTINCT ?resource) as ?count)
 } else {
 SELECT DISTINCT
     ?resource

--- a/webapi/src/main/twirl/queries/sparql/v1/searchFulltext.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/searchFulltext.scala.txt
@@ -68,10 +68,9 @@ prefix knora-base: <http://www.knora.org/ontology/knora-base#>
 SELECT (COUNT(DISTINCT ?resourceIri) as ?count)
 } else {
 SELECT DISTINCT
-    ?resourceIri
-    ?resourceClassIcon
-    ?resourceClassLabel
-    ?firstProperty
+    ?resource
+    ?resourceLabel
+    ?resourceClass
     ?previewPath
     ?previewDimX
     ?previewDimY
@@ -98,14 +97,14 @@ WHERE {
     @triplestore match {
         case "graphdb" | "graphdb-free" => {
 
-            ?s ?p ?literal .
+            ?matchingSubject ?matchingProperty ?literal .
             ?literal <http://www.ontotext.com/owlim/lucene#fullTextSearchIndex> '@for((searchTerm, index) <- searchTerms.zipWithIndex) {@if(index > 0){ AND }@searchTerm}' .
 
         }
 
         case "embedded-jena-tdb" | "fuseki" => {
 
-            ?s <http://jena.apache.org/text#query> '@for((searchTerm, index) <- searchTerms.zipWithIndex) {@if(index > 0){ AND }@searchTerm}' .
+            ?matchingSubject <http://jena.apache.org/text#query> '@for((searchTerm, index) <- searchTerms.zipWithIndex) {@if(index > 0){ AND }@searchTerm}' .
 
         }
 
@@ -115,63 +114,47 @@ WHERE {
     }
 
     MINUS {
-        ?s knora-base:isDeleted true .
+        ?matchingSubject knora-base:isDeleted true .
     }
 
-    # ?s could be a resource (rdfs:label) or a value object
+    # ?matchingSubject could be a resource (rdfs:label) or a value object
 
     OPTIONAL {
         # if this clause is executed, it is a value object
 
-        ?s a ?valueObjectType .
+        ?matchingSubject a ?valueObjectType .
         ?valueObjectType rdfs:subClassOf+ knora-base:Value .
-        ?resIri ?resourceProperty ?s .
+        ?valueObjectResource ?resourceProperty ?matchingSubject .
+        ?resourceProperty rdfs:subPropertyOf+ knora-base:hasValue .
 
         @if(triplestore == "embedded-jena-tdb" || triplestore == "fuseki") {
-            ?s knora-base:valueHasString ?literal .
-            #?s ?p ?literal .
-            #FILTER(?p = knora-base:valueHasString || ?p = rdfs:label)
+            ?matchingSubject knora-base:valueHasString ?literal .
+            #?matchingSubject ?p ?literal .
+            #FILTER(?p = knora-base:valueHasString || ?matchingProperty = rdfs:label)
         }
 
-        OPTIONAL {
-            ?resourceProperty rdfs:label ?preferredLanguageResourcePropertyLabel .
-            FILTER (LANG(?preferredLanguageResourcePropertyLabel) = ?preferredLanguage) .
-        }
-
-        OPTIONAL {
-            ?resourceProperty rdfs:label ?fallbackLanguageResourcePropertyLabel .
-            FILTER (LANG(?fallbackLanguageResourcePropertyLabel) = ?fallbackLanguage) .
-        }
-
-        OPTIONAL {
-            ?resourceProperty rdfs:label ?anyLanguageResourcePropertyLabel .
-        }
-
-        BIND(COALESCE(str(?preferredLanguageResourcePropertyLabel), str(?fallbackLanguageResourcePropertyLabel), str(?anyLanguageResourcePropertyLabel)) AS ?propertyLabel)
-
-        # Concatenate each tuple of ?valueObjectType, ?propertyLabel, and ?literal into a string (using
+        # Concatenate each tuple of ?valueObjectType, ?resourceProperty, and ?literal into a string (using
         # a non-printing delimiter character, Unicode INFORMATION SEPARATOR ONE, that should never occur in data),
         # so the tuple can be treated as a unit in the SAMPLE function above.
-        BIND(CONCAT(STR(?valueObjectType), "@separator", STR(?propertyLabel), "@separator", STR(?literal)) AS ?anyMatch)
+        BIND(CONCAT(STR(?valueObjectType), "@separator", STR(?resourceProperty), "@separator", STR(?literal)) AS ?anyMatch)
 
         MINUS {
-            ?resIri knora-base:isDeleted true .
+            ?valueObjectResource knora-base:isDeleted true .
         }
     }
 
-    BIND(COALESCE(?resIri, ?s) AS ?resourceIri)
+    BIND(COALESCE(?valueObjectResource, ?matchingSubject) AS ?resource)
 
-    ?resourceIri a ?resourceClass .
+    ?resource a ?resourceClass .
     ?resourceClass rdfs:subClassOf+ knora-base:Resource .
-    ?resourceClass knora-base:resourceIcon ?resourceClassIcon .
 
-    ?resourceIri rdfs:label ?firstProperty .
+    ?resource rdfs:label ?resourceLabel .
 
     @projectIriOption match {
         case Some(projectIri) => {
 
             # filter by projectIri
-            ?resourceIri knora-base:attachedToProject <@projectIri> .
+            ?resource knora-base:attachedToProject <@projectIri> .
 
         }
 
@@ -182,31 +165,15 @@ WHERE {
         case Some(restypeIri) => {
 
             # filter by restypeIri
-            ?resourceIri a <@restypeIri> .
+            ?resource a <@restypeIri> .
         }
 
         case None => {}
     }
 
     OPTIONAL {
-        ?resourceClass rdfs:label ?preferredLanguageResourceClassLabel .
-        FILTER (LANG(?preferredLanguageResourceClassLabel) = ?preferredLanguage) .
-    }
-
-    OPTIONAL {
-        ?resourceClass rdfs:label ?fallbackLanguageResourceClassLabel .
-        FILTER (LANG(?fallbackLanguageResourceClassLabel) = ?fallbackLanguage) .
-    }
-
-    OPTIONAL {
-        ?resourceClass rdfs:label ?anyLanguageResourceClassLabel .
-    }
-
-    BIND(COALESCE(str(?preferredLanguageResourceClassLabel), str(?fallbackLanguageResourceClassLabel), str(?anyLanguageResourceClassLabel)) AS ?resourceClassLabel)
-
-    OPTIONAL {
         ?fileValueProp rdfs:subPropertyOf* knora-base:hasFileValue .
-        ?resourceIri ?fileValueProp ?fileValue .
+        ?resource ?fileValueProp ?fileValue .
         ?fileValue a knora-base:StillImageFileValue .
         ?fileValue knora-base:valueIsPreview true .
         ?fileValue knora-base:internalFilename ?previewPath .
@@ -219,31 +186,30 @@ WHERE {
 
     OPTIONAL {
         ?permission rdfs:subPropertyOf+ knora-base:hasPermission .
-        ?resourceIri ?permission ?group .
+        ?resource ?permission ?group .
         BIND(CONCAT(STR(?permission), ",", STR(?group)) as ?permissionAssertion)
     }
 
     OPTIONAL {
-        ?resourceIri knora-base:attachedToUser ?attachedToUser .
+        ?resource knora-base:attachedToUser ?attachedToUser .
     }
 
     OPTIONAL {
-        ?resourceIri knora-base:attachedToProject ?attachedToProject .
+        ?resource knora-base:attachedToProject ?attachedToProject .
     }
 }
 @if(!countResults) {
 GROUP BY
-    ?resourceIri
-    ?resourceClassIcon
-    ?resourceClassLabel
-    ?firstProperty
+    ?resource
+    ?resourceLabel
+    ?resourceClass
     ?previewPath
     ?previewDimX
     ?previewDimY
     ?attachedToUser
     ?attachedToProject
 
-ORDER BY ?resourceIri
+ORDER BY ?resource
 }
 
 @offsetOption match {

--- a/webapi/src/main/twirl/queries/sparql/v1/searchFulltext.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/searchFulltext.scala.txt
@@ -69,7 +69,7 @@ SELECT (COUNT(DISTINCT ?resource) as ?count)
 } else {
 SELECT DISTINCT
     ?resource
-    ?resourceLabel
+    ?resourceLabel @* The label of a matching resource. This is called "firstprop" in the v1 API. *@
     ?resourceClass
     ?previewPath
     ?previewDimX
@@ -124,7 +124,7 @@ WHERE {
 
         ?matchingSubject a ?valueObjectType .
         ?valueObjectType rdfs:subClassOf+ knora-base:Value .
-        ?valueObjectResource ?resourceProperty ?matchingSubject .
+        ?containingResource ?resourceProperty ?matchingSubject . @* ?containingResource is the resource that contains the matching value object *@
         ?resourceProperty rdfs:subPropertyOf+ knora-base:hasValue .
 
         @if(triplestore == "embedded-jena-tdb" || triplestore == "fuseki") {
@@ -139,11 +139,11 @@ WHERE {
         BIND(CONCAT(STR(?valueObjectType), "@separator", STR(?resourceProperty), "@separator", STR(?literal)) AS ?anyMatch)
 
         MINUS {
-            ?valueObjectResource knora-base:isDeleted true .
+            ?containingResource knora-base:isDeleted true .
         }
     }
 
-    BIND(COALESCE(?valueObjectResource, ?matchingSubject) AS ?resource)
+    BIND(COALESCE(?containingResource, ?matchingSubject) AS ?resource)
 
     ?resource a ?resourceClass .
     ?resourceClass rdfs:subClassOf+ knora-base:Resource .

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/SearchResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/SearchResponderV1Spec.scala
@@ -110,7 +110,7 @@ class SearchResponderV1Spec extends CoreSpec() with ImplicitSender {
                 iconlabel = Some("Buch"),
                 icontitle = Some("Buch"),
                 iconsrc = Some("book.gif"),
-                preview_path = "book.gif",
+                preview_path = Some("book.gif"),
                 obj_id = "http://data.knora.org/c5058f3a"
             ),
             SearchResultRowV1(
@@ -132,7 +132,7 @@ class SearchResponderV1Spec extends CoreSpec() with ImplicitSender {
                 iconlabel = Some("Buch"),
                 icontitle = Some("Buch"),
                 iconsrc = Some("book.gif"),
-                preview_path = "book.gif",
+                preview_path = Some("book.gif"),
                 obj_id = "http://data.knora.org/ff17e5ef9601"
             )
         ),
@@ -144,8 +144,8 @@ class SearchResponderV1Spec extends CoreSpec() with ImplicitSender {
         subjects = Vector(
             SearchResultRowV1(
                 obj_id = "http://data.knora.org/c5058f3a",
-                preview_path = "book.gif",
-                iconsrc = Some("http://localhost:3333/v1/assets/book.gif"),
+                preview_path = Some("book.gif"),
+                iconsrc = Some("book.gif"),
                 icontitle = Some("Buch"),
                 iconlabel = Some("Buch"),
                 valuetype_id = Vector("http://www.w3.org/2000/01/rdf-schema#label", "http://www.knora.org/ontology/knora-base#TextValue"),
@@ -157,8 +157,8 @@ class SearchResponderV1Spec extends CoreSpec() with ImplicitSender {
             ),
             SearchResultRowV1(
                 obj_id = "http://data.knora.org/ff17e5ef9601",
-                preview_path = "book.gif",
-                iconsrc = Some("http://localhost:3333/v1/assets/book.gif"),
+                preview_path = Some("book.gif"),
+                iconsrc = Some("book.gif"),
                 icontitle = Some("Buch"),
                 iconlabel = Some("Buch"),
                 valuetype_id = Vector("http://www.w3.org/2000/01/rdf-schema#label", "http://www.knora.org/ontology/knora-base#TextValue"),


### PR DESCRIPTION
This branch changes search SPARQL queries and the search responder so the search queries don't get ontology information. Instead, the search responder first does the search, then asks the ontology responder for the ontology information, which it merges into the search results.