### PR TITLE
Remove redundant valueHasURI property.

### DIFF
--- a/knora-ontologies/knora-base.ttl
+++ b/knora-ontologies/knora-base.ttl
@@ -1658,18 +1658,6 @@
 
 
 
-###  http://www.knora.org/ontology/knora-base#valueHasURI
-
-:valueHasURI rdf:type owl:DatatypeProperty ;
-
-             rdfs:subPropertyOf :valueHas ;
-
-             :subjectClassConstraint :Value ;
-
-             :objectDatatypeConstraint xsd:anyURI .
-
-
-
 ###  http://www.knora.org/ontology/knora-base#website
 
 :website rdf:type owl:DatatypeProperty ;

--- a/webapi/src/main/scala/org/knora/webapi/util/InputValidation.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/InputValidation.scala
@@ -83,7 +83,6 @@ object InputValidation {
 
     def toSparqlEncodedString(s: String): String = {
         // http://www.morelab.deusto.es/code_injection/
-        // TODO: if the user submits backslashes, could the possibly neutralize the backslashes we insert?
 
         StringUtils.replaceEach(
             s,


### PR DESCRIPTION
We have both `valueHasUri` (which is used) and `valueHasURI` (which is not used). This removes the unused one.