### PR TITLE
Wip/sipi values responder

### DIFF
--- a/webapi/_test_data/test_route/change_page_with_binaries.py
+++ b/webapi/_test_data/test_route/change_page_with_binaries.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import requests, json, urllib
+
+#
+# This scripts tests the changing of the file value of a page and submits binary image data to the values route, testing the running Sipi server.
+#
+
+try:
+    base_url = "http://localhost/v1/"
+
+
+    filename = 'Chlaus.jpg'
+    path = 'images/'
+    mimetype = 'image/jpeg'
+
+    files = {'file': (filename, open(path + filename, 'rb'), mimetype)}
+
+    resIri = urllib.parse.quote_plus('http://data.knora.org/8a0b1e75')
+
+    r = requests.put(base_url + 'filevalue/' + resIri,
+                      files=files,
+                      headers=None,
+                      auth=('root', 'test'),
+                      proxies={'http': 'http://localhost:3333'})
+
+    r.raise_for_status()
+    print(r.text)
+except Exception as e:
+    print('Knora API answered with an error:\n')
+    print(e)
+    print(r.text)

--- a/webapi/_test_data/test_route/change_page_with_params.py
+++ b/webapi/_test_data/test_route/change_page_with_params.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import requests, json, urllib
+
+#
+# This scripts tests the chaning ogf the file value of a page and submits image data params (no binaries) to the values route, testing the running Sipi server.
+#
+
+try:
+    base_url = "http://localhost/v1/"
+
+    params = {
+        'file': {
+            'originalFilename' : "Chlaus.jpg",
+            'originalMimeType' : "image/jpeg",
+            'filename' : "./test_server/images/Chlaus.jpg"
+        }
+    }
+
+    resIri = urllib.parse.quote_plus('http://data.knora.org/8a0b1e75')
+
+    r = requests.put(base_url + 'filevalue/' + resIri,
+                      data=json.dumps(params),
+                      headers={'content-type': 'application/json; charset=utf8'},
+                      auth=('root', 'test'),
+                      proxies={'http': 'http://localhost:3333'})
+
+    r.raise_for_status()
+    print(r.text)
+except Exception as e:
+    print('Knora API answered with an error:\n')
+    print(e)
+    print(r.text)

--- a/webapi/_test_data/test_route/change_page_with_params.py
+++ b/webapi/_test_data/test_route/change_page_with_params.py
@@ -3,7 +3,7 @@
 import requests, json, urllib
 
 #
-# This scripts tests the chaning ogf the file value of a page and submits image data params (no binaries) to the values route, testing the running Sipi server.
+# This scripts tests the changing of the file value of a page and submits image data params (no binaries) to the values route, testing the running Sipi server.
 #
 
 try:

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -127,6 +127,7 @@ object OntologyConstants {
         val IntervalValue = "http://www.knora.org/ontology/knora-base#IntervalValue"
         val TimeValue = "http://www.knora.org/ontology/knora-base#TimeValue"
         val StillImageFileValue = "http://www.knora.org/ontology/knora-base#StillImageFileValue"
+        val MovingImageFileValue = "http://www.knora.org/ontology/knora-base#MovingImageFileValue"
         val FileValue = "http://www.knora.org/ontology/knora-base#FileValue"
         val LinkValue = "http://www.knora.org/ontology/knora-base#LinkValue"
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1respondermessages/valuemessages/ValueMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1respondermessages/valuemessages/ValueMessagesV1.scala
@@ -23,6 +23,7 @@ package org.knora.webapi.messages.v1respondermessages.valuemessages
 import java.util.UUID
 
 import org.knora.webapi._
+import org.knora.webapi.messages.v1respondermessages.sipimessages.SipiResponderConversionRequestV1
 import org.knora.webapi.messages.v1respondermessages.usermessages.{UserDataV1, UserProfileV1}
 import org.knora.webapi.messages.v1respondermessages.{KnoraRequestV1, KnoraResponseV1}
 import org.knora.webapi.util.DateUtilV1
@@ -45,6 +46,8 @@ import spray.json._
   * @param float_value    a floating-point literal to be used in the value.
   * @param date_value     a date object to be used in the value.
   * @param color_value    a colour literal to be used in the value.
+  * @param geom_value     a geometry literal to be used in the value.
+  * @param comment        a comment to add to the value.
   */
 case class CreateValueApiRequestV1(project_id: IRI,
                                    res_id: IRI,
@@ -113,6 +116,7 @@ case class CreateFileQualityLevelV1(path: String,
   * @param date_value     a date object to be used in the value.
   * @param color_value    a colour literal to be used in the value.
   * @param geom_value     a geometry literal to be used in the value.
+  * @param comment        a comment to add to the value.
   */
 case class ChangeValueApiRequestV1(project_id: IRI,
                                    richtext_value: Option[CreateRichtextV1] = None,
@@ -122,6 +126,14 @@ case class ChangeValueApiRequestV1(project_id: IRI,
                                    color_value: Option[String] = None,
                                    geom_value: Option[String] = None,
                                    comment: Option[String] = None)
+
+/**
+  * Represents an API request payload that asks the Knora API server to change the file attached to a resource
+  * (i. e. to create a new version of its file values).
+  *
+  * @param file the new file to be attached to the resource (GUI-case).
+  */
+case class ChangeFileValueApiRequestV1(file: CreateFileV1)
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Messages
@@ -237,6 +249,7 @@ case class UnverifiedCreateValueResponseV1(newValueIri: IRI, value: UpdateValueV
 
 /**
   * Requests verification that new values were created.
+  *
   * @param resourceIri the IRI of the resource in which the values should have been created.
   * @param unverifiedValues a [[Map]] of property IRIs to [[UnverifiedCreateValueResponseV1]] objects
   *                         describing the values that should have been created for each property.
@@ -249,6 +262,7 @@ case class VerifyMultipleValueCreationRequestV1(resourceIri: IRI,
 /**
   * In response to a [[VerifyMultipleValueCreationRequestV1]], indicates that all requested values were
   * created successfully.
+  *
   * @param verifiedValues information about the values that were created.
   */
 case class VerifyMultipleValueCreationResponseV1(verifiedValues: Map[IRI, Seq[CreateValueResponseV1]])
@@ -368,6 +382,26 @@ case class DeleteValueResponseV1(id: IRI,
     def toJsValue = ApiValueV1JsonProtocol.deleteValueResponseV1Format.write(this)
 }
 
+/**
+  * Represents a request to change (update) the file value(s) of a given resource.
+  * In case of an image, two file valueshave to be changed: thumbnail and full quality.
+  *
+  * @param resourceIri the resource whose files value(s) should be changed.
+  * @param file the file to be created and added.
+  */
+case class ChangeFileValueRequestV1(resourceIri: IRI, file: SipiResponderConversionRequestV1, apiRequestID: UUID, userProfile: UserProfileV1) extends ValuesResponderRequestV1
+
+/**
+  * Represents a response to a [[ChangeFileValueRequestV1]].
+  * Possibly, two file values have been changed (thumb and full quality).
+  *
+  * @param changedFilesValues the updated file value(s).
+  * @param userdata information about the user that made the request.
+  */
+case class ChangeFileValueResponseV1(changedFilesValues: Vector[ChangeValueResponseV1],
+                                 userdata: UserDataV1) extends KnoraResponseV1 {
+    def toJsValue = ApiValueV1JsonProtocol.changeFileValueresponseV1Format.write(this)
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Components of messages
@@ -871,6 +905,19 @@ case class StillImageFileValueV1(internalMimeType: String,
     override def toString = originalFilename
 }
 
+case class MovingImageFileValueV1(internalMimeType: String,
+                                internalFilename: String,
+                                originalFilename: String,
+                                originalMimeType: Option[String] = None) extends FileValueV1 {
+
+    def valueTypeIri = OntologyConstants.KnoraBase.MovingImageFileValue
+
+    def toJsValue = ApiValueV1JsonProtocol.movingImageFileValueV1Format.write(this)
+
+    override def toString = originalFilename
+
+}
+
 
 /**
   * Represents information about a version of a value.
@@ -973,6 +1020,7 @@ object ApiValueV1JsonProtocol extends DefaultJsonProtocol with NullOptions with 
     implicit val valueGetResponseV1Format: RootJsonFormat[ValueGetResponseV1] = jsonFormat4(ValueGetResponseV1)
     implicit val dateValueV1Format: JsonFormat[DateValueV1] = jsonFormat3(DateValueV1)
     implicit val stillImageFileValueV1Format: JsonFormat[StillImageFileValueV1] = jsonFormat9(StillImageFileValueV1)
+    implicit val movingImageFileValueV1Format: JsonFormat[MovingImageFileValueV1] = jsonFormat4(MovingImageFileValueV1)
     implicit val valueVersionV1Format: JsonFormat[ValueVersionV1] = jsonFormat3(ValueVersionV1)
     implicit val linkValueV1Format: JsonFormat[LinkValueV1] = jsonFormat4(LinkValueV1)
     implicit val valueVersionHistoryGetResponseV1Format: RootJsonFormat[ValueVersionHistoryGetResponseV1] = jsonFormat2(ValueVersionHistoryGetResponseV1)
@@ -982,4 +1030,6 @@ object ApiValueV1JsonProtocol extends DefaultJsonProtocol with NullOptions with 
     implicit val changeValueApiRequestV1Format: RootJsonFormat[ChangeValueApiRequestV1] = jsonFormat8(ChangeValueApiRequestV1)
     implicit val changeValueResponseV1Format: RootJsonFormat[ChangeValueResponseV1] = jsonFormat5(ChangeValueResponseV1)
     implicit val deleteValueResponseV1Format: RootJsonFormat[DeleteValueResponseV1] = jsonFormat2(DeleteValueResponseV1)
+    implicit val changeFileValueApiRequestV1Format: RootJsonFormat[ChangeFileValueApiRequestV1] = jsonFormat1(ChangeFileValueApiRequestV1)
+    implicit val changeFileValueresponseV1Format: RootJsonFormat[ChangeFileValueResponseV1] = jsonFormat2(ChangeFileValueResponseV1)
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1respondermessages/valuemessages/ValueMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1respondermessages/valuemessages/ValueMessagesV1.scala
@@ -133,7 +133,10 @@ case class ChangeValueApiRequestV1(project_id: IRI,
   *
   * @param file the new file to be attached to the resource (GUI-case).
   */
-case class ChangeFileValueApiRequestV1(file: CreateFileV1)
+case class ChangeFileValueApiRequestV1(file: CreateFileV1) {
+
+    def toJsValue = ApiValueV1JsonProtocol.changeFileValueApiRequestV1Format.write(this)
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Messages
@@ -243,17 +246,17 @@ case class CreateValueResponseV1(value: ApiValueV1,
   * To verify that the value was in fact created, send a [[VerifyMultipleValueCreationRequestV1]].
   *
   * @param newValueIri the IRI of the value that should have been created.
-  * @param value the [[UpdateValueV1]] that was used to request the creation of the value.
+  * @param value       the [[UpdateValueV1]] that was used to request the creation of the value.
   */
 case class UnverifiedCreateValueResponseV1(newValueIri: IRI, value: UpdateValueV1)
 
 /**
   * Requests verification that new values were created.
   *
-  * @param resourceIri the IRI of the resource in which the values should have been created.
+  * @param resourceIri      the IRI of the resource in which the values should have been created.
   * @param unverifiedValues a [[Map]] of property IRIs to [[UnverifiedCreateValueResponseV1]] objects
   *                         describing the values that should have been created for each property.
-  * @param userProfile the profile of the user making the request.
+  * @param userProfile      the profile of the user making the request.
   */
 case class VerifyMultipleValueCreationRequestV1(resourceIri: IRI,
                                                 unverifiedValues: Map[IRI, Seq[UnverifiedCreateValueResponseV1]],
@@ -286,9 +289,9 @@ case class CreateValueV1WithComment(updateValueV1: UpdateValueV1, comment: Optio
   * - The resource class has a suitable cardinality for each submitted value.
   * - All required values are provided.
   *
-  * @param transactionID the ID of the transaction in which the values should be created.
-  * @param projectIri the project the values belong to.
-  * @param resourceIri the resource the values will be attached to.
+  * @param transactionID    the ID of the transaction in which the values should be created.
+  * @param projectIri       the project the values belong to.
+  * @param resourceIri      the resource the values will be attached to.
   * @param resourceClassIri the IRI of the resource's OWL class.
   * @param values           the values to be added, with optional comments.
   * @param userProfile      the user that is creating the values.
@@ -387,7 +390,7 @@ case class DeleteValueResponseV1(id: IRI,
   * In case of an image, two file valueshave to be changed: thumbnail and full quality.
   *
   * @param resourceIri the resource whose files value(s) should be changed.
-  * @param file the file to be created and added.
+  * @param file        the file to be created and added.
   */
 case class ChangeFileValueRequestV1(resourceIri: IRI, file: SipiResponderConversionRequestV1, apiRequestID: UUID, userProfile: UserProfileV1) extends ValuesResponderRequestV1
 
@@ -396,10 +399,10 @@ case class ChangeFileValueRequestV1(resourceIri: IRI, file: SipiResponderConvers
   * Possibly, two file values have been changed (thumb and full quality).
   *
   * @param changedFilesValues the updated file value(s).
-  * @param userdata information about the user that made the request.
+  * @param userdata           information about the user that made the request.
   */
 case class ChangeFileValueResponseV1(changedFilesValues: Vector[ChangeValueResponseV1],
-                                 userdata: UserDataV1) extends KnoraResponseV1 {
+                                     userdata: UserDataV1) extends KnoraResponseV1 {
     def toJsValue = ApiValueV1JsonProtocol.changeFileValueresponseV1Format.write(this)
 }
 
@@ -906,9 +909,9 @@ case class StillImageFileValueV1(internalMimeType: String,
 }
 
 case class MovingImageFileValueV1(internalMimeType: String,
-                                internalFilename: String,
-                                originalFilename: String,
-                                originalMimeType: Option[String] = None) extends FileValueV1 {
+                                  internalFilename: String,
+                                  originalFilename: String,
+                                  originalMimeType: Option[String] = None) extends FileValueV1 {
 
     def valueTypeIri = OntologyConstants.KnoraBase.MovingImageFileValue
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/ResourceLocker.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/ResourceLocker.scala
@@ -130,7 +130,7 @@ object ResourceLocker {
                 acquireOrIncrementLock(resourceIri, apiRequestID, tries - 1)
             } else {
                 // No, we've run out of retries, so throw an exception.
-                throw ApplicationLockException(s"Could not acquire update lock on resource $resourceIri within $MAX_LOCK_RETRY_MILLIS ms")
+                throw ApplicationLockException(s"Could not acquire update lock on resource $resourceIri within $MAX_LOCK_RETRY_MILLIS ms, because ${newLock.apiRequestID} is holding it")
             }
         }
     }

--- a/webapi/src/main/scala/org/knora/webapi/responders/ResourceLocker.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/ResourceLocker.scala
@@ -130,7 +130,7 @@ object ResourceLocker {
                 acquireOrIncrementLock(resourceIri, apiRequestID, tries - 1)
             } else {
                 // No, we've run out of retries, so throw an exception.
-                throw ApplicationLockException(s"Could not acquire update lock on resource $resourceIri within $MAX_LOCK_RETRY_MILLIS ms, because ${newLock.apiRequestID} is holding it")
+                throw ApplicationLockException(s"Could not acquire update lock on resource $resourceIri for API request $apiRequestID within $MAX_LOCK_RETRY_MILLIS ms, because API request ${newLock.apiRequestID} is holding it")
             }
         }
     }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
@@ -1005,7 +1005,7 @@ class ResourcesResponderV1 extends ResponderV1 {
 
                         // check if the file type returned by Sipi corresponds to the expected fileValue property in resourceClassInfo.fileValueProperties.head
                         _ = if (SipiConstants.fileType2FileValueProperty(sipiResponse.file_type) != resourceClassInfo.fileValueProperties.head) {
-                            // TODO: remove the file from SIPI
+                            // TODO: remove the file from SIPI (delete request)
                             throw BadRequestException(s"Type of submitted file (${sipiResponse.file_type}) does not correspond to expected property type ${resourceClassInfo.fileValueProperties.head}")
                         }
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
@@ -39,6 +39,7 @@ import org.knora.webapi.util.ActorUtil._
 import org.knora.webapi.util._
 
 import scala.concurrent.{Future, Promise}
+import scala.util.Try
 
 /**
   * Responds to requests for information about resources, and returns responses in Knora API v1 format.
@@ -880,6 +881,7 @@ class ResourcesResponderV1 extends ResponderV1 {
       * @return a [[ResourceCreateResponseV1]] informing the client about the new resource.
       */
     private def createNewResource(resourceClassIri: IRI, label: String, values: Map[IRI, Seq[CreateValueV1WithComment]], sipiConversionRequest: Option[SipiResponderConversionRequestV1] = None, projectIri: IRI, userProfile: UserProfileV1, apiRequestID: UUID): Future[ResourceCreateResponseV1] = {
+
         /**
           * Implements a pre-update check to ensure that an [[UpdateValueV1]] has the correct type for the `knora-base:objectClassConstraint` of
           * the property that is supposed to point to it.
@@ -1003,6 +1005,7 @@ class ResourcesResponderV1 extends ResponderV1 {
 
                         // check if the file type returned by Sipi corresponds to the expected fileValue property in resourceClassInfo.fileValueProperties.head
                         _ = if (SipiConstants.fileType2FileValueProperty(sipiResponse.file_type) != resourceClassInfo.fileValueProperties.head) {
+                            // TODO: remove the file from SIPI
                             throw BadRequestException(s"Type of submitted file (${sipiResponse.file_type}) does not correspond to expected property type ${resourceClassInfo.fileValueProperties.head}")
                         }
 
@@ -1013,16 +1016,14 @@ class ResourcesResponderV1 extends ResponderV1 {
                 } else {
                     // resource class requires no binary representation
                     // check if there was no file sent
+                    // TODO: in all cases of an error, the tmp file has to be deleted
                     sipiConversionRequest match {
                         case None => Future(None) // expected behaviour
                         case Some(sipiConversionFileRequest: SipiResponderConversionFileRequestV1) =>
                             throw BadRequestException(s"File params (GUI-case) are given but resource class $resourceClassIri does not allow any representation")
                         case Some(sipiConversionPathRequest: SipiResponderConversionPathRequestV1) =>
-                            // a tmp file has been created by the resources route, delete it (SipiResponder was not called, so do it here)
-                            InputValidation.deleteFileFromTmpLocation(sipiConversionPathRequest.source)
                             throw BadRequestException(s"A binary file was provided (non GUI-case) but resource class $resourceClassIri does not have any binary representation")
                     }
-
                 }
 
                 // Everything looks OK, so we can create an empty resource and add the values to it. This must
@@ -1094,19 +1095,17 @@ class ResourcesResponderV1 extends ResponderV1 {
             } yield apiResponse
         }
 
-        val maybeUserIri: Option[IRI] = userProfile.userData.user_id
-        // TODO: remove dummy user after testing!
-        //val maybeUserIri: Option[IRI] = Some("http://data.knora.org/users/91e19f1e01")
-
-        val namedGraph = settings.projectNamedGraphs(projectIri).data
-        val resourceIri: IRI = knoraIriUtil.makeRandomResourceIri
-
-        for {
+        val resultFuture = for {
         // Don't allow anonymous users to create resources.
-            userIri <- maybeUserIri match {
-                case Some(iri) => Future(iri)
-                case None => Future.failed(ForbiddenException("Anonymous users aren't allowed to create resources"))
+            userIri: IRI <- Future {
+                userProfile.userData.user_id match {
+                    case Some(iri) => iri
+                    case None => throw ForbiddenException("Anonymous users aren't allowed to create resources")
+                }
             }
+
+            namedGraph = settings.projectNamedGraphs(projectIri).data
+            resourceIri: IRI = knoraIriUtil.makeRandomResourceIri
 
             // check if the user has the permissions to create a new resource in the given project
             // get project info that includes the permissions the current user has on the project
@@ -1150,6 +1149,21 @@ class ResourcesResponderV1 extends ResponderV1 {
                 )
             )
         } yield result
+
+        // If a temporary file was created, ensure that it's deleted, regardless of whether the request succeeded or failed.
+        resultFuture.andThen {
+            case _ =>
+                sipiConversionRequest match {
+                    case Some(conversionRequest) =>
+                        conversionRequest match {
+                            case (conversionPathRequest: SipiResponderConversionPathRequestV1) =>
+                                // a tmp file has been created by the resources route (non GUI-case), delete it
+                                InputValidation.deleteFileFromTmpLocation(conversionPathRequest.source, log)
+                            case _ => ()
+                        }
+                    case None => ()
+                }
+        }
     }
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/SipiResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/SipiResponderV1.scala
@@ -203,7 +203,7 @@ class SipiResponderV1 extends ResponderV1 {
                             isPreview = true
                         ))
 
-                case unknownType => throw BadRequestException(s"Could not handle file type $unknownType")
+                case unknownType => throw NotImplementedException(s"Could not handle file type $unknownType")
 
                 // TODO: add missing file types
             }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/SipiResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/SipiResponderV1.scala
@@ -95,16 +95,6 @@ class SipiResponderV1 extends ResponderV1 {
       */
     private def callSipiConvertRoute(url: String, conversionRequest: SipiResponderConversionRequestV1): Future[SipiResponderConversionResponseV1] = {
 
-        // delete tmp file (depending on the kind of request given: only necessary if Knora stored the file - non GUI-case)
-        def deleteTmpFile(conversionRequest: SipiResponderConversionRequestV1): Unit = {
-            conversionRequest match {
-                case (conversionPathRequest: SipiResponderConversionPathRequestV1) =>
-                    // a tmp file has been created by the resources route (non GUI-case), delete it
-                    InputValidation.deleteFileFromTmpLocation(conversionPathRequest.source)
-                case _ => ()
-            }
-        }
-
         // define a pipeline function that gets turned into a generic [[HTTP Response]] (containing JSON)
         val pipeline: HttpRequest => Future[HttpResponse] = (
             addHeader("Accept", "application/json")
@@ -124,13 +114,11 @@ class SipiResponderV1 extends ResponderV1 {
         //
         val recoveredConversionResultFuture = conversionResultFuture.recoverWith {
             case noResponse: spray.can.Http.ConnectionAttemptFailedException =>
-                deleteTmpFile(conversionRequest) // delete tmp file (if given)
                 // this problem is hardly the user's fault. Create a SipiException
                 throw SipiException(message = "Sipi not reachable", e = noResponse, log = log)
 
             case httpError: spray.httpx.UnsuccessfulResponseException =>
-                deleteTmpFile(conversionRequest) // delete tmp file (if given)
-            val statusCode: StatusCode = httpError.response.status
+                val statusCode: StatusCode = httpError.response.status
 
                 val statusInt: Int = statusCode.intValue / 100
 
@@ -155,7 +143,6 @@ class SipiResponderV1 extends ResponderV1 {
 
             case err =>
                 // unknown error
-                deleteTmpFile(conversionRequest) // delete tmp file (if given)
                 throw SipiException(message = s"Unknown error: ${err.toString}", e = err, log = log)
 
         }
@@ -163,9 +150,6 @@ class SipiResponderV1 extends ResponderV1 {
         for {
 
             conversionResultResponse <- recoveredConversionResultFuture
-
-            // delete tmp file
-            _ = deleteTmpFile(conversionRequest)
 
             // get file type from Sipi response
             responseAsMap: Map[String, JsValue] = conversionResultResponse.entity.asString.parseJson.asJsObject.fields.toMap

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ValueUtilV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ValueUtilV1.scala
@@ -115,6 +115,7 @@ class ValueUtilV1(private val settings: SettingsImpl) {
                     ny = Some(stillImageFileValueV1.dimY),
                     path = makeSipiFileGetUrlFromFileValueV1(fileValueV1)
                 )
+            case otherType => throw NotImplementedException(s"Type not yet implemented: ${otherType.valueTypeIri}")
         }
     }
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
@@ -27,13 +27,15 @@ import akka.pattern._
 import org.knora.webapi._
 import org.knora.webapi.messages.v1respondermessages.ontologymessages._
 import org.knora.webapi.messages.v1respondermessages.resourcemessages._
+import org.knora.webapi.messages.v1respondermessages.sipimessages.SipiConstants.FileType
+import org.knora.webapi.messages.v1respondermessages.sipimessages.{SipiConstants, SipiResponderConversionResponseV1, SipiResponderConversionPathRequestV1, SipiResponderConversionRequestV1}
 import org.knora.webapi.messages.v1respondermessages.triplestoremessages._
 import org.knora.webapi.messages.v1respondermessages.usermessages.UserProfileV1
 import org.knora.webapi.messages.v1respondermessages.valuemessages._
 import org.knora.webapi.responders.ResourceLocker
 import org.knora.webapi.twirl.SparqlTemplateLinkUpdate
 import org.knora.webapi.util.ActorUtil._
-import org.knora.webapi.util.{ActorUtil, KnoraIriUtil}
+import org.knora.webapi.util.{InputValidation, ScalaPrettyPrinter, ActorUtil, KnoraIriUtil}
 
 import scala.annotation.tailrec
 import scala.collection.breakOut
@@ -61,6 +63,7 @@ class ValuesResponderV1 extends ResponderV1 {
         case versionHistoryRequest: ValueVersionHistoryGetRequestV1 => future2Message(sender(), getValueVersionHistoryResponseV1(versionHistoryRequest), log)
         case createValueRequest: CreateValueRequestV1 => future2Message(sender(), createValueV1(createValueRequest), log)
         case changeValueRequest: ChangeValueRequestV1 => future2Message(sender(), changeValueV1(changeValueRequest), log)
+        case changeFileValueRequest: ChangeFileValueRequestV1 => future2Message(sender(), changeFileValueV1(changeFileValueRequest), log)
         case changeCommentRequest: ChangeCommentRequestV1 => future2Message(sender(), changeCommentV1(changeCommentRequest), log)
         case deleteValueRequest: DeleteValueRequestV1 => future2Message(sender(), deleteValueV1(deleteValueRequest), log)
         case createMultipleValuesRequest: CreateMultipleValuesRequestV1 => future2Message(sender(), createMultipleValuesV1(createMultipleValuesRequest), log)
@@ -314,6 +317,7 @@ class ValuesResponderV1 extends ResponderV1 {
 
     /**
       * Verifies the creation of multiple values.
+      *
       * @param verifyRequest a [[VerifyMultipleValueCreationRequestV1]].
       * @return a [[VerifyMultipleValueCreationResponseV1]] if all values were created successfully, or a failed
       *         future if any values were not created.
@@ -342,6 +346,116 @@ class ValuesResponderV1 extends ResponderV1 {
         for {
             valueVerificationResponses: Map[IRI, Seq[CreateValueResponseV1]] <- ActorUtil.sequenceFuturesInMap(valueVerificationFutures)
         } yield VerifyMultipleValueCreationResponseV1(verifiedValues = valueVerificationResponses)
+    }
+
+    /**
+      * Temporary structure to represent existing file values of a resource.
+      *
+      * @param property       the property Iri (e.g., hasStillImageFileValueRepresentation)
+      * @param valueObjectIri the Iri of the value object.
+      * @param quality        the quality of the file value
+      */
+    private case class CurrentFileValue(property: IRI, valueObjectIri: IRI, quality: Option[Int])
+
+    private def changeFileValueV1(changeFileValueRequest: ChangeFileValueRequestV1): Future[ChangeFileValueResponseV1] = {
+
+        // get the Iris of the current file value(s)
+        val resultFuture = for {
+
+            resourceIri <- Future(changeFileValueRequest.resourceIri)
+
+            getFileValuesSparql = queries.sparql.v1.txt.getFileValuesForResource(resourceIri = resourceIri).toString()
+            //_ = print(getFileValuesSparql)
+            getFileValuesResponse: SparqlSelectResponse <- (storeManager ? SparqlSelectRequest(getFileValuesSparql)).mapTo[SparqlSelectResponse]
+            // _ <- Future(println(getFileValuesResponse))
+
+
+            // get the property Iris, file value Iris and qualities attached to the resource
+            fileValues: Seq[CurrentFileValue] = getFileValuesResponse.results.bindings.map {
+                (row: VariableResultsRow) =>
+
+                    CurrentFileValue(
+                        property = row.rowMap("p"),
+                        valueObjectIri = row.rowMap("fileValueIri"),
+                        quality = row.rowMap("quality") match {
+                            case "" => None
+                            case quality: String => Some(quality.toInt)
+                        }
+                    )
+            }
+
+            sipiConversionMessage: SipiResponderConversionRequestV1 = changeFileValueRequest.file
+
+            // if resource has no existing file values, throw an exception
+            _ = if (fileValues.isEmpty) {
+                BadRequestException(s"File values for ${resourceIri} should be updated, but resource has no existing file values")
+            }
+
+            // the message to be sent to Sipi responder
+            sipiConversionRequest: SipiResponderConversionRequestV1 = changeFileValueRequest.file
+
+            sipiResponse: SipiResponderConversionResponseV1 <- (responderManager ? sipiConversionRequest).mapTo[SipiResponderConversionResponseV1]
+
+            // check if the file type returned by Sipi corresponds to the already exisitng file value type (e.g., hasStillImageRepresentation)
+            _ = if (SipiConstants.fileType2FileValueProperty(sipiResponse.file_type) != fileValues.head.property) {
+                // TODO: remove the file from SIPI
+                throw BadRequestException(s"Type of submitted file (${sipiResponse.file_type}) does not correspond to expected property type ${fileValues.head.property}")
+            }
+
+            // handle file types individually
+
+            // create the apt case class depending on the file type returned by Sipi
+            changedFileValues: Vector[ChangeValueResponseV1] <- Future.sequence(sipiResponse.file_type match {
+                case SipiConstants.FileType.IMAGE =>
+                    // we deal with hasStillImageFileValue, so there need to be two file values:
+                    // one for the full and one for the thumb
+                    if (fileValues.size != 2) {
+                        throw InconsistentTriplestoreDataException(s"Expected 2 file values for ${resourceIri}, but ${fileValues.size} given.")
+                    }
+
+                    // sort file values by quality
+                    val oldFileValuesSorted: Seq[CurrentFileValue] = fileValues.sortBy(_.quality)
+                    val newFileValuesSorted: Vector[FileValueV1] = sipiResponse.fileValuesV1.sortBy {
+                        case imageFileValue: StillImageFileValueV1 => imageFileValue.qualityLevel
+                        case otherFileValue: FileValueV1 => throw SipiException(s"Sipi returned a wrong file value type: ${otherFileValue.valueTypeIri}")
+                    }
+
+                    // now change the values
+                    newFileValuesSorted.zip(oldFileValuesSorted).map {
+                        case (newFileValue: StillImageFileValueV1, oldFileValue: CurrentFileValue) =>
+                            val changeImageFileValueRequest: ChangeValueRequestV1 = ChangeValueRequestV1(
+                                valueIri = oldFileValue.valueObjectIri,
+                                value = newFileValue,
+                                userProfile = changeFileValueRequest.userProfile,
+                                apiRequestID = changeFileValueRequest.apiRequestID
+                            )
+
+                            changeValueV1(changeImageFileValueRequest)
+                        case _ => throw SipiException("Sipi created a wrong file value type")
+                    }
+
+
+                case otherFileType => throw SipiException(s"File type ${otherFileType} not yet supported")
+            })
+
+
+        } yield ChangeFileValueResponseV1(
+            changedFilesValues = changedFileValues,
+            userdata = changeFileValueRequest.userProfile.userData
+        )
+
+        // If a temporary file was created, ensure that it's deleted, regardless of whether the request succeeded or failed.
+        resultFuture.andThen {
+            case _ => changeFileValueRequest.file match {
+                case (conversionPathRequest: SipiResponderConversionPathRequestV1) =>
+                    // a tmp file has been created by the resources route (non GUI-case), delete it
+                    InputValidation.deleteFileFromTmpLocation(conversionPathRequest.source, log)
+                case _ => ()
+            }
+
+
+        }
+
     }
 
     /**
@@ -438,21 +552,26 @@ class ValuesResponderV1 extends ResponderV1 {
                     getIncoming = false
                 )).mapTo[ResourceFullResponseV1]
 
-                // Ensure that adding the new value version would not create a duplicate value. This works in API v1 because a
-                // ResourceFullResponseV1 contains only the values that the user is allowed to see, otherwise checking for
-                // duplicate values would be a security risk. We'll have to implement this in a different way in API v2.
-                _ = resourceFullResponse.props.flatMap(_.properties.find(_.pid == propertyIri)) match {
-                    case Some(prop: PropertyV1) =>
-                        // Don't consider the current value version when looking for duplicates.
-                        val filteredValues = prop.value_ids.zip(prop.values).filter(_._1 != changeValueRequest.valueIri).unzip._2
+                _ = changeValueRequest.value match {
+                    case fileValue: FileValueV1 => () // It is a file value, do not check for duplicates.
+                    case _ => // It is not a file value.
+                        // Ensure that adding the new value version would not create a duplicate value. This works in API v1 because a
+                        // ResourceFullResponseV1 contains only the values that the user is allowed to see, otherwise checking for
+                        // duplicate values would be a security risk. We'll have to implement this in a different way in API v2.
+                        resourceFullResponse.props.flatMap(_.properties.find(_.pid == propertyIri)) match {
+                            case Some(prop: PropertyV1) =>
+                                // Don't consider the current value version when looking for duplicates.
+                                val filteredValues = prop.value_ids.zip(prop.values).filter(_._1 != changeValueRequest.valueIri).unzip._2
 
-                        if (filteredValues.exists(apiValueV1 => changeValueRequest.value.isDuplicateOfOtherValue(apiValueV1))) {
-                            throw DuplicateValueException()
+                                if (filteredValues.exists(apiValueV1 => changeValueRequest.value.isDuplicateOfOtherValue(apiValueV1))) {
+                                    throw DuplicateValueException()
+                                }
+
+                            case None =>
+                                // This shouldn't happen unless someone just changed the ontology.
+                                throw NotFoundException(s"No information found about property $propertyIri for resource ${findResourceWithValueResult.resourceIri}")
                         }
 
-                    case None =>
-                        // This shouldn't happen unless someone just changed the ontology.
-                        throw NotFoundException(s"No information found about property $propertyIri for resource ${findResourceWithValueResult.resourceIri}")
                 }
 
                 // The rest of the preparation for the update depends on whether we're changing a link or an ordinary value.
@@ -689,9 +808,9 @@ class ValuesResponderV1 extends ResponderV1 {
                 throw UpdateNotPerformedException(s"Value ${deleteValueRequest.valueIri} was not deleted. Please report this as a possible bug.")
             }
         } yield DeleteValueResponseV1(
-                id = newValueIri,
-                userdata = deleteValueRequest.userProfile.userData
-            )
+            id = newValueIri,
+            userdata = deleteValueRequest.userProfile.userData
+        )
 
         for {
         // Don't allow anonymous users to update values.
@@ -1005,10 +1124,11 @@ class ValuesResponderV1 extends ResponderV1 {
 
     /**
       * Verifies that a value was created.
-      * @param resourceIri the IRI of the resource in which the value should have been created.
-      * @param propertyIri the IRI of the property that should point from the resource to the value.
+      *
+      * @param resourceIri     the IRI of the resource in which the value should have been created.
+      * @param propertyIri     the IRI of the property that should point from the resource to the value.
       * @param unverifiedValue the value that should have been created.
-      * @param userProfile the profile of the user making the request.
+      * @param userProfile     the profile of the user making the request.
       * @return a [[CreateValueResponseV1]], or a failed [[Future]] if the value could not be found in
       *         the resource's version history.
       */
@@ -1233,15 +1353,15 @@ class ValuesResponderV1 extends ResponderV1 {
       * Creates a new value (either an ordinary value or a link), using an existing transaction, assuming that
       * pre-update checks have already been done.
       *
-      * @param transactionID the transaction ID.
-      * @param projectIri the IRI of the project in which to create the value.
-      * @param resourceIri the IRI of the resource in which to create the value.
-      * @param propertyIri the IRI of the property that will point from the resource to the value.
-      * @param value the value to create.
-      * @param permissionRelevantAssertions the permission-relevant assertions to assign to the value, i.e. its owner
-      *                                     and project plus its permissions.
+      * @param transactionID                      the transaction ID.
+      * @param projectIri                         the IRI of the project in which to create the value.
+      * @param resourceIri                        the IRI of the resource in which to create the value.
+      * @param propertyIri                        the IRI of the property that will point from the resource to the value.
+      * @param value                              the value to create.
+      * @param permissionRelevantAssertions       the permission-relevant assertions to assign to the value, i.e. its owner
+      *                                           and project plus its permissions.
       * @param updateResourceLastModificationDate if true, update the resource's `knora-base:lastModificationDate`.
-      * @param userProfile the profile of the user making the request.
+      * @param userProfile                        the profile of the user making the request.
       * @return an [[UnverifiedCreateValueResponseV1]].
       */
     private def createValueV1AfterChecks(transactionID: UUID,
@@ -1285,15 +1405,15 @@ class ValuesResponderV1 extends ResponderV1 {
     /**
       * Creates a link, using an existing transaction, assuming that pre-update checks have already been done.
       *
-      * @param transactionID the transaction ID.
-      * @param projectIri the IRI of the project in which the link is to be created.
-      * @param resourceIri the resource in which the link is to be created.
-      * @param propertyIri the link property.
-      * @param linkUpdateV1 a [[LinkUpdateV1]] specifying the target resource.
-      * @param permissionRelevantAssertions permission-relevant assertions for the new `knora-base:LinkValue`, i.e.
-      *                                     its owner and project plus permissions.
+      * @param transactionID                      the transaction ID.
+      * @param projectIri                         the IRI of the project in which the link is to be created.
+      * @param resourceIri                        the resource in which the link is to be created.
+      * @param propertyIri                        the link property.
+      * @param linkUpdateV1                       a [[LinkUpdateV1]] specifying the target resource.
+      * @param permissionRelevantAssertions       permission-relevant assertions for the new `knora-base:LinkValue`, i.e.
+      *                                           its owner and project plus permissions.
       * @param updateResourceLastModificationDate if true, update the resource's `knora-base:lastModificationDate`.
-      * @param userProfile the profile of the user making the request.
+      * @param userProfile                        the profile of the user making the request.
       * @return an [[UnverifiedCreateValueResponseV1]].
       */
     private def createLinkValueV1AfterChecks(transactionID: UUID,
@@ -1340,15 +1460,15 @@ class ValuesResponderV1 extends ResponderV1 {
     /**
       * Creates an ordinary value (i.e. not a link), using an existing transaction, assuming that pre-update checks have already been done.
       *
-      * @param transactionID the transaction ID.
-      * @param projectIri the project in which the value is to be created.
-      * @param resourceIri the resource in which the value is to be created.
-      * @param propertyIri the property that should point to the value.
-      * @param value an [[UpdateValueV1]] describing the value.
-      * @param permissionRelevantAssertions permission-relevant assertions for the new value, i.e.
-      *                                     its owner and project plus permissions.
+      * @param transactionID                      the transaction ID.
+      * @param projectIri                         the project in which the value is to be created.
+      * @param resourceIri                        the resource in which the value is to be created.
+      * @param propertyIri                        the property that should point to the value.
+      * @param value                              an [[UpdateValueV1]] describing the value.
+      * @param permissionRelevantAssertions       permission-relevant assertions for the new value, i.e.
+      *                                           its owner and project plus permissions.
       * @param updateResourceLastModificationDate if true, update the resource's `knora-base:lastModificationDate`.
-      * @param userProfile the profile of the user making the request.
+      * @param userProfile                        the profile of the user making the request.
       * @return an [[UnverifiedCreateValueResponseV1]].
       */
     private def createOrdinaryValueV1AfterChecks(transactionID: UUID,
@@ -1747,10 +1867,10 @@ class ValuesResponderV1 extends ResponderV1 {
       * Implements a pre-update check to ensure that an [[UpdateValueV1]] has the correct type for the `knora-base:objectClassConstraint` of
       * the property that is supposed to point to it.
       *
-      * @param propertyIri the IRI of the property.
+      * @param propertyIri                   the IRI of the property.
       * @param propertyObjectClassConstraint the IRI of the `knora-base:objectClassConstraint` of the property.
-      * @param updateValueV1 the value to be updated.
-      * @param userProfile   the profile of the user making the request.
+      * @param updateValueV1                 the value to be updated.
+      * @param userProfile                   the profile of the user making the request.
       * @return an empty [[Future]] on success, or a failed [[Future]] if the value has the wrong type.
       */
     private def checkPropertyObjectClassConstraintForValue(propertyIri: IRI, propertyObjectClassConstraint: IRI, updateValueV1: UpdateValueV1, userProfile: UserProfileV1): Future[Unit] = {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
@@ -349,15 +349,22 @@ class ValuesResponderV1 extends ResponderV1 {
     }
 
     /**
-      * Temporary structure to represent existing file values of a resource.
+      * Preprocesses a file value change request by calling the Sipi responder to create a new file
+      * and calls [[changeValueV1]] to actually change the file value in Knora.
       *
-      * @param property       the property Iri (e.g., hasStillImageFileValueRepresentation)
-      * @param valueObjectIri the Iri of the value object.
-      * @param quality        the quality of the file value
+      * @param changeFileValueRequest a [[ChangeFileValueRequestV1]] sent by the values route.
+      * @return a [[ChangeFileValueResponseV1]] representing all the changed file values.
       */
-    private case class CurrentFileValue(property: IRI, valueObjectIri: IRI, quality: Option[Int])
-
     private def changeFileValueV1(changeFileValueRequest: ChangeFileValueRequestV1): Future[ChangeFileValueResponseV1] = {
+
+        /**
+          * Temporary structure to represent existing file values of a resource.
+          *
+          * @param property       the property Iri (e.g., hasStillImageFileValueRepresentation)
+          * @param valueObjectIri the Iri of the value object.
+          * @param quality        the quality of the file value
+          */
+        case class CurrentFileValue(property: IRI, valueObjectIri: IRI, quality: Option[Int])
 
         // get the Iris of the current file value(s)
         val resultFuture = for {

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/ValuesRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/ValuesRouteV1.scala
@@ -237,7 +237,7 @@ object ValuesRouteV1 extends Authenticator {
         implicit val timeout = settings.defaultTimeout
         val responderManager = system.actorSelection("/user/responderManager")
 
-        // TODO: add documentation
+        // Version history request requires 3 URL path segments: resource IRI, property IRI, and current value IRI
         path("v1" / "values" / "history" / Segments) { iris =>
             get {
                 requestContext => {
@@ -323,7 +323,9 @@ object ValuesRouteV1 extends Authenticator {
                     )
                 }
             }
-        } ~ path("v1" / "links" / Segments) { iris =>
+        } ~
+            // Link value request requires 3 URL path segments: subject IRI, predicate IRI, and object IRI
+            path("v1" / "links" / Segments) { iris =>
             get {
                 requestContext => {
                     val requestMessageTry = Try {

--- a/webapi/src/main/scala/org/knora/webapi/util/InputValidation.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/InputValidation.scala
@@ -23,6 +23,7 @@ package org.knora.webapi.util
 import java.io.File
 import java.nio.file.{Files, Paths}
 
+import akka.event.LoggingAdapter
 import org.apache.commons.lang3.StringUtils
 import org.apache.commons.validator.routines.UrlValidator
 import org.joda.time.DateTime
@@ -250,14 +251,15 @@ object InputValidation {
         fileName
     }
 
-    def deleteFileFromTmpLocation(fileName: File): Boolean = {
+    def deleteFileFromTmpLocation(fileName: File, log: LoggingAdapter): Boolean = {
 
         val path = fileName.toPath
 
-        if (!fileName.canWrite) throw FileWriteException(s"File ${path} cannot be deleted.")
+        if (!fileName.canWrite) {
+            val ex = FileWriteException(s"File $path cannot be deleted.")
+            log.error(ex, ex.getMessage)
+        }
 
         Files.deleteIfExists(path)
-
     }
-
 }

--- a/webapi/src/main/twirl/queries/sparql/v1/addValueVersion.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/addValueVersion.scala.txt
@@ -200,6 +200,7 @@ DELETE {
             ?newValue <@assertion._1> <@assertion._2> .
         }
 
+        @* TODO: in case of a file value, order is not given *@
         ?newValue knora-base:valueHasOrder ?order .
         ?newValue knora-base:valueCreationDate ?currentTime .
         ?newValue knora-base:previousValue ?currentValue .
@@ -253,7 +254,16 @@ DELETE {
 
     ?resource ?property ?currentValue .
     ?property knora-base:objectClassConstraint ?valueType .
-    ?currentValue knora-base:valueHasOrder ?order .
+
+    @*
+
+        Consider order if given (not given for file values)
+
+    *@
+
+    OPTIONAL {
+        ?currentValue knora-base:valueHasOrder ?order .
+    }
 
     @*
 

--- a/webapi/src/main/twirl/queries/sparql/v1/getFileValuesForResource.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getFileValuesForResource.scala.txt
@@ -1,0 +1,43 @@
+@*
+ * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and André Fatton.
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ *@
+
+@import org.knora.webapi.IRI
+
+@**
+ * Gets the file value Iris of a resource and their quality level.
+ *
+ * @param resourceIri the IRI of the resource.
+ *@
+@(resourceIri: IRI)
+
+
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?p ?fileValueIri ?quality WHERE {
+	BIND(IRI("@resourceIri") as ?resIri)
+
+    ?resIri ?p ?fileValueIri .
+    ?p rdfs:subPropertyOf+ knora-base:hasFileValue .
+
+    OPTIONAL {
+        ?fileValueIri knora-base:qualityLevel ?quality .
+    }
+}

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/SipiV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/SipiV1E2ESpec.scala
@@ -21,6 +21,7 @@
 package org.knora.webapi.e2e.v1
 
 import java.io.File
+import java.net.URLEncoder
 import java.nio.file.{Files, Paths}
 
 import akka.actor._
@@ -29,15 +30,13 @@ import akka.util.Timeout
 import org.knora.webapi.e2e.E2ESpec
 import org.knora.webapi.messages.v1respondermessages.resourcemessages.{CreateResourceApiRequestV1, CreateResourceValueV1}
 import org.knora.webapi.messages.v1respondermessages.triplestoremessages.{RdfDataObject, ResetTriplestoreContent}
-import org.knora.webapi.messages.v1respondermessages.valuemessages.{CreateFileV1, CreateRichtextV1, ChangeFileValueApiRequestV1}
+import org.knora.webapi.messages.v1respondermessages.valuemessages.{ChangeFileValueApiRequestV1, CreateFileV1, CreateRichtextV1}
 import org.knora.webapi.responders._
 import org.knora.webapi.responders.v1._
-import org.knora.webapi.routing.v1.ResourcesRouteV1
-import org.knora.webapi.routing.v1.ValuesRouteV1
+import org.knora.webapi.routing.v1.{ResourcesRouteV1, ValuesRouteV1}
 import org.knora.webapi.store._
 import org.knora.webapi.{FileWriteException, LiveActorMaker}
 import spray.http._
-import java.net.URLEncoder
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -154,7 +153,7 @@ class SipiV1E2ESpec extends E2ESpec {
             }
         }
 
-        /*"create a resource with a digital representation doing a multipart request submitting a wrong mimetype to make the request fail" in {
+        "create a resource with a digital representation doing a multipart request submitting a wrong mimetype to make the request fail" in {
 
             val fileToSend = new File(RequestParams.pathToFile)
             // check if the file exists
@@ -175,7 +174,7 @@ class SipiV1E2ESpec extends E2ESpec {
                 assert(!tmpFile.exists(), s"Tmp file ${tmpFile} was not deleted.")
                 assert(status != StatusCodes.OK, "Status code is not set to OK, Knora says:\n" + responseAs[String])
             }
-        }*/
+        }
 
         "create a resource with a digital representation doing a params only request without binary data (GUI-case)" in {
 
@@ -191,6 +190,7 @@ class SipiV1E2ESpec extends E2ESpec {
                 assert(status == StatusCodes.OK, "Status code is not set to OK, Knora says:\n" + responseAs[String])
             }
         }
+
     }
 
     "The Values endpoint" should {
@@ -248,5 +248,4 @@ class SipiV1E2ESpec extends E2ESpec {
 
         }
     }
-
 }

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/MockSipiResponderV1.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/MockSipiResponderV1.scala
@@ -60,7 +60,7 @@ class MockSipiResponderV1 extends ResponderV1 {
             val originalMimeType: String = conversionRequest.originalMimeType
 
             // we expect original mimetype to be "image/jpeg"
-            if (originalMimeType != "image/jpeg") throw BadRequestException("")
+            if (originalMimeType != "image/jpeg") throw BadRequestException("Wrong mimetype for jpg file")
 
             val fileValuesV1 = Vector(StillImageFileValueV1(// full representation
                 internalMimeType = "image/jp2",

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/MockSipiResponderV1.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/MockSipiResponderV1.scala
@@ -40,16 +40,6 @@ class MockSipiResponderV1 extends ResponderV1 {
       */
     private def imageConversionResponse(conversionRequest: SipiResponderConversionRequestV1): Future[SipiResponderConversionResponseV1] = {
 
-        // delete tmp file (depending on the kind of request given: only necessary if Knora stored the file - non GUI-case)
-        def deleteTmpFile(conversionRequest: SipiResponderConversionRequestV1): Unit = {
-            conversionRequest match {
-                case (conversionPathRequest: SipiResponderConversionPathRequestV1) =>
-                    // a tmp file has been created by the resources route (non GUI-case), delete it
-                    InputValidation.deleteFileFromTmpLocation(conversionPathRequest.source)
-                case _ => ()
-            }
-        }
-
         val originalFilename = conversionRequest.originalFilename
         val originalMimeType: String = conversionRequest.originalMimeType
 
@@ -74,8 +64,6 @@ class MockSipiResponderV1 extends ResponderV1 {
                 qualityName = Some("thumbnail"),
                 isPreview = true
             ))
-
-        deleteTmpFile(conversionRequest)
 
         Future(SipiResponderConversionResponseV1(fileValuesV1, file_type = SipiConstants.FileType.IMAGE))
     }

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/MockSipiResponderV1.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/MockSipiResponderV1.scala
@@ -55,46 +55,47 @@ class MockSipiResponderV1 extends ResponderV1 {
       * @return a [[SipiResponderConversionResponseV1]] imitating the answer from Sipi.
       */
     private def imageConversionResponse(conversionRequest: SipiResponderConversionRequestV1): Future[SipiResponderConversionResponseV1] = {
+        Future {
+            val originalFilename = conversionRequest.originalFilename
+            val originalMimeType: String = conversionRequest.originalMimeType
 
-        val originalFilename = conversionRequest.originalFilename
-        val originalMimeType: String = conversionRequest.originalMimeType
+            // we expect original mimetype to be "image/jpeg"
+            if (originalMimeType != "image/jpeg") throw BadRequestException("")
 
-        // we expect original mimetype to be "image/jpeg"
-        if (originalMimeType != "image/jpeg") throw BadRequestException("")
-
-        val fileValuesV1 = Vector(StillImageFileValueV1(// full representation
-            internalMimeType = "image/jp2",
-            originalFilename = originalFilename,
-            originalMimeType = Some(originalMimeType),
-            dimX = 800,
-            dimY = 800,
-            internalFilename = "full.jp2",
-            qualityLevel = 100,
-            qualityName = Some("full")
-        ),
-            StillImageFileValueV1(// thumbnail representation
-                internalMimeType = "image/jpeg",
+            val fileValuesV1 = Vector(StillImageFileValueV1(// full representation
+                internalMimeType = "image/jp2",
                 originalFilename = originalFilename,
                 originalMimeType = Some(originalMimeType),
-                dimX = 80,
-                dimY = 80,
-                internalFilename = "thumb.jpg",
-                qualityLevel = 10,
-                qualityName = Some("thumbnail"),
-                isPreview = true
-            ))
+                dimX = 800,
+                dimY = 800,
+                internalFilename = "full.jp2",
+                qualityLevel = 100,
+                qualityName = Some("full")
+            ),
+                StillImageFileValueV1(// thumbnail representation
+                    internalMimeType = "image/jpeg",
+                    originalFilename = originalFilename,
+                    originalMimeType = Some(originalMimeType),
+                    dimX = 80,
+                    dimY = 80,
+                    internalFilename = "thumb.jpg",
+                    qualityLevel = 10,
+                    qualityName = Some("thumbnail"),
+                    isPreview = true
+                ))
 
-        // Whenever Knora had to create a temporary file, store its path
-        // the calling test context can then make sure that is has actually been deleted after the test is done
-        // (on successful or failed conversion)
-        conversionRequest match {
-            case conversionPathRequest: SipiResponderConversionPathRequestV1 =>
-                // store path to tmp file
-                SourcePath.setSourcePath(conversionPathRequest.source)
-            case _ => () // params request only
+            // Whenever Knora had to create a temporary file, store its path
+            // the calling test context can then make sure that is has actually been deleted after the test is done
+            // (on successful or failed conversion)
+            conversionRequest match {
+                case conversionPathRequest: SipiResponderConversionPathRequestV1 =>
+                    // store path to tmp file
+                    SourcePath.setSourcePath(conversionPathRequest.source)
+                case _ => () // params request only
+            }
+
+            SipiResponderConversionResponseV1(fileValuesV1, file_type = SipiConstants.FileType.IMAGE)
         }
-
-        Future(SipiResponderConversionResponseV1(fileValuesV1, file_type = SipiConstants.FileType.IMAGE))
     }
 
     def receive = {


### PR DESCRIPTION
Add support for the change of existing file values.

The main difficulty is that file values are stored like ordinary values in Knora, but they were handled quite differently in the old SALSAH - as locations. In consequence, we do not know the Iris of file values from a resource's response.

Because of this, a Put request has to deliver also the Iri of the resource in question, so the current file value objects can be retrieved. Then, this is treated like any other value change by calling `changeValueV1` in values responder.

For more explanation, please read `sipi-and-knora.rst`.