### PR TITLE
Use inference to optimise searches on GraphDB

### DIFF
--- a/docs/rst/knora-api-server/api_v1/reading-and-searching-resources.rst
+++ b/docs/rst/knora-api-server/api_v1/reading-and-searching-resources.rst
@@ -171,9 +171,9 @@ This is a simplified way for searching for resources just by their label. It is 
     HTTP GET to http://host/v1/resources?searchstr=searchValue
 
 Additionally, the following parameters can be appended to the URL (search value is ``Zeitglöcklein``):
- - ``restype_id=resourceClassIRI``: This restricts the search to resources of the specified class. ``-1`` is the default value and means no restriction to a specific class. If a resource class IRI is specified, it has to be URL encoded (e.g. ``http://www.knora.org/v1/resources?searchstr=Zeitgl%C3%B6cklein&restype_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23book``).
+ - ``restype_id=resourceClassIRI``: This restricts the search to resources of the specified class (subclasses of that class will also match). ``-1`` is the default value and means no restriction to a specific class. If a resource class IRI is specified, it has to be URL encoded (e.g. ``http://www.knora.org/v1/resources?searchstr=Zeitgl%C3%B6cklein&restype_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23book``).
  - ``numprops=Integer``: Specifies the number of properties returned for each resource that was found (sorted by GUI order), e.g. ``http://www.knora.org/v1/resources?searchstr=Zeitgl%C3%B6cklein&numprops=4``.
- - ``limit=Integer``: Lmits the amount of results returned (e.g. ``http://www.knora.org/v1/resources?searchstr=Zeitgl%C3%B6cklein&limit=1``).
+ - ``limit=Integer``: Limits the amount of results returned (e.g. ``http://www.knora.org/v1/resources?searchstr=Zeitgl%C3%B6cklein&limit=1``).
 
 
 The response lists the resources that matched the search criteria (see TypeScript interface ``resourceLabelSearchResponse`` in module ``resourceResponseFormats``).
@@ -191,7 +191,7 @@ Please note that the search terms have to be URL encoded.
     [&filter_by_project=projectIRI][&show_nrows=Integer]{[&start_at=Integer]
 
 The parameter ``searchtype`` is required and has to be set to ``fulltext``. Additionally, these parameters can be set:
-  - ``filter_by_restype=resourceClassIRI``: restricts the search to resources of the specified resource class.
+  - ``filter_by_restype=resourceClassIRI``: restricts the search to resources of the specified resource class (subclasses of that class will also match).
   - ``filter_by_project=projectIRI``: restricts the search to resources of the specified project.
   - ``show_nrows=Integer``: Indicates how many reults should be presented on one page. If omitted, the default value ``25`` is used.
   - ``start_at=Integer``: Used to enable paging and go through all the results request by request.
@@ -213,7 +213,7 @@ Extended Search for Resources
     [&show_nrows=Integer][&start_at=Integer]
 
 The parameter ``searchtype`` is required and has to be set to ``extended``. An extended search requires at least one set of parameters consisting of:
-  - ``property_id=propertyTypeIRI``: the type of property the resource has to have
+  - ``property_id=propertyTypeIRI``: the property the resource has to have (subproperties of that property will also match).
   - ``compop=comparisonOperator``: the comparison operator to be used to match between the resource's property value and the search term.
   - ``searchval=searchTerm``: the search value to look for.
 
@@ -255,7 +255,7 @@ Explanation of the comparison operators:
   - ``MATCH_BOOLEAN``: checks if a resource's text value *matches* the provided list of positive (exist) and negative (do not exist) terms. The list takes this form: ``([+-]term\s)+``.
 
 Additionally, these parameters can be set:
-  - ``filter_by_restype=resourceClassIRI``: restricts the search to resources of the specified resource class.
+  - ``filter_by_restype=resourceClassIRI``: restricts the search to resources of the specified resource class (subclasses of that class will also match).
   - ``filter_by_project=projectIRI``: restricts the search to resources of the specified project.
   - ``filter_by_owner``: restricts the search to resources owned by the specified user.
   - ``show_nrows=Integer``: Indicates how many reults should be presented on one page. If omitted, the default value ``25`` is used.

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1/store/triplestoremessages/TriplestoreMessages.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1/store/triplestoremessages/TriplestoreMessages.scala
@@ -24,7 +24,12 @@ case object CheckConnection extends TriplestoreRequest
   * Represents a SPARQL SELECT query to be sent to the triplestore.
   *
   * @param sparql       the SPARQL string.
-  * @param useInference if `true`, ask the triplestore to use inference in the query, if possible.
+  * @param useInference if `true`, ask the triplestore to use inference in the query, if possible. If the triplestore
+  *                     is being accessed over HTTP, this is likely to mean setting a parameter in the HTTP request.
+  *                     Note that with GraphDB, setting this to `false` is not sufficient to completely disable inference,
+  *                     because it does not disable the `owl:sameAs` optimisation. To completely disable inference
+  *                     for a query in GraphDB, you must include `FROM <http://www.ontotext.com/explicit>`
+  *                     in the SPARQL.
   */
 case class SparqlSelectRequest(sparql: String, useInference: Boolean = false) extends TriplestoreRequest
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1/store/triplestoremessages/TriplestoreMessages.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1/store/triplestoremessages/TriplestoreMessages.scala
@@ -11,21 +11,22 @@ import spray.json.{DefaultJsonProtocol, NullOptions, RootJsonFormat}
 sealed trait TriplestoreRequest
 
 /**
-  * Simple message for initial actor functionality
+  * Simple message for initial actor functionality.
   */
 case class HelloTriplestore(txt: String) extends TriplestoreRequest
 
 /**
-  * Simple message for checking the connection to the Triplestore
+  * Simple message for checking the connection to the triplestore.
   */
 case object CheckConnection extends TriplestoreRequest
 
 /**
   * Represents a SPARQL SELECT query to be sent to the triplestore.
   *
-  * @param sparql the SPARQL string.
+  * @param sparql       the SPARQL string.
+  * @param useInference if `true`, ask the triplestore to use inference in the query, if possible.
   */
-case class SparqlSelectRequest(sparql: String) extends TriplestoreRequest
+case class SparqlSelectRequest(sparql: String, useInference: Boolean = false) extends TriplestoreRequest
 
 /**
   * Represents a response to a SPARQL SELECT query, containing a parsed representation of the response (JSON, etc.)
@@ -208,7 +209,6 @@ case class Initialized() extends TriplestoreRequest
   * @param initFinished indicates if actor initialization has finished
   */
 case class InitializedResponse(initFinished: Boolean)
-
 
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
@@ -1092,13 +1092,18 @@ class ResourcesResponderV1 extends ResponderV1 {
                 triplestore = settings.triplestoreType,
                 phrase = phrase,
                 lastTerm = lastTerm,
-                resourceTypeIri = resourceTypeIri,
+                restypeIriOption = resourceTypeIri,
                 numberOfProps = numberOfProps,
                 limitOfResults = limitOfResults,
                 separator = FormatConstants.INFORMATION_SEPARATOR_ONE
             ).toString())
-            //_ = println(searchResourcesSparql)
-            searchResponse <- (storeManager ? SparqlSelectRequest(searchResourcesSparql)).mapTo[SparqlSelectResponse]
+
+            // _ = println(searchResourcesSparql)
+
+            // If we're using GraphDB, optimise this query by using inference.
+            useInference = settings.triplestoreType.startsWith("graphdb")
+
+            searchResponse <- (storeManager ? SparqlSelectRequest(sparql = searchResourcesSparql, useInference = useInference)).mapTo[SparqlSelectResponse]
 
             resources: Seq[ResourceSearchResultRowV1] = searchResponse.results.bindings.map {
                 case (row: VariableResultsRow) =>

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/SearchResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/SearchResponderV1.scala
@@ -146,7 +146,10 @@ class SearchResponderV1 extends ResponderV1 {
 
             // _ = println("================" + pagingSparql)
 
-            searchResponse: SparqlSelectResponse <- (storeManager ? SparqlSelectRequest(searchSparql)).mapTo[SparqlSelectResponse]
+            // If we're using GraphDB, optimise this query by using inference.
+            useInference = settings.triplestoreType.startsWith("graphdb")
+
+            searchResponse: SparqlSelectResponse <- (storeManager ? SparqlSelectRequest(sparql = searchSparql, useInference = useInference)).mapTo[SparqlSelectResponse]
 
             // Get the IRIs of all the properties mentioned in the search results.
             propertyIris: Set[IRI] = searchResponse.results.bindings.flatMap(_.rowMap.get("resourceProperty")).toSet
@@ -471,7 +474,10 @@ class SearchResponderV1 extends ResponderV1 {
 
             // _ = println(searchSparql)
 
-            searchResponse: SparqlSelectResponse <- (storeManager ? SparqlSelectRequest(searchSparql)).mapTo[SparqlSelectResponse]
+            // If we're using GraphDB, optimise this query by using inference.
+            useInference = settings.triplestoreType.startsWith("graphdb")
+
+            searchResponse: SparqlSelectResponse <- (storeManager ? SparqlSelectRequest(sparql = searchSparql, useInference = useInference)).mapTo[SparqlSelectResponse]
 
             // Collect all the resource class IRIs mentioned in the search results.
             resourceClassIris: Set[IRI] = searchResponse.results.bindings.map(_.rowMap("resourceClass")).toSet

--- a/webapi/src/main/scala/org/knora/webapi/store/triplestore/embedded/JenaTDBActor.scala
+++ b/webapi/src/main/scala/org/knora/webapi/store/triplestore/embedded/JenaTDBActor.scala
@@ -118,7 +118,7 @@ class JenaTDBActor extends Actor with ActorLogging {
       * method first returns `Failure` to the sender, then throws an exception.
       */
     def receive = {
-        case SparqlSelectRequest(sparqlSelectString) => future2Message(sender(), executeSparqlSelectQuery(sparqlSelectString), log)
+        case SparqlSelectRequest(sparqlSelectString, useInference) => future2Message(sender(), executeSparqlSelectQuery(sparqlSelectString, useInference), log)
         case SparqlUpdateRequest(sparqlUpdateString) => future2Message(sender(), executeSparqlUpdateQuery(sparqlUpdateString), log)
         case ResetTriplestoreContent(rdfDataObjects) => future2Message(sender(), resetTripleStoreContent(rdfDataObjects), log)
         case DropAllTriplestoreContent() => future2Message(sender(), Future(dropAllTriplestoreContent()), log)
@@ -132,9 +132,10 @@ class JenaTDBActor extends Actor with ActorLogging {
       * Submits a SPARQL query to the embedded Jena TDB store and returns the response as a [[SparqlSelectResponse]].
       *
       * @param queryString the SPARQL request to be submitted.
+      * @param useInference not supported.
       * @return [[SparqlSelectResponse]].
       */
-    private def executeSparqlSelectQuery(queryString: String): Future[SparqlSelectResponse] = {
+    private def executeSparqlSelectQuery(queryString: String, useInference: Boolean): Future[SparqlSelectResponse] = {
 
         // Start read transaction
         this.dataset.begin(ReadWrite.READ)

--- a/webapi/src/main/twirl/queries/sparql/v1/getResourceSearchResult.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getResourceSearchResult.scala.txt
@@ -24,17 +24,20 @@
 @*
  * Performs a search for resources matching the given criteria.
  *
- * If the triplestore type is GraphDB, the generated SPARQL is optimised by taking advantage of forward-chaining
- * RDFS inference.
+ * If the triplestore type is GraphDB, we assume that inference is enabled, and we use it to optimise the generated
+ * SPARQL. Specifically, we use inference to return search results matching subclasses of the resource class
+ * specified by the user. Without inference, we have to do this using SPARQL property path syntax
+ * (rdfs:subClassOf*). Using inference requires us to use GraphDB's GRAPH <http://www.ontotext.com/explicit>
+ * whenever we need to get explicit (non-inferred) statements.
  *
  * @param triplestore the name of the triplestore being used.
  * @param phrase the search phrase (e.g. "Reise ins").
  * @param lastTerm the last search term (e.g. "Heili").
- * @param resourceTypeIri if set, restrict search to this resource type.
- * @param numberOfProps the amount of describing properties to be returned for each found resource (e.g if set to two, for an incunabula book its title and creator would be returned).
+ * @param resourceTypeIri if set, restricts search to this resource class and its subclasses.
+ * @param numberOfProps the amount of describing properties to be returned for each found resource (e.g if set to two,
+ *                      for an incunabula book its title and creator would be returned).
  * @param limitOfResults limits number of resources to be returned.
- * @param separator The separater to be used when concatenating the value strings.
- *
+ * @param separator the separator to be used when concatenating the value strings.
  *@
 @(triplestore: String,
   phrase: Option[String],

--- a/webapi/src/main/twirl/queries/sparql/v1/getResourceSearchResult.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getResourceSearchResult.scala.txt
@@ -24,6 +24,9 @@
 @*
  * Performs a search for resources matching the given criteria.
  *
+ * If the triplestore type is GraphDB, the generated SPARQL is optimised by taking advantage of forward-chaining
+ * RDFS inference.
+ *
  * @param triplestore the name of the triplestore being used.
  * @param phrase the search phrase (e.g. "Reise ins").
  * @param lastTerm the last search term (e.g. "Heili").
@@ -36,7 +39,7 @@
 @(triplestore: String,
   phrase: Option[String],
   lastTerm: String,
-  resourceTypeIri: Option[IRI],
+  restypeIriOption: Option[IRI],
   numberOfProps: Int,
   limitOfResults: Int,
   separator: Char)
@@ -49,10 +52,6 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT ?resourceIri ?firstProp ?attachedToUser ?attachedToProject ?resourcePermissions
 @if(numberOfProps > 1) {
     (GROUP_CONCAT(?valueString; separator="@separator") AS ?values) (GROUP_CONCAT(?guiOrder; separator=";") AS ?guiOrders) (GROUP_CONCAT(?valueOrder; separator=";") AS ?valueOrders)
-}
-@* Ensure that inference is not used in this query. *@
-@if(triplestore.startsWith("graphdb")) {
-    FROM <http://www.ontotext.com/explicit>
 }
 WHERE {
 
@@ -94,17 +93,68 @@ WHERE {
         }
     }
 
+    ?resourceIri knora-base:isDeleted false .
 
-    ?resourceIri a ?resourceClass ;
-        knora-base:isDeleted false .
-    ?resourceClass rdfs:subClassOf+ knora-base:Resource .
+    @if(triplestore.startsWith("graphdb")) {
 
-    @if(resourceTypeIri.nonEmpty) {
-        ?resourceClass rdfs:subClassOf* <@resourceTypeIri> .
+        @restypeIriOption match {
+
+            case Some(restypeIri) => {
+
+                # Filter by resource class.
+
+                ?resourceIri a <@restypeIri> .
+
+            }
+
+            case None => {
+
+                @* Ensure that each matching resource is a knora-base:Resource. *@
+
+                ?resourceIri a knora-base:Resource .
+            }
+        }
+
+    } else {
+
+        @restypeIriOption match {
+
+            case Some(restypeIri) => {
+
+                # Filter by resource class.
+
+                ?resClass rdfs:subClassOf* <@restypeIri> .
+                ?resourceIri a ?resClass .
+
+            }
+
+            case None => {
+
+                @* Ensure that each matching resource is a knora-base:Resource. *@
+
+                ?resClass rdfs:subClassOf+ knora-base:Resource .
+                ?resourceIri a ?resClass .
+
+            }
+        }
     }
 
     @if(numberOfProps > 1) {
-        ?resourceIri ?property ?valueObjectIri .
+
+        @if(triplestore.startsWith("graphdb")) {
+
+            GRAPH <http://www.ontotext.com/explicit> {
+
+                ?resourceIri ?property ?valueObjectIri .
+
+             }
+
+        } else {
+
+            ?resourceIri ?property ?valueObjectIri .
+
+        }
+
         ?property knora-base:objectClassConstraint knora-base:TextValue .
         ?valueObjectIri knora-base:valueHasString ?valueString ;
             knora-base:isDeleted false ;

--- a/webapi/src/main/twirl/queries/sparql/v1/searchExtended.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/searchExtended.scala.txt
@@ -93,11 +93,11 @@ WHERE {
 
             @if(triplestore.startsWith("graphdb")) {
 
-                ?resource <@{searchCriterion.propertyIri}> ?valueObject@index .
+                ?resource <@searchCriterion.propertyIri> ?valueObject@index .
 
             } else {
 
-                ?p@index rdfs:subPropertyOf* <@{searchCriterion.propertyIri}> .
+                ?p@index rdfs:subPropertyOf* <@searchCriterion.propertyIri> .
                 ?resource ?p@index ?valueObject@index .
 
             }
@@ -171,7 +171,25 @@ WHERE {
                 @searchCriterion.valueType match {
                     case "http://www.knora.org/ontology/knora-base#Resource" => {
 
-                        ?resource <@searchCriterion.propertyIri> ?targetResource@index .
+                        @if(triplestore.startsWith("graphdb")) {
+
+                            ?resource <@searchCriterion.propertyIri> ?targetResource@index .
+                            ?resource <@{searchCriterion.propertyIri}Value> ?valueObject@index .
+
+                            GRAPH <http://www.ontotext.com/explicit> {
+
+                                ?resource ?linkProperty@index ?targetResource@index .
+
+                            }
+
+                        } else {
+
+                            ?linkProperty@index rdfs:subPropertyOf* <@searchCriterion.propertyIri> .
+                            ?resource ?linkProperty@index ?targetResource@index .
+                            ?linkValueProperty@index rdfs:subPropertyOf* <@{searchCriterion.propertyIri}Value> .
+                            ?resource ?linkValueProperty@index ?valueObject@index .
+
+                        }
 
                         ?targetResource@index rdfs:label ?literal@index ;
                             knora-base:isDeleted false ;
@@ -182,11 +200,9 @@ WHERE {
                             ?targetResource@index knora-base:hasPermissions ?targetResourcePermissions@index .
                         }
 
-                        ?resource <@{searchCriterion.propertyIri}Value> ?valueObject@index .
-
                         ?valueObject@index rdf:type knora-base:LinkValue ;
                             rdf:subject ?resource ;
-                            rdf:predicate <@searchCriterion.propertyIri> ;
+                            rdf:predicate ?linkProperty@index ;
                             rdf:object ?targetResource@index .
                     }
 
@@ -240,8 +256,27 @@ WHERE {
                     case "http://www.knora.org/ontology/knora-base#Resource" => {
 
                         BIND(IRI("@searchCriterion.searchValue") AS ?targetResource@index)
-                        
-                        ?resource <@searchCriterion.propertyIri> <@searchCriterion.searchValue> .
+
+
+                        @if(triplestore.startsWith("graphdb")) {
+
+                            ?resource <@searchCriterion.propertyIri> <@searchCriterion.searchValue> .
+                            ?resource <@{searchCriterion.propertyIri}Value> ?valueObject@index .
+
+                            GRAPH <http://www.ontotext.com/explicit> {
+
+                                ?resource ?linkProperty@index <@searchCriterion.searchValue> .
+
+                            }
+
+                        } else {
+
+                            ?linkProperty@index rdfs:subPropertyOf* <@searchCriterion.propertyIri> .
+                            ?resource ?linkProperty@index <@searchCriterion.searchValue> .
+                            ?linkValueProperty@index rdfs:subPropertyOf* <@{searchCriterion.propertyIri}Value> .
+                            ?resource ?linkValueProperty@index ?valueObject@index .
+
+                        }
 
                         <@searchCriterion.searchValue> rdfs:label ?literal@index ;
                             knora-base:isDeleted false ;
@@ -252,11 +287,9 @@ WHERE {
                             <@searchCriterion.searchValue> knora-base:hasPermissions ?targetResourcePermissions@index .
                         }
 
-                        ?resource <@{searchCriterion.propertyIri}Value> ?valueObject@index .
-
                         ?valueObject@index rdf:type knora-base:LinkValue ;
                             rdf:subject ?resource ;
-                            rdf:predicate <@searchCriterion.propertyIri> ;
+                            rdf:predicate ?linkProperty@index ;
                             rdf:object <@searchCriterion.searchValue> .
                     }
 

--- a/webapi/src/main/twirl/queries/sparql/v1/searchExtended.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/searchExtended.scala.txt
@@ -27,14 +27,16 @@
  * Performs an extended search. The number of rows returned per matching resource is the product of the number of
  * values that each search criterion matched in the resource.
  *
+ * If the triplestore type is GraphDB, the generated SPARQL is optimised by taking advantage of forward-chaining
+ * RDFS inference.
+ *
  * @param triplestore the name of the triplestore being used.
  * @param searchCriteria a list of maps containing search criteria, each of which contains:
  * @param preferredLanguage the language code of the user's preferred language.
  * @param fallbackLanguage the language code of the application's default language.
- * @param projectIri if filtering by project is desired, the IRI of the project to search.
- * @param restypeIri if filtering by resource type is desired, the IRI of the resource type to search for.
- * @param ownerIri if filtering by owner is desired, the IRI of the resource owner to search for.
- * @param limit the maximum number of results to re
+ * @param projectIriOption if filtering by project is desired, the IRI of the project to search.
+ * @param restypeIriOption if filtering by resource type is desired, the IRI of the resource type to search for.
+ * @param ownerIriOption if filtering by owner is desired, the IRI of the resource owner to search for.
  *@
 @(triplestore: String,
   searchCriteria: Seq[SearchCriterion],
@@ -70,10 +72,6 @@ SELECT DISTINCT
         ?targetResourcePermissions@index
         ?literal@index
     }
-@* Ensure that inference is not used in this query. *@
-@if(triplestore.startsWith("graphdb")) {
-    FROM <http://www.ontotext.com/explicit>
-}
 WHERE {
     BIND(STR("@preferredLanguage") AS ?preferredLanguage)
     BIND(STR("@fallbackLanguage") AS ?fallbackLanguage)
@@ -92,8 +90,18 @@ WHERE {
         *@
 
         @if(searchCriterion.valueType != "http://www.knora.org/ontology/knora-base#Resource") {
-            ?p@index rdfs:subPropertyOf* <@{searchCriterion.propertyIri}> .
-            ?resource ?p@index ?valueObject@index .
+
+            @if(triplestore.startsWith("graphdb")) {
+
+                ?resource <@{searchCriterion.propertyIri}> ?valueObject@index .
+
+            } else {
+
+                ?p@index rdfs:subPropertyOf* <@{searchCriterion.propertyIri}> .
+                ?resource ?p@index ?valueObject@index .
+
+            }
+
         }
 
         @*
@@ -536,8 +544,6 @@ WHERE {
     }
 
     ?resource knora-base:isDeleted false .
-    ?resource rdfs:label ?resourceLabel .
-    ?resource a ?resourceClass .
 
     @projectIriOption match {
         case Some(projectIri) => {
@@ -550,23 +556,57 @@ WHERE {
         case None => {}
     }
 
-    @restypeIriOption match {
-        case Some(restypeIri) => {
+    @if(triplestore.startsWith("graphdb")) {
 
-            # filter by restypeIri
-            ?resClass rdfs:subClassOf* <@restypeIri> .
-            ?resource a ?resClass .
+        GRAPH <http://www.ontotext.com/explicit> {
+
+            ?resource a ?resourceClass .
+
         }
 
-        case None => {
+        @restypeIriOption match {
 
-            # Make sure we have a knora-base:Resource.
-            ?resClass rdfs:subClassOf+ knora-base:Resource .
-            ?resource a ?resClass .
+            case Some(restypeIri) => {
 
+                # Filter by resource class.
+
+                ?resource a <@restypeIri> .
+
+            }
+
+            case None => {
+
+                @* Ensure that each matching resource is a knora-base:Resource. *@
+
+                ?resource a knora-base:Resource .
+            }
+        }
+
+    } else {
+
+        ?resource a ?resourceClass .
+
+        @restypeIriOption match {
+
+            case Some(restypeIri) => {
+
+                # Filter by resource class.
+
+                ?resClass rdfs:subClassOf* <@restypeIri> .
+                ?resource a ?resClass .
+
+            }
+
+            case None => {
+
+                @* Ensure that each matching resource is a knora-base:Resource. *@
+
+                ?resClass rdfs:subClassOf+ knora-base:Resource .
+                ?resource a ?resClass .
+
+            }
         }
     }
-
 
     @ownerIriOption match {
         case Some(ownerIri) => {
@@ -577,6 +617,8 @@ WHERE {
 
         case None => {}
     }
+
+    ?resource rdfs:label ?resourceLabel .
 
     OPTIONAL {
         ?resource knora-base:hasStillImageFileValue ?fileValue .

--- a/webapi/src/main/twirl/queries/sparql/v1/searchExtended.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/searchExtended.scala.txt
@@ -27,15 +27,18 @@
  * Performs an extended search. The number of rows returned per matching resource is the product of the number of
  * values that each search criterion matched in the resource.
  *
- * If the triplestore type is GraphDB, the generated SPARQL is optimised by taking advantage of forward-chaining
- * RDFS inference.
+ * If the triplestore type is GraphDB, we assume that inference is enabled, and we use it to optimise the generated
+ * SPARQL. Specifically, we use inference to return search results matching subclasses and subproperties of the ones
+ * specified in the search criteria. Without inference, we have to do this using SPARQL property path syntax
+ * (rdfs:subClassOf* and rdfs:subPropertyOf*). Using inference requires us to use GraphDB's
+ * GRAPH <http://www.ontotext.com/explicit> whenever we need to get explicit (non-inferred) statements.
  *
  * @param triplestore the name of the triplestore being used.
  * @param searchCriteria a list of maps containing search criteria, each of which contains:
  * @param preferredLanguage the language code of the user's preferred language.
  * @param fallbackLanguage the language code of the application's default language.
  * @param projectIriOption if filtering by project is desired, the IRI of the project to search.
- * @param restypeIriOption if filtering by resource type is desired, the IRI of the resource type to search for.
+ * @param restypeIriOption if given, returns only resources of this class and its subclasses.
  * @param ownerIriOption if filtering by owner is desired, the IRI of the resource owner to search for.
  *@
 @(triplestore: String,

--- a/webapi/src/main/twirl/queries/sparql/v1/searchFulltext.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/searchFulltext.scala.txt
@@ -25,6 +25,9 @@
  * Performs a simple full-text search. The number of rows returned per matching resource is equal to the number of
  * values that matched in the resource, plus one if the resource's label matched.
  *
+ * If the triplestore type is GraphDB, the generated SPARQL is optimised by taking advantage of forward-chaining
+ * RDFS inference.
+ *
  * @param triplestore the name of the triplestore being used.
  * @param searchTerms search terms to be combined with AND in Lucene full-text search syntax.
  * @param preferredLanguage the language code of the user's preferred language.
@@ -60,10 +63,6 @@ SELECT DISTINCT
     ?valueProject
     ?valuePermissions
     ?literal
-@* Ensure that inference is not used in this query. *@
-@if(triplestore.startsWith("graphdb")) {
-    FROM <http://www.ontotext.com/explicit>
-}
 WHERE {
     BIND(STR("@preferredLanguage") AS ?preferredLanguage)
     BIND(STR("@fallbackLanguage") AS ?fallbackLanguage)
@@ -103,13 +102,30 @@ WHERE {
     # ?matchingSubject could be a resource (whose rdfs:label matched) or a value object
 
     OPTIONAL {
-        # if this clause is executed, it is a value object
+        # If this clause is executed, it is a value object. We set ?containingResource to the resource that contains the matching value object.
 
-        ?matchingSubject a ?valueObjectType .
-        ?valueObjectType rdfs:subClassOf+ knora-base:Value .
+        @if(triplestore.startsWith("graphdb")) {
+
+            ?matchingSubject a knora-base:Value .
+            ?containingResource knora-base:hasValue ?matchingSubject .
+
+            GRAPH <http://www.ontotext.com/explicit> {
+
+                ?matchingSubject a ?valueObjectType .
+                ?containingResource ?resourceProperty ?matchingSubject .
+
+            }
+
+        } else {
+
+            ?matchingSubject a ?valueObjectType .
+            ?valueObjectType rdfs:subClassOf+ knora-base:Value .
+            ?containingResource ?resourceProperty ?matchingSubject .
+            ?resourceProperty rdfs:subPropertyOf+ knora-base:hasValue .
+
+        }
+
         FILTER(?valueObjectType != knora-base:LinkValue)
-        ?containingResource ?resourceProperty ?matchingSubject . @* ?containingResource is the resource that contains the matching value object *@
-        ?resourceProperty rdfs:subPropertyOf+ knora-base:hasValue .
         ?containingResource knora-base:isDeleted false .
 
         BIND(?matchingSubject AS ?valueObject)
@@ -134,9 +150,6 @@ WHERE {
     # If the previous OPTIONAL clause executed, ?matchingSubject is a value, and ?containingResource will be set. Otherwise, ?matchingSubject is a resource.
     BIND(COALESCE(?containingResource, ?matchingSubject) AS ?resource)
 
-    ?resource a ?resourceClass .
-    ?resource rdfs:label ?resourceLabel .
-
     @projectIriOption match {
         case Some(projectIri) => {
 
@@ -148,22 +161,59 @@ WHERE {
         case None => {}
     }
 
-    @restypeIriOption match {
-        case Some(restypeIri) => {
+    @if(triplestore.startsWith("graphdb")) {
 
-            # filter by restypeIri
-            ?resClass rdfs:subClassOf* <@restypeIri> .
-            ?resource a ?resClass .
+        GRAPH <http://www.ontotext.com/explicit> {
+
+            ?resource a ?resourceClass .
+
         }
 
-        case None => {
+        @restypeIriOption match {
 
-            # Make sure we have a knora-base:Resource.
-            ?resClass rdfs:subClassOf+ knora-base:Resource .
-            ?resource a ?resClass .
+            case Some(restypeIri) => {
 
+                # Filter by resource class.
+
+                ?resource a <@restypeIri> .
+
+            }
+
+            case None => {
+
+                @* Ensure that each matching resource is a knora-base:Resource. *@
+
+                ?resource a knora-base:Resource .
+            }
+        }
+
+    } else {
+
+        ?resource a ?resourceClass .
+
+        @restypeIriOption match {
+
+            case Some(restypeIri) => {
+
+                # Filter by resource class.
+
+                ?resClass rdfs:subClassOf* <@restypeIri> .
+                ?resource a ?resClass .
+
+            }
+
+            case None => {
+
+                @* Ensure that each matching resource is a knora-base:Resource. *@
+
+                ?resClass rdfs:subClassOf+ knora-base:Resource .
+                ?resource a ?resClass .
+
+            }
         }
     }
+
+    ?resource rdfs:label ?resourceLabel .
 
     OPTIONAL {
        ?resource knora-base:hasStillImageFileValue ?fileValue .

--- a/webapi/src/main/twirl/queries/sparql/v1/searchFulltext.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/searchFulltext.scala.txt
@@ -25,15 +25,18 @@
  * Performs a simple full-text search. The number of rows returned per matching resource is equal to the number of
  * values that matched in the resource, plus one if the resource's label matched.
  *
- * If the triplestore type is GraphDB, the generated SPARQL is optimised by taking advantage of forward-chaining
- * RDFS inference.
+ * If the triplestore type is GraphDB, we assume that inference is enabled, and we use it to optimise the generated
+ * SPARQL. Specifically, we use inference to return search results matching subclasses of the resource class
+ * specified by the user. Without inference, we have to do this using SPARQL property path syntax
+ * (rdfs:subClassOf*). Using inference requires us to use GraphDB's GRAPH <http://www.ontotext.com/explicit> whenever
+ * we need to get explicit (non-inferred) statements.
  *
  * @param triplestore the name of the triplestore being used.
  * @param searchTerms search terms to be combined with AND in Lucene full-text search syntax.
  * @param preferredLanguage the language code of the user's preferred language.
  * @param fallbackLanguage the language code of the application's default language.
  * @param projectIriOption if filtering by project is desired, the IRI of the project to search.
- * @param restypeIriOption if filtering by resource type is desired, the IRI of the resource type to search for.
+ * @param restypeIriOption if given, searches only for resources of this class and its subclasses.
  *@
 @(triplestore: String,
   searchTerms: Seq[String],

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/ResourcesResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/ResourcesResponderV1Spec.scala
@@ -618,7 +618,7 @@ class ResourcesResponderV1Spec extends CoreSpec() with ImplicitSender {
         }
 
         "return 27 resources containing 'Narrenschiff' in their label" in {
-            //http://localhost:3333/v1/resources?searchstr=Narrenschiff&numprops=4&limit=100&restype_id=-1
+            //http://localhost:3333/v1/resources?searchstr=Narrenschiff&numprops=4&limit=100&restype_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23book
 
             // This query is going to return also resources of knora-baseLinkObj with a knora-base:hasComment.
             // Because this resource is directly defined in knora-base, its property knora-base:hasComment
@@ -640,7 +640,7 @@ class ResourcesResponderV1Spec extends CoreSpec() with ImplicitSender {
         }
 
         "return 3 resources containing 'Narrenschiff' in their label of type incunabula:book" in {
-            //http://localhost:3333/v1/resources?searchstr=Narrenschiff&numprops=3&limit=100&restype_id=-1
+            //http://localhost:3333/v1/resources?searchstr=Narrenschiff&numprops=3&limit=100&restype_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23book
 
             actorUnderTest ! ResourceSearchGetRequestV1(
                 searchString = "Narrenschiff",
@@ -653,6 +653,40 @@ class ResourcesResponderV1Spec extends CoreSpec() with ImplicitSender {
             expectMsgPF(timeout) {
                 case response: ResourceSearchResponseV1 =>
                     assert(response.resources.size == 3, s"expected 3 resources")
+            }
+        }
+
+        "return 19 resources containing 'a1r' in their label of type incunabula:page" in {
+            //http://localhost:3333/v1/resources?searchstr=a1r&numprops=3&limit=100&restype_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23page
+
+            actorUnderTest ! ResourceSearchGetRequestV1(
+                searchString = "a1r",
+                numberOfProps = 3,
+                limitOfResults = 100,
+                userProfile = incunabulaUser,
+                resourceTypeIri = Some("http://www.knora.org/ontology/incunabula#page")
+            )
+
+            expectMsgPF(timeout) {
+                case response: ResourceSearchResponseV1 =>
+                    assert(response.resources.size == 19, s"expected 19 resources")
+            }
+        }
+
+        "return 19 resources containing 'a1r' in their label of type knora-base:Representation" in {
+            //http://localhost:3333/v1/resources?searchstr=a1r&numprops=3&limit=100&restype_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fknora-base%23Representation
+
+            actorUnderTest ! ResourceSearchGetRequestV1(
+                searchString = "a1r",
+                numberOfProps = 3,
+                limitOfResults = 100,
+                userProfile = incunabulaUser,
+                resourceTypeIri = Some("http://www.knora.org/ontology/knora-base#Representation")
+            )
+
+            expectMsgPF(timeout) {
+                case response: ResourceSearchResponseV1 =>
+                    assert(response.resources.size == 19, s"expected 19 resources")
             }
         }
 

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/SearchResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/SearchResponderV1Spec.scala
@@ -581,7 +581,7 @@ class SearchResponderV1Spec extends CoreSpec() with ImplicitSender {
             }
         }
 
-        "return 79 pages when we search for all pages that have a sequence number greater than 450 in the Incunabula test data" in {
+        "return 79 pages when we search for all pages that have an incunabula:seqnum greater than 450 in the Incunabula test data" in {
             // http://localhost:3333/v1/search/?searchtype=extended&filter_by_restype=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23page&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23seqnum&compop=GT&searchval=450
             actorUnderTest ! ExtendedSearchGetRequestV1(
                 userProfile = incunabulaUser,
@@ -589,6 +589,23 @@ class SearchResponderV1Spec extends CoreSpec() with ImplicitSender {
                 compareProps = Vector(SearchComparisonOperatorV1.GT),
                 propertyIri = Vector("http://www.knora.org/ontology/incunabula#seqnum"),
                 filterByRestype = Some("http://www.knora.org/ontology/incunabula#page"),
+                startAt = 0,
+                showNRows = 100
+            )
+
+            expectMsgPF(timeout) {
+                case response: SearchGetResponseV1 => response.subjects.size should ===(79)
+            }
+        }
+
+        "return 79 pages when we search for all representations that have an incunabula:seqnum greater than 450 in the Incunabula test data" in {
+            // http://localhost:3333/v1/search/?searchtype=extended&filter_by_restype=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23page&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23seqnum&compop=GT&searchval=450
+            actorUnderTest ! ExtendedSearchGetRequestV1(
+                userProfile = incunabulaUser,
+                searchValue = Vector("450"),
+                compareProps = Vector(SearchComparisonOperatorV1.GT),
+                propertyIri = Vector("http://www.knora.org/ontology/incunabula#seqnum"),
+                filterByRestype = Some("http://www.knora.org/ontology/knora-base#Representation"),
                 startAt = 0,
                 showNRows = 100
             )

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/SearchResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/SearchResponderV1Spec.scala
@@ -599,7 +599,6 @@ class SearchResponderV1Spec extends CoreSpec() with ImplicitSender {
         }
 
         "return 79 pages when we search for all representations that have an incunabula:seqnum greater than 450 in the Incunabula test data" in {
-            // http://localhost:3333/v1/search/?searchtype=extended&filter_by_restype=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23page&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23seqnum&compop=GT&searchval=450
             actorUnderTest ! ExtendedSearchGetRequestV1(
                 userProfile = incunabulaUser,
                 searchValue = Vector("450"),
@@ -700,6 +699,22 @@ class SearchResponderV1Spec extends CoreSpec() with ImplicitSender {
             }
         }
 
+        "return all the representations that have a sequence number of 1 and are part of some book (using knora-base:isPartOf)" in {
+            actorUnderTest ! ExtendedSearchGetRequestV1(
+                userProfile = incunabulaUser,
+                searchValue = Vector("1", ""),
+                compareProps = Vector(SearchComparisonOperatorV1.EQ, SearchComparisonOperatorV1.EXISTS),
+                propertyIri = Vector("http://www.knora.org/ontology/incunabula#seqnum", "http://www.knora.org/ontology/knora-base#isPartOf"),
+                filterByRestype = Some("http://www.knora.org/ontology/knora-base#Representation"),
+                startAt = 0,
+                showNRows = 25
+            )
+
+            expectMsgPF(timeout) {
+                case response: SearchGetResponseV1 => response.subjects.size should ===(19)
+            }
+        }
+
         "return all the pages that are part of Zeitglöcklein des Lebens and have a seqnum" in {
             // http://localhost:3333/v1/search/?searchtype=extended&filter_by_restype=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23page&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23partOf&compop=EQ&searchval=http%3A%2F%2Fdata.knora.org%2Fc5058f3a&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23seqnum&compop=EXISTS&searchval=
             actorUnderTest ! ExtendedSearchGetRequestV1(
@@ -708,6 +723,23 @@ class SearchResponderV1Spec extends CoreSpec() with ImplicitSender {
                 compareProps = Vector(SearchComparisonOperatorV1.EQ, SearchComparisonOperatorV1.EXISTS),
                 propertyIri = Vector("http://www.knora.org/ontology/incunabula#partOf", "http://www.knora.org/ontology/incunabula#seqnum"),
                 filterByRestype = Some("http://www.knora.org/ontology/incunabula#page"),
+                startAt = 0,
+                showNRows = 500
+            )
+
+            expectMsgPF(timeout) {
+                case response: SearchGetResponseV1 => response.subjects.size should ===(402)
+            }
+
+        }
+
+        "return all the representations that are part of Zeitglöcklein des Lebens and have a seqnum (using base properties from knora-base)" in {
+            actorUnderTest ! ExtendedSearchGetRequestV1(
+                userProfile = incunabulaUser,
+                searchValue = Vector("http://data.knora.org/c5058f3a", ""),
+                compareProps = Vector(SearchComparisonOperatorV1.EQ, SearchComparisonOperatorV1.EXISTS),
+                propertyIri = Vector("http://www.knora.org/ontology/knora-base#isPartOf", "http://www.knora.org/ontology/knora-base#seqnum"),
+                filterByRestype = Some("http://www.knora.org/ontology/knora-base#Representation"),
                 startAt = 0,
                 showNRows = 500
             )


### PR DESCRIPTION
When we added support for searching for subclasses and subproperties in #283, there was a performance penalty in some cases. This pull requests optimises those cases by using inference on GraphDB.

For most of the existing search tests, the performance improvement is small, but it's significant in a few cases.

Before:

```
[info] - should return 19 books when we search for all books in the Incunabula test data (321 milliseconds)
```

After:

```
[info] - should return 19 books when we search for all books in the Incunabula test data (9 milliseconds)
```

Before:

```
[info] - should return 79 pages when we search for all pages that have a sequence number greater than 450 in the Incunabula test data (189 milliseconds)
```

After:

```
[info] - should return 79 pages when we search for all pages that have an incunabula:seqnum greater than 450 in the Incunabula test data (57 milliseconds)
```

I also added support for searching for subproperties of link properties, which we forgot to do in #283.
