### PR TITLE
removing relative URL paths for http proxying

### DIFF
--- a/salsah/src/public/default.css
+++ b/salsah/src/public/default.css
@@ -758,16 +758,16 @@ input.disp_csv {
   cursor: pointer;
 }
 input.disp_list {
-  background: url('../icons/sets/view/list_bullets_icon&16.png') no-repeat top left;
+  background: url('icons/sets/view/list_bullets_icon&16.png') no-repeat top left;
 }
 input.disp_lightbox {
-  background: url('../icons/sets/view/2x2_grid_icon&16.png') no-repeat top left;
+  background: url('icons/sets/view/2x2_grid_icon&16.png') no-repeat top left;
 }
 input.disp_tableedit {
-  background: url('../icons/sets/view/3x3_grid_icon&16.png') no-repeat top left;
+  background: url('icons/sets/view/3x3_grid_icon&16.png') no-repeat top left;
 }
 input.disp_csv {
-  background: url('../icons/sets/view/csv_icon&16.png') no-repeat top left;
+  background: url('icons/sets/view/csv_icon&16.png') no-repeat top left;
 }
 .dock {
   position: absolute;


### PR DESCRIPTION
simple url change as the rest of my problems concerning proxying knora behind apache were not linked to knora, but to apache.

 Here's the commit's comment:

```
removing relative paths to icons in css file: it doesn't survive an front apache proxy like:

<Location "/salsah/">
   ProxyPass "http://localhost:3335/"
   ProxyPassReverse "http://localhost:3335/"
</Location>

in order to have salsah/knora/sipi served as paths ( http://myserver.unil.ch/salsah/ ) instead of URL with their ports ( http://myserver.unil.ch:3335/ ).
```
