### PR TITLE
tests (browser tests): remove beol data from test data

### DIFF
--- a/salsah/src/test/scala/org.knora.salsah/browser/ResourceCreationSpec.scala
+++ b/salsah/src/test/scala/org.knora.salsah/browser/ResourceCreationSpec.scala
@@ -70,7 +70,6 @@ class ResourceCreationSpec extends SalsahSpec {
                 {"path": "_test_data/ontologies/images-demo-onto.ttl", "name": "http://www.knora.org/ontology/images"},
                 {"path": "_test_data/demo_data/images-demo-data.ttl", "name": "http://www.knora.org/data/images"},
                 {"path": "_test_data/ontologies/beol-onto.ttl", "name": "http://www.knora.org/ontology/beol"},
-                {"path": "_test_data/all_data/beol-data.ttl", "name": "http://www.knora.org/data/beol"},
                 {"path": "_test_data/ontologies/anything-onto.ttl", "name": "http://www.knora.org/ontology/anything"},
                 {"path": "_test_data/all_data/anything-data.ttl", "name": "http://www.knora.org/data/anything"}
             ]

--- a/salsah/src/test/scala/org.knora.salsah/browser/SearchAndEditSpec.scala
+++ b/salsah/src/test/scala/org.knora.salsah/browser/SearchAndEditSpec.scala
@@ -71,7 +71,6 @@ class SearchAndEditSpec extends SalsahSpec {
                 {"path": "_test_data/ontologies/images-demo-onto.ttl", "name": "http://www.knora.org/ontology/images"},
                 {"path": "_test_data/demo_data/images-demo-data.ttl", "name": "http://www.knora.org/data/images"},
                 {"path": "_test_data/ontologies/beol-onto.ttl", "name": "http://www.knora.org/ontology/beol"},
-                {"path": "_test_data/all_data/beol-data.ttl", "name": "http://www.knora.org/data/beol"},
                 {"path": "_test_data/ontologies/anything-onto.ttl", "name": "http://www.knora.org/ontology/anything"},
                 {"path": "_test_data/all_data/anything-data.ttl", "name": "http://www.knora.org/data/anything"}
             ]


### PR DESCRIPTION
Exclude beol data from browser test data because we do not need it.

However, beol ontology has still to be loaded because the beol named graph is not ignored when beol ontology is not loaded since this is statically defined in `application.conf`.