### PR TITLE
Wip/sipi knora communication

### DIFF
--- a/docs/rst/sipi/sipi-and-knora.rst
+++ b/docs/rst/sipi/sipi-and-knora.rst
@@ -168,12 +168,58 @@ These messages are passed to ``changeValueV1`` because with the described handli
 
 In case of success, a ``ChangeFileValueResponseV1`` is sent back to the client, containing a list of the single ``ChangeValueResponseV1``.
 
-
-
-
-
-
-
 .. [#] Of course, also the GUI uses the API. But the user does not need to know about it.
 
+Retrieving Files from Sipi
+==========================
 
+Binary representions of Knora locations are served by Sipi. For each file value, Knora creates several locations representing different quality levels:
+
+.. code::
+
+   "resinfo": {
+      "locations": [
+         {
+            "duration": ​0,
+            "nx": ​95,
+            "path": "http://sipiserver:port/knora/incunabula_0000000002.jpg/full/full/0/default.jpg",
+            "ny": ​128,
+            "fps": ​0,
+            "format_name": "JPEG",
+            "origname": "ad+s167_druck1=0001.tif",
+            "protocol": "file"
+         },
+         {
+            "duration": ​0,
+             "nx": ​82,
+             "path": "http://sipiserver:port/knora/incunabula_0000000002.jp2/full/82,110/0/default.jpg",
+             "ny": ​110,
+             "fps": ​0,
+             "format_name": "JPEG2000",
+             "origname": "ad+s167_druck1=0001.tif",
+             "protocol": "file"
+         },
+         {
+             "duration": ​0,
+             "nx": ​163,
+             "path": "http://sipiserver:port/knora/incunabula_0000000002.jp2/full/163,219/0/default.jpg",
+             "ny": ​219,
+             "fps": ​0,
+             "format_name": "JPEG2000",
+             "origname": "ad+s167_druck1=0001.tif",
+             "protocol": "file"
+         }
+         ...
+      ],
+   "restype_label": "Seite",
+   "resclass_has_location": true,
+
+Each of these paths has to be handled by the browser by making a call to Sipi, obtaining the binary representation in the desired quality.
+To deal with different image quality levels, Sipi implements the `IIIF standard <http://iiif.io/api/image/2.0/>`_. The different quality level paths
+are created by Knora in ``ValueUtilV1``.
+
+Whenever Sipi serves a binary representation of a Knora file value (indicated by using the prefix ``knora`` in the path), it has to make a request to Knora's
+Sipi responder to get the user's permissions on the requested file. Sipi's request to Knora contains a cookie with the Knora session id the user has obtained when logging in to Knora:
+As a response to a successful login, Knora returns the user's session id and this id is automatically sent to Sipi by the browser, setting a second cookie for the communication with Sipi.
+The reason the Knora session id is set in two cookies, is the fact that cookies can not be shared among different domains. Since Knora and Sipi are likely to be running
+under different domains, this solution offers the necessary flexibility.

--- a/salsah/src/public/index.html
+++ b/salsah/src/public/index.html
@@ -179,6 +179,21 @@
 
             SALSAH.ApiPost('session', {username: $('#user_id').val(), password: $('#password').val()}, authorization, function(data) {
 				if (data.status == ApiErrors.OK) {
+					console.log("session created with id " + data.sid);
+					$.ajax({
+						url: "http://localhost:1024/Knora_login",
+						type: "POST",
+						data: {
+							sid: data.sid
+						},
+						xhrFields: {
+							withCredentials: true
+						},
+						success: function(data) {
+							console.log("from Sipi: " + data.status)
+						}
+					})
+
 					$('#dologin').simpledialog('loginbox', 'close');
 					SALSAH.reload_css();
 					$('#userctrl').empty().append(s_('_user') + ' : ' + SALSAH.userdata.username)

--- a/salsah/src/public/index.html
+++ b/salsah/src/public/index.html
@@ -179,9 +179,13 @@
 
             SALSAH.ApiPost('session', {username: $('#user_id').val(), password: $('#password').val()}, authorization, function(data) {
 				if (data.status == ApiErrors.OK) {
-					console.log("session created with id " + data.sid);
+
+					// The login to Knora is successful.
+					// Now do a request to Sipi providing the Knora session id.
+					// When retrieving a file from Sipi (e.g. an IIIF URL), Sipi can send the session id to Knora with the request,
+					// identifying the user that is making the request to Knora.
 					$.ajax({
-						url: "http://localhost:1024/Knora_login",
+						url: SIPI_URL + SIPI_LOGIN_ROUTE,
 						type: "POST",
 						data: {
 							sid: data.sid
@@ -190,9 +194,15 @@
 							withCredentials: true
 						},
 						success: function(data) {
-							console.log("from Sipi: " + data.status)
+							if (data.status != ApiErrors.OK) {
+								// request to Sipi was not successful
+								alert(data.message)
+							}
+						},
+						error: function() {
+							alert("Call to Sipi failed")
 						}
-					})
+					});
 
 					$('#dologin').simpledialog('loginbox', 'close');
 					SALSAH.reload_css();
@@ -212,6 +222,25 @@
 		$('#logout_button').on('click', function() {
             SALSAH.ApiDelete('session', function(data) {
 				if (data.status == ApiErrors.OK) {
+
+					// invalidate cookie obtained from Sipi when logging in to Knora
+					$.ajax({
+						url: SIPI_URL + SIPI_LOGOUT_ROUTE,
+						type: "POST",
+						xhrFields: {
+							withCredentials: true
+						},
+						success: function(data) {
+							if (data.status != ApiErrors.OK) {
+								// request to Sipi was not successful
+								alert("Invalidating Sipi cookie failed")
+							}
+						},
+						error: function() {
+							alert("Call to Sipi failed")
+						}
+					});
+
 					$('#dologut').simpledialog('logoutbox', 'close');
 					SALSAH.reload_css();
 					$('#userctrl').empty().append($('<img>').attr({id: 'dologin', src: 'app/icons/24x24/user.png', title: s_('_login')})

--- a/salsah/src/public/js/00_init_javascript.js
+++ b/salsah/src/public/js/00_init_javascript.js
@@ -15,7 +15,9 @@
  */
 
 var API_URL = 'http://localhost:3333';
-
+var SIPI_URL = 'http://localhost:1024';
+var SIPI_LOGIN_ROUTE = '/Knora_login';
+var SIPI_LOGOUT_ROUTE = '/Knora_logout';
 
 /*
  * let's find the SITE_URL...

--- a/webapi/_test_data/test_route/change_page_with_params.py
+++ b/webapi/_test_data/test_route/change_page_with_params.py
@@ -9,11 +9,27 @@ import requests, json, urllib
 try:
     base_url = "http://localhost/v1/"
 
+    filename = 'Chlaus.jpg'
+    path = 'images/'
+    mimetype = 'image/jpeg'
+
+    files = {'file': (filename, open(path + filename, 'rb'), mimetype)}
+
+    r = requests.post("http://localhost:1024/make_thumbnail", files = files)
+
+    print(r.text)
+
+    thumb_response = r.json()
+
+    # Get the thumbnail
+    r = requests.get(thumb_response['preview_path'])
+    print("Got preview with status code " + str(r.status_code))
+
     params = {
         'file': {
-            'originalFilename' : "Chlaus.jpg",
-            'originalMimeType' : "image/jpeg",
-            'filename' : "./test_server/images/Chlaus.jpg"
+            'originalFilename' : thumb_response["original_filename"],
+            'originalMimeType' : thumb_response["original_mimetype"],
+            'filename' : thumb_response['filename']
         }
     }
 

--- a/webapi/_test_data/test_route/create_page_with_params.py
+++ b/webapi/_test_data/test_route/create_page_with_params.py
@@ -1,15 +1,34 @@
 #!/usr/bin/env python3
 
-import requests, json
+import requests, json, sys
 
 #
-# This scripts tests the creation of a page and submits image data params (no binaries) to the resources route, testing the running Sipi server.
+# This scripts tests the creation of a page and submits image data params (no binaries) to the resources route after the binaries have been uploaded to Sipi and a preview thumbnail has been created,
+#  testing the running Sipi server.
 #
 
 try:
+
+    # do a make_thumbnail request here to Sipi to obtain a valid filename for later conversion request
     base_url = "http://localhost/v1/"
 
-    params = {
+    filename = 'Chlaus.jpg'
+    path = 'images/'
+    mimetype = 'image/jpeg'
+
+    files = {'file': (filename, open(path + filename, 'rb'), mimetype)}
+
+    r = requests.post("http://localhost:1024/make_thumbnail", files = files)
+
+    print(r.text)
+
+    thumb_response = r.json()
+
+    # Get the thumbnail
+    r = requests.get(thumb_response['preview_path'])
+    print("Got preview with status code " + str(r.status_code))
+
+    conversion_params = {
         'restype_id': 'http://www.knora.org/ontology/incunabula#page',
         'properties': {
             'http://www.knora.org/ontology/incunabula#pagenum': [
@@ -24,9 +43,9 @@ try:
             'http://www.knora.org/ontology/incunabula#seqnum': [{'int_value': 99999999}]
         },
         'file': {
-            'originalFilename' : "Chlaus.jpg",
-            'originalMimeType' : "image/jpeg",
-            'filename' : "./test_server/images/Chlaus.jpg"
+            'originalFilename' : thumb_response["original_filename"],
+            'originalMimeType' : thumb_response["original_mimetype"],
+            'filename' : thumb_response['filename']
         },
         'label': 'test page',
         'project_id': 'http://data.knora.org/projects/77275339'
@@ -34,7 +53,7 @@ try:
 
 
     r = requests.post(base_url + 'resources',
-                      data=json.dumps(params),
+                      data=json.dumps(conversion_params),
                       headers={'content-type': 'application/json; charset=utf8'},
                       auth=('root', 'test'),
                       proxies={'http': 'http://localhost:3333'})

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -86,8 +86,8 @@ app {
         url = "http://localhost"
         port = 1024
         prefix = "knora"
-        path-conversion-route = "convert_path"
-        file-conversion-route = "convert_file"
+        path-conversion-route = "convert_from_binaries"
+        file-conversion-route = "convert_from_file"
         image-mime-types = ["image/tiff", "image/jpeg", "image/png", "image/jp2"]
         movie-mime-types = []
         sound-mime-types = []

--- a/webapi/src/main/resources/logback.xml
+++ b/webapi/src/main/resources/logback.xml
@@ -37,6 +37,7 @@
     <logger name="org.knora.webapi" level="DEBUG"/>
     <logger name="org.knora.webapi.util.authentication" level="INFO"/>
     <logger name="org.knora.webapi.util.cache" level="INFO"/>
+    <logger name="org.knora.webapi.routing.v1.AssetsRouteV1" level="DEBUG"/>
     <logger name="org.knora.webapi.store.StoreManager" level="INFO"/>
     <logger name="org.knora.webapi.store.triplestore" level="INFO"/>
     <logger name="org.knora.webapi.responders.v1.CkanResponderV1" level="INFO"/>

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1respondermessages/sipimessages/SipiMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1respondermessages/sipimessages/SipiMessagesV1.scala
@@ -232,10 +232,10 @@ sealed trait SipiResponderRequestV1 extends KnoraRequestV1
 /**
   * A Knora v1 API request message that requests information about a `FileValue`.
   *
-  * @param fileValueIri the IRI of the file value to be queried.
+  * @param filename the name of the file belonging to the file value to be queried.
   * @param userProfile  the profile of the user making the request.
   */
-case class SipiFileInfoGetRequestV1(fileValueIri: IRI, userProfile: UserProfileV1) extends SipiResponderRequestV1
+case class SipiFileInfoGetRequestV1(filename: String, userProfile: UserProfileV1) extends SipiResponderRequestV1
 
 /**
   * Represents the Knora API v1 JSON response to a request for a information about a `FileValue`.

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1respondermessages/sipimessages/SipiMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1respondermessages/sipimessages/SipiMessagesV1.scala
@@ -23,7 +23,7 @@ package org.knora.webapi.messages.v1respondermessages.sipimessages
 import java.io.File
 
 import org.knora.webapi._
-import org.knora.webapi.messages.v1respondermessages.usermessages.UserProfileV1
+import org.knora.webapi.messages.v1respondermessages.usermessages.{UserDataV1, UserProfileV1}
 import org.knora.webapi.messages.v1respondermessages.valuemessages.{StillImageFileValueV1, FileValueV1}
 import org.knora.webapi.messages.v1respondermessages.{KnoraRequestV1, KnoraResponseV1}
 import spray.json._
@@ -244,7 +244,8 @@ case class SipiFileInfoGetRequestV1(filename: String, userProfile: UserProfileV1
   * @param filepath       the path to the file.
   */
 case class SipiFileInfoGetResponseV1(permissionCode: Option[Int],
-                                     filepath: Option[String]) extends KnoraResponseV1 {
+                                     filepath: Option[String],
+                                     userdata: UserDataV1) extends KnoraResponseV1 {
     def toJsValue = RepresentationV1JsonProtocol.sipiFileInfoGetResponseV1Format.write(this)
 }
 
@@ -256,8 +257,9 @@ case class SipiFileInfoGetResponseV1(permissionCode: Option[Int],
   * A spray-json protocol for generating Knora API v1 JSON providing data about representations of a resource.
   */
 object RepresentationV1JsonProtocol extends DefaultJsonProtocol with NullOptions {
+    import org.knora.webapi.messages.v1respondermessages.usermessages.UserDataV1JsonProtocol._
 
-    implicit val sipiFileInfoGetResponseV1Format: RootJsonFormat[SipiFileInfoGetResponseV1] = jsonFormat2(SipiFileInfoGetResponseV1)
+    implicit val sipiFileInfoGetResponseV1Format: RootJsonFormat[SipiFileInfoGetResponseV1] = jsonFormat3(SipiFileInfoGetResponseV1)
     implicit val sipiErrorConversionResponseFormat = jsonFormat2(SipiErrorConversionResponse)
     implicit val sipiImageConversionResponseFormat = jsonFormat12(SipiImageConversionResponse)
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/SipiResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/SipiResponderV1.scala
@@ -165,7 +165,7 @@ class SipiResponderV1 extends ResponderV1 {
             }
 
             // check if Sipi returned a status code != 0
-            _ = if (statusCode != 0) throw BadRequestException(s"Sipi returned a HTTP 200 status code, a unsuccessful status code ${statusCode}")
+            _ = if (statusCode != 0) throw BadRequestException(s"Sipi returned a HTTP 200 status code, but an unsuccessful status code ${statusCode}")
 
             fileType: String = responseAsMap.getOrElse("file_type", throw SipiException(message = "Sipi did not return a file type")) match {
                 case JsString(ftype: String) => ftype

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/SipiResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/SipiResponderV1.scala
@@ -85,7 +85,8 @@ class SipiResponderV1 extends ResponderV1 {
             permissionCode: Option[Int] = PermissionUtilV1.getUserPermissionV1WithValueProps(filename, valueProps, userProfile)
         } yield SipiFileInfoGetResponseV1(
             permissionCode = permissionCode,
-            filepath = permissionCode.map(_ => path)
+            filepath = permissionCode.map(_ => path),
+            userdata = userProfile.userData
         )
     }
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/Proxy.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/Proxy.scala
@@ -29,6 +29,9 @@ import spray.routing.{Route, RequestContext}
 /**
   * This trait provides proxy capabilities to routes, i.e. it allows to tunnel a http requests to an external service
   * and pipe the result back to the client.
+  *
+  * A possible use case for a proxy is when a service not run by Knora should be called using a Knora route. This can be necessary in case
+  * a cross-domain request is not possible due to browsers' security restraints.
   */
 trait Proxy {
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/Proxy.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/Proxy.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and André Fatton.
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.routing
+
+import akka.actor.ActorSystem
+import akka.io.IO
+import spray.can.Http
+import spray.http.{Uri, HttpHeaders, HttpHeader, HttpRequest}
+import spray.routing.{Route, RequestContext}
+
+/**
+  * This trait provides proxy capabilities to routes, i.e. it allows to tunnel a http requests to an external service
+  * and pipe the result back to the client.
+  */
+trait Proxy {
+
+    /**
+      * Used to tunnel the requests to another server and then pipe the result back to the client.
+      * @param uri the new URI to which the request will be tunneled
+      * @param unmatchedPath the part of the route that should be appended to the uri
+      * @return
+      */
+    def proxyToUnmatchedPath(uri: Uri, unmatchedPath: Uri.Path)(implicit system: ActorSystem): Route = {
+        proxyRequest(updateRequest(uri, unmatchedPath, updateUriUnmatchedPath))
+    }
+
+    private val updateUriUnmatchedPath = (uri: Uri, unmatchedPath: Uri.Path, ctx: RequestContext) => {
+        println(s"URI: ${uri.toString}, unmatchedPath: ${unmatchedPath.toString}")
+        val resUri = uri.withPath(uri.path ++ unmatchedPath)
+        println(s"resulting URI: $resUri")
+        resUri
+    }
+
+    private def updateRequest(uri: Uri, unmatchedPath: Uri.Path, updateUri: (Uri, Uri.Path, RequestContext) => Uri): RequestContext => HttpRequest =
+        ctx => ctx.request.copy(
+            uri = updateUri(uri, unmatchedPath, ctx),
+            headers = stripHostHeader(ctx.request.headers)
+        )
+
+    private def proxyRequest(updateRequest: RequestContext => HttpRequest)(implicit system: ActorSystem): Route =
+        ctx => IO(Http)(system) tell (updateRequest(ctx), ctx.responder)
+
+    private def stripHostHeader(headers: List[HttpHeader]) = {
+        println(s"headers before strip: ${headers.toString}")
+        val strippedHeaders = headers filterNot (header => header is (HttpHeaders.Host.lowercaseName))
+        println(s"headers after strip: ${strippedHeaders.toString}")
+        strippedHeaders
+    }
+
+
+
+
+
+
+}

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/AssetsRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/AssetsRouteV1.scala
@@ -43,14 +43,14 @@ object AssetsRouteV1 extends Authenticator {
         implicit val executionContext = system.dispatcher
         implicit val timeout = settings.defaultTimeout
 
-        path("v1" / "assets" / Segment) { assetId =>
+        path("v1" / "assets" / Rest) { assetId =>
             get {
                 requestContext => {
                     requestContext.complete {
-
+                        log.debug(s"got request: ${requestContext.toString}")
 
                         val (width, height, text) = assetId match {
-                            case string if string.contains("http".toCharArray) => (1024, 1024, assetId)
+                            case string if string.contains("big".toCharArray) => (1024, 1024, assetId)
                             case _ => (16, 16, assetId)
                         }
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/SipiRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/SipiRouteV1.scala
@@ -63,9 +63,12 @@ object SipiRouteV1 extends Authenticator with Proxy {
                         log
                     )
             }
-        } ~ path("v1" / "sipi" / Rest) { iiif =>
+        } /*~ path("v1" / "sipi" / Rest) { iiif =>
                 println(iiif)
                 proxyToUnmatchedPath(Uri("http://localhost:3333/v1/assets/"), Uri.Path(iiif))
-        }
+        }*/
+        // this proxy is meant to be used in case we decide that IIIF-URLs should not refer directly to Sipi,
+        // but be processed and fowarded to Sipi
+
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/SipiRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/SipiRouteV1.scala
@@ -23,9 +23,10 @@ package org.knora.webapi.routing.v1
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
 import org.knora.webapi.messages.v1respondermessages.sipimessages.SipiFileInfoGetRequestV1
-import org.knora.webapi.routing.{Authenticator, RouteUtilV1}
+import org.knora.webapi.routing.{Authenticator, Proxy, RouteUtilV1}
 import org.knora.webapi.util.InputValidation
 import org.knora.webapi.{BadRequestException, SettingsImpl}
+import spray.http.Uri
 import spray.routing.Directives._
 import spray.routing._
 
@@ -34,7 +35,7 @@ import scala.util.Try
 /**
   * Provides a spray-routing function for the API routes that Sipi connects to.
   */
-object SipiRouteV1 extends Authenticator {
+object SipiRouteV1 extends Authenticator with Proxy {
 
     /**
       * A spray-routing function for the API routes that Sipi connects to.
@@ -62,6 +63,9 @@ object SipiRouteV1 extends Authenticator {
                         log
                     )
             }
+        } ~ path("v1" / "sipi" / Rest) { iiif =>
+                println(iiif)
+                proxyToUnmatchedPath(Uri("http://localhost:3333/v1/assets/"), Uri.Path(iiif))
         }
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/SipiRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/SipiRouteV1.scala
@@ -45,13 +45,14 @@ object SipiRouteV1 extends Authenticator {
         implicit val timeout = settings.defaultTimeout
         val responderManager = system.actorSelection("/user/responderManager")
 
-        path("v1" / "files" / Segment) { iri =>
+        path("v1" / "files" / Segment) { file =>
             get {
                 requestContext =>
                     val requestMessageTry = Try {
                         val userProfile = getUserProfileV1(requestContext)
-                        val fileValueIRI = InputValidation.toIri(iri, () => throw BadRequestException(s"Invalid file value IRI: $iri"))
-                        SipiFileInfoGetRequestV1(fileValueIRI, userProfile)
+                        //val fileValueIRI = InputValidation.toIri(iri, () => throw BadRequestException(s"Invalid file value IRI: $iri"))
+                        val filename = InputValidation.toSparqlEncodedString(file)
+                        SipiFileInfoGetRequestV1(filename, userProfile)
                     }
                     RouteUtilV1.runJsonRoute(
                         requestMessageTry,

--- a/webapi/src/main/twirl/queries/sparql/v1/getFileValue.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getFileValue.scala.txt
@@ -21,11 +21,11 @@
 @import org.knora.webapi.IRI
 
 @**
- * Gets information about a file value.
+ * Given a knora:base:internalFilename, retrieves the file value and information attached to it.
  *
  * @param fileValueIri the IRI of the file value.
  *@
-@(fileValueIri: IRI)
+@(filename: IRI)
 
 prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -33,7 +33,8 @@ prefix knora-base: <http://www.knora.org/ontology/knora-base#>
 
 SELECT ?objPred ?objObj
 WHERE {
-    BIND(IRI("@fileValueIri") AS ?fileValue)
+
+    ?fileValue knora-base:internalFilename "@filename"
 
     {
         ?fileValue ?objPred ?objObj .

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/SipiResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/SipiResponderV1Spec.scala
@@ -98,19 +98,19 @@ class SipiResponderV1Spec extends CoreSpec() with ImplicitSender {
             // http://localhost:3333/v1/files/http%3A%2F%2Fdata.knora.org%2F8a0b1e75%2Freps%2F7e4ba672
             actorUnderTest ! SipiFileInfoGetRequestV1(
                 userProfile = SipiResponderV1Spec.userProfile,
-                fileValueIri = "http://data.knora.org/8a0b1e75/reps/7e4ba672"
+                filename = "incunabula_0000000002.jp2"
             )
 
             expectMsg(timeout, SipiResponderV1Spec.fileValueResponseFull)
         }
     }
 
-    "The representations responder" should {
+    "The Sipi responder" should {
         "return details of a preview file value (a test project Iri is directly attached to file value: the current user is member of the resource's project, not of the one of the file value)" in {
             // http://localhost:3333/v1/files/http%3A%2F%2Fdata.knora.org%2F8a0b1e75%2Freps%2Fbf255339
             actorUnderTest ! SipiFileInfoGetRequestV1(
                 userProfile = SipiResponderV1Spec.userProfile,
-                fileValueIri = "http://data.knora.org/8a0b1e75/reps/bf255339"
+                filename = "incunabula_0000000002.jpg"
             )
 
             expectMsg(timeout, SipiResponderV1Spec.fileValueResponsePreview)

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/SipiResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/SipiResponderV1Spec.scala
@@ -56,7 +56,8 @@ object SipiResponderV1Spec {
      */
     private val fileValueResponseFull = SipiFileInfoGetResponseV1(
         filepath = Some("incunabula_0000000002.jp2"),
-        permissionCode = Some(6)
+        permissionCode = Some(6),
+        userdata = SipiResponderV1Spec.userData
     )
 
     /*
@@ -64,7 +65,8 @@ object SipiResponderV1Spec {
      */
     private val fileValueResponsePreview = SipiFileInfoGetResponseV1(
         filepath = Some("incunabula_0000000002.jpg"),
-        permissionCode = Some(2) // the user is not member of the file value's project.
+        permissionCode = Some(2), // the user is not member of the file value's project.
+        userdata = SipiResponderV1Spec.userData
     )
 }
 


### PR DESCRIPTION
I changed the Sipi responder so it receives a request from Sipi containing the name of the file the permissions shall be returned for. Given the file name, Knora looks for the corresponding file value Iri to return the permissions.

In Salsah, I added an extra request that is sent to Sipi when the login to Knora has been made. This will set a second cookie that contains the Knora session id. Like this, Sipi can attach the Knora session id when asking Knora about the user's permission on a file. Without this second cookie, Knora could not find out which user is making request.

For security reasons, we should use SSL in the productive version of Knora and make cookies HTTPOnly (so they cannot be read by running JS `document.cookie`).