### PR TITLE
Add script to update docs on knora.org

### DIFF
--- a/docs/update-gh-pages.sh
+++ b/docs/update-gh-pages.sh
@@ -9,9 +9,16 @@
 # If you don't want git to ask you for your username and password, use SSH instad of HTTPS
 # to clone the Knora repository.
 
-TMP_HTML="/tmp/knora-html"
-
 set -e
+
+TMP_HTML="/tmp/knora-html" # The temporary directory where we store built HTML.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD) # The current git branch.
+
+if [ "$CURRENT_BRANCH" != "develop" ]
+then
+    echo "Current branch is $CURRENT_BRANCH, not develop"
+    exit 1
+fi
 
 # Build the HTML docs.
 

--- a/docs/update-gh-pages.sh
+++ b/docs/update-gh-pages.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# This script updates the documentation on knora.org by pushing a commit to the gh-pages branch
+# of the Knora repository on GitHub.
+
+# Before you run this script, you must be on the develop branch, having committed any changes
+# you made there.
+
+# If you don't want git to ask you for your username and password, use SSH instad of HTTPS
+# to clone the Knora repository.
+
+TMP_HTML="/tmp/knora-html"
+
+set -e
+
+# Build the HTML docs.
+
+make html
+
+# Copy the built HTML docs to a temporary directory.
+
+rm -rf $TMP_HTML
+mkdir $TMP_HTML
+cp -R _build/html $TMP_HTML/manual
+cp -R _format_docu $TMP_HTML/api
+
+# Switch to the gh-pages branch and remove the existing HTML docs from it.
+
+git checkout gh-pages
+rm -rf ../documentation/manual
+rm -rf ../documentation/api
+
+# Move the new docs from the temporary directory into the git repository tree.
+
+mv $TMP_HTML/manual $TMP_HTML/api ../documentation
+
+# Commit the changes to the gh-pages branch, and push to origin.
+
+git add ../documentation/manual
+git add ../documentation/api
+git commit -m "Update gh-pages."
+git push origin gh-pages
+
+# Switch back to the develop branch, and remove the leftover documentation directory.
+
+git checkout develop
+rm -rf ../documentation

--- a/docs/update-gh-pages.sh
+++ b/docs/update-gh-pages.sh
@@ -16,6 +16,7 @@ set -e
 # Build the HTML docs.
 
 make html
+make jsonformat
 
 # Copy the built HTML docs to a temporary directory.
 

--- a/docs/update-gh-pages.sh
+++ b/docs/update-gh-pages.sh
@@ -28,8 +28,8 @@ cp -R _format_docu $TMP_HTML/api
 # Switch to the gh-pages branch and remove the existing HTML docs from it.
 
 git checkout gh-pages
-rm -rf ../documentation/manual
-rm -rf ../documentation/api
+git rm -rf ../documentation/manual
+git rm -rf ../documentation/api
 
 # Move the new docs from the temporary directory into the git repository tree.
 


### PR DESCRIPTION
This adds a script that you can run manually to update the documentation on knora.org when the RST or generated API docs have changed.

The script assumes that you're on the `develop` branch and have already committed any changes you made there. It builds the docs and updates the `gh-pages` branch with the resulting HTML.

In the future we could automate this to run every time `develop` is updated.