### PR TITLE
Allow inheritance of objectClassConstraint

### DIFF
--- a/docs/rst/knora-ontologies/knora-base.rst
+++ b/docs/rst/knora-ontologies/knora-base.rst
@@ -1452,7 +1452,8 @@ is done using the following Knora-specific properties:
 ``subjectClassConstraint``
     Specifies the class that subjects of the property must belong to.
     This constraint is recommended but not required. Knora will attempt
-    to enforce this constraint.
+    to enforce this constraint. This constraint can be inherited or
+    overridden by subproperties.
 
 ``objectClassConstraint``
     If the property is an object property, specifies the class that
@@ -1461,7 +1462,8 @@ is done using the following Knora-specific properties:
     resource that points to a ``kb:Value`` or to another resource) is
     required have this constraint, because the Knora API server relies
     on it to know what type of object to expect for the property. Knora
-    will attempt to enforce this constraint.
+    will attempt to enforce this constraint. This constraint can be
+    inherited or overridden by subproperties.
 
 ``objectDatatypeConstraint``
     If the property is a datatype property, specifies the type of

--- a/webapi/_test_data/ontologies/anything-onto.ttl
+++ b/webapi/_test_data/ontologies/anything-onto.ttl
@@ -61,7 +61,6 @@
                knora-base:hasDefaultModifyPermission knora-base:ProjectMember .
 
 
-
 :hasOtherThingValue rdf:type owl:ObjectProperty ;
 
                rdfs:subPropertyOf knora-base:hasLinkToValue ;
@@ -419,6 +418,46 @@
 
 
 
+:hasBlueThing rdf:type owl:ObjectProperty ;
+
+               rdfs:subPropertyOf :hasOtherThing ;
+
+               rdfs:label "Ein blaues Ding"@de ,
+                          "Une chose bleue"@fr ,
+                          "Una cosa azzurra"@it ,
+                          "A blue thing"@en ;
+
+               knora-base:subjectClassConstraint :Thing ;
+
+               knora-base:objectClassConstraint :BlueThing ;
+
+               salsah-gui:guiOrder "16"^^xsd:integer .
+
+
+
+:hasBlueThingValue rdf:type owl:ObjectProperty ;
+
+               rdfs:subPropertyOf :hasOtherThingValue ;
+
+               salsah-gui:guiOrder "16"^^xsd:integer .
+
+
+
+:hasUnspecifiedThing rdf:type owl:ObjectProperty ;
+
+               rdfs:subPropertyOf :hasOtherThing ;
+
+               salsah-gui:guiOrder "17"^^xsd:integer .
+
+
+
+:hasUnspecifiedThingValue rdf:type owl:ObjectProperty ;
+
+               rdfs:subPropertyOf :hasOtherThingValue ;
+
+               salsah-gui:guiOrder "17"^^xsd:integer .
+
+
 :Thing rdf:type owl:Class ;
 
       rdfs:subClassOf knora-base:Resource ,
@@ -495,6 +534,26 @@
                          rdf:type owl:Restriction ;
                          owl:onProperty :hasColor ;
                          owl:minCardinality "0"^^xsd:nonNegativeInteger
+                      ] ,
+                      [
+                         rdf:type owl:Restriction ;
+                         owl:onProperty :hasBlueThing ;
+                         owl:minCardinality "0"^^xsd:nonNegativeInteger
+                      ] ,
+                      [
+                         rdf:type owl:Restriction ;
+                         owl:onProperty :hasBlueThingValue ;
+                         owl:minCardinality "0"^^xsd:nonNegativeInteger
+                      ] ,
+                      [
+                         rdf:type owl:Restriction ;
+                         owl:onProperty :hasUnspecifiedThing ;
+                         owl:minCardinality "0"^^xsd:nonNegativeInteger
+                      ] ,
+                      [
+                         rdf:type owl:Restriction ;
+                         owl:onProperty :hasUnspecifiedThingValue ;
+                         owl:minCardinality "0"^^xsd:nonNegativeInteger
                       ] ;
                       #[
                       #   rdf:type owl:Restriction ;
@@ -520,6 +579,15 @@
 
       knora-base:hasDefaultModifyPermission knora-base:ProjectMember .
 
+
+:BlueThing rdf:type owl:Class ;
+
+      rdfs:subClassOf :Thing ;
+
+      rdfs:label "Blaues Ding"@de ,
+                 "Chose bleue"@fr ,
+                 "Cosa azzurra"@it ,
+                 "Blue thing"@en .
 
 
 :hasPictureTitle rdf:type owl:ObjectProperty ;

--- a/webapi/_test_data/ontologies/anything-onto.ttl
+++ b/webapi/_test_data/ontologies/anything-onto.ttl
@@ -584,6 +584,8 @@
 
       rdfs:subClassOf :Thing ;
 
+      rdfs:comment """Diese Resource-Klasse beschreibt ein blaues Ding"""@de ;
+
       rdfs:label "Blaues Ding"@de ,
                  "Chose bleue"@fr ,
                  "Cosa azzurra"@it ,
@@ -635,3 +637,4 @@
     knora-base:hasDefaultViewPermission knora-base:UnknownUser ;
 
     knora-base:hasDefaultModifyPermission knora-base:ProjectMember .
+    

--- a/webapi/src/main/twirl/queries/sparql/v1/addValueVersion.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/addValueVersion.scala.txt
@@ -326,25 +326,6 @@ WHERE {
 
     @*
 
-    Do nothing if the submitted value has the wrong type. Inherit the property's objectClassConstraint from a base
-    property if necessary, letting the subproperty's objectClassConstraint override the base property's
-    objectClassConstraint.
-
-    *@
-
-    ?property rdfs:subPropertyOf* ?baseProperty .
-    ?baseProperty knora-base:objectClassConstraint ?propObjConstraint .
-
-    FILTER NOT EXISTS {
-        ?property rdfs:subPropertyOf* ?otherBaseProperty .
-        ?otherBaseProperty rdfs:subPropertyOf+ ?baseProperty .
-        ?otherBaseProperty knora-base:objectClassConstraint ?otherPropObjConstraint .
-    }
-
-    ?valueType rdfs:subClassOf* ?propObjConstraint .
-
-    @*
-
     Consider order if given (not given for file values).
 
     *@
@@ -381,16 +362,13 @@ WHERE {
             @*
 
             Do nothing if we were asked to insert a direct link to a target that doesn't exist, is marked as deleted,
-            isn't a knora-base:Resource, or belongs to the wrong OWL class for the link property.
+            or isn't a knora-base:Resource.
 
             *@
 
-            <@linkUpdate.linkTargetIri> rdf:type ?linkTargetClass@linkValueIndex .
-            <@linkUpdate.linkTargetIri> knora-base:isDeleted false .
-
+            <@linkUpdate.linkTargetIri> rdf:type ?linkTargetClass@linkValueIndex ;
+                knora-base:isDeleted false .
             ?linkTargetClass@linkValueIndex rdfs:subClassOf+ knora-base:Resource .
-            <@linkUpdate.linkPropertyIri> knora-base:objectClassConstraint ?expectedTargetClass@linkValueIndex .
-            ?linkTargetClass@linkValueIndex rdfs:subClassOf* ?expectedTargetClass@linkValueIndex .
         }
 
         @if(linkUpdate.directLinkExists) {

--- a/webapi/src/main/twirl/queries/sparql/v1/addValueVersion.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/addValueVersion.scala.txt
@@ -323,11 +323,29 @@ WHERE {
 
     ?resource ?property ?currentValue .
     ?currentValue rdf:type ?valueType .
-    ?property knora-base:objectClassConstraint ?valueType .
 
     @*
 
-        Consider order if given (not given for file values)
+    Do nothing if the submitted value has the wrong type. Inherit the property's objectClassConstraint from a base
+    property if necessary, letting the subproperty's objectClassConstraint override the base property's
+    objectClassConstraint.
+
+    *@
+
+    ?property rdfs:subPropertyOf* ?baseProperty .
+    ?baseProperty knora-base:objectClassConstraint ?propObjConstraint .
+
+    FILTER NOT EXISTS {
+        ?property rdfs:subPropertyOf* ?otherBaseProperty .
+        ?otherBaseProperty rdfs:subPropertyOf+ ?baseProperty .
+        ?otherBaseProperty knora-base:objectClassConstraint ?otherPropObjConstraint .
+    }
+
+    ?valueType rdfs:subClassOf* ?propObjConstraint .
+
+    @*
+
+    Consider order if given (not given for file values).
 
     *@
 

--- a/webapi/src/main/twirl/queries/sparql/v1/changeLink.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/changeLink.scala.txt
@@ -251,35 +251,19 @@ WHERE {
             knora-base:isDeleted false .
     }
 
-    @*
-
-    Do nothing if we were asked to insert a direct link to a target that doesn't exist, is marked as deleted,
-    isn't a knora-base:Resource, or belongs to the wrong OWL class for the link property.
-
-    *@
-
     @if(linkUpdateForNewLink.insertDirectLink) {
+
+        @*
+
+        Do nothing if we were asked to insert a direct link to a target that doesn't exist, is marked as deleted,
+        or isn't a knora-base:Resource.
+
+        *@
+
         ?linkTargetForNewLink rdf:type ?linkTargetClass ;
             knora-base:isDeleted false .
         ?linkTargetClass rdfs:subClassOf+ knora-base:Resource .
 
-        @*
-
-        Inherit the link property's objectClassConstraint from a base property if necessary, letting the subproperty's
-        objectClassConstraint override the base property's objectClassConstraint.
-
-        *@
-
-        ?linkProperty rdfs:subPropertyOf* ?baseLinkProperty .
-        ?baseLinkProperty knora-base:objectClassConstraint ?linkPropObjConstraint .
-
-        FILTER NOT EXISTS {
-            ?linkProperty rdfs:subPropertyOf* ?otherBaseLinkProperty .
-            ?otherBaseLinkProperty rdfs:subPropertyOf+ ?baseLinkProperty .
-            ?otherBaseLinkProperty knora-base:objectClassConstraint ?otherLinkPropObjConstraint .
-        }
-
-        ?linkTargetClass rdfs:subClassOf* ?linkPropObjConstraint .
     } else {
         @{throw SparqlGenerationException(s"linkUpdateForNewLink.insertDirectLink must be true in this SPARQL template"); ()}
     }

--- a/webapi/src/main/twirl/queries/sparql/v1/changeLink.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/changeLink.scala.txt
@@ -262,8 +262,24 @@ WHERE {
         ?linkTargetForNewLink rdf:type ?linkTargetClass ;
             knora-base:isDeleted false .
         ?linkTargetClass rdfs:subClassOf+ knora-base:Resource .
-        ?linkProperty knora-base:objectClassConstraint ?expectedTargetClass .
-        ?linkTargetClass rdfs:subClassOf* ?expectedTargetClass .
+
+        @*
+
+        Inherit the link property's objectClassConstraint from a base property if necessary, letting the subproperty's
+        objectClassConstraint override the base property's objectClassConstraint.
+
+        *@
+
+        ?linkProperty rdfs:subPropertyOf* ?baseLinkProperty .
+        ?baseLinkProperty knora-base:objectClassConstraint ?linkPropObjConstraint .
+
+        FILTER NOT EXISTS {
+            ?linkProperty rdfs:subPropertyOf* ?otherBaseLinkProperty .
+            ?otherBaseLinkProperty rdfs:subPropertyOf+ ?baseLinkProperty .
+            ?otherBaseLinkProperty knora-base:objectClassConstraint ?otherLinkPropObjConstraint .
+        }
+
+        ?linkTargetClass rdfs:subClassOf* ?linkPropObjConstraint .
     } else {
         @{throw SparqlGenerationException(s"linkUpdateForNewLink.insertDirectLink must be true in this SPARQL template"); ()}
     }

--- a/webapi/src/main/twirl/queries/sparql/v1/generateWhereStatementsForCreateLink.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/generateWhereStatementsForCreateLink.scala.txt
@@ -24,6 +24,8 @@
 
 @**
  * Generates statements to be added to the WHERE clause of a SPARQL update when creating a new link between resources.
+ * This template is used in two contexts: when creating a single value in an existing resource, and when creating a new
+ * resource with its initial values.
  *
  * @param valueIndex the index of the link value in the sequence of values that are being created in the transaction (can
  *                   be 0 if only one value is being created). This index will be used to make SPARQL variable names
@@ -46,33 +48,11 @@
     BIND(IRI("@linkUpdate.newLinkValueIri") AS ?newLinkValue@valueIndex)
     BIND(IRI("@linkUpdate.linkTargetIri") AS ?linkTarget@valueIndex)
 
-    @* Make sure the link target is a knora-base:Resource. *@
+    @* Do nothing if the target resource doesn't exist, is marked as deleted, or isn't a knora-base:Resource. *@
 
-    ?linkTarget@valueIndex rdf:type ?linkTargetClass@valueIndex .
+    ?linkTarget@valueIndex rdf:type ?linkTargetClass@valueIndex ;
+        knora-base:isDeleted false .
     ?linkTargetClass@valueIndex rdfs:subClassOf+ knora-base:Resource .
-
-    @*
-
-    Do nothing if the target resource belongs to the wrong OWL class. Inherit the link property's objectClassConstraint
-    from a base property if necessary, letting the subproperty's objectClassConstraint override the base property's
-    objectClassConstraint.
-
-    *@
-
-    ?linkProperty@valueIndex rdfs:subPropertyOf* ?baseLinkProperty@valueIndex .
-    ?baseLinkProperty@valueIndex knora-base:objectClassConstraint ?linkPropObjConstraint@valueIndex .
-
-    FILTER NOT EXISTS {
-        ?linkProperty@valueIndex rdfs:subPropertyOf* ?otherBaseLinkProperty@valueIndex .
-        ?otherBaseLinkProperty@valueIndex rdfs:subPropertyOf+ ?baseLinkProperty@valueIndex .
-        ?otherBaseLinkProperty@valueIndex knora-base:objectClassConstraint ?otherLinkPropObjConstraint@valueIndex .
-    }
-
-    ?linkTargetClass@valueIndex rdfs:subClassOf* ?linkPropObjConstraint@valueIndex .
-
-    @* Do nothing if the target resource doesn't exist or is marked as deleted. *@
-
-    ?linkTarget@valueIndex knora-base:isDeleted false .
 
     @* Do nothing if the source resource's OWL class has no cardinality for the link property. *@
 

--- a/webapi/src/main/twirl/queries/sparql/v1/generateWhereStatementsForCreateLink.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/generateWhereStatementsForCreateLink.scala.txt
@@ -51,10 +51,24 @@
     ?linkTarget@valueIndex rdf:type ?linkTargetClass@valueIndex .
     ?linkTargetClass@valueIndex rdfs:subClassOf+ knora-base:Resource .
 
-    @* Do nothing if the target resource belongs to the wrong OWL class. *@
+    @*
 
-    ?linkProperty@valueIndex knora-base:objectClassConstraint ?expectedTargetClass@valueIndex .
-    ?linkTargetClass@valueIndex rdfs:subClassOf* ?expectedTargetClass@valueIndex .
+    Do nothing if the target resource belongs to the wrong OWL class. Inherit the link property's objectClassConstraint
+    from a base property if necessary, letting the subproperty's objectClassConstraint override the base property's
+    objectClassConstraint.
+
+    *@
+
+    ?linkProperty@valueIndex rdfs:subPropertyOf* ?baseLinkProperty@valueIndex .
+    ?baseLinkProperty@valueIndex knora-base:objectClassConstraint ?linkPropObjConstraint@valueIndex .
+
+    FILTER NOT EXISTS {
+        ?linkProperty@valueIndex rdfs:subPropertyOf* ?otherBaseLinkProperty@valueIndex .
+        ?otherBaseLinkProperty@valueIndex rdfs:subPropertyOf+ ?baseLinkProperty@valueIndex .
+        ?otherBaseLinkProperty@valueIndex knora-base:objectClassConstraint ?otherLinkPropObjConstraint@valueIndex .
+    }
+
+    ?linkTargetClass@valueIndex rdfs:subClassOf* ?linkPropObjConstraint@valueIndex .
 
     @* Do nothing if the target resource doesn't exist or is marked as deleted. *@
 

--- a/webapi/src/main/twirl/queries/sparql/v1/generateWhereStatementsForCreateValue.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/generateWhereStatementsForCreateValue.scala.txt
@@ -57,10 +57,24 @@
     BIND(IRI("@newValueIri") AS ?newValue@valueIndex)
     BIND(IRI("@valueTypeIri") AS ?valueType@valueIndex)
 
-    @* Do nothing if the submitted value has the wrong type. *@
+    @*
 
-    ?property@valueIndex knora-base:objectClassConstraint ?propertyRange@valueIndex .
-    ?valueType@valueIndex rdfs:subClassOf* ?propertyRange@valueIndex .
+    Do nothing if the submitted value has the wrong type. Inherit the property's objectClassConstraint from a base
+    property if necessary, letting the subproperty's objectClassConstraint override the base property's
+    objectClassConstraint.
+
+    *@
+
+    ?property@valueIndex rdfs:subPropertyOf* ?baseProperty@valueIndex .
+    ?baseProperty@valueIndex knora-base:objectClassConstraint ?propObjConstraint@valueIndex .
+
+    FILTER NOT EXISTS {
+        ?property@valueIndex rdfs:subPropertyOf* ?otherBaseProperty@valueIndex .
+        ?otherBaseProperty@valueIndex rdfs:subPropertyOf+ ?baseProperty@valueIndex .
+        ?otherBaseProperty@valueIndex knora-base:objectClassConstraint ?otherPropObjConstraint@valueIndex .
+    }
+
+    ?valueType@valueIndex rdfs:subClassOf* ?propObjConstraint@valueIndex .
 
     @* Do nothing if neither the resource class nor any of its superclasses has a cardinality for this property. *@
 

--- a/webapi/src/main/twirl/queries/sparql/v1/generateWhereStatementsForCreateValue.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/generateWhereStatementsForCreateValue.scala.txt
@@ -57,25 +57,6 @@
     BIND(IRI("@newValueIri") AS ?newValue@valueIndex)
     BIND(IRI("@valueTypeIri") AS ?valueType@valueIndex)
 
-    @*
-
-    Do nothing if the submitted value has the wrong type. Inherit the property's objectClassConstraint from a base
-    property if necessary, letting the subproperty's objectClassConstraint override the base property's
-    objectClassConstraint.
-
-    *@
-
-    ?property@valueIndex rdfs:subPropertyOf* ?baseProperty@valueIndex .
-    ?baseProperty@valueIndex knora-base:objectClassConstraint ?propObjConstraint@valueIndex .
-
-    FILTER NOT EXISTS {
-        ?property@valueIndex rdfs:subPropertyOf* ?otherBaseProperty@valueIndex .
-        ?otherBaseProperty@valueIndex rdfs:subPropertyOf+ ?baseProperty@valueIndex .
-        ?otherBaseProperty@valueIndex knora-base:objectClassConstraint ?otherPropObjConstraint@valueIndex .
-    }
-
-    ?valueType@valueIndex rdfs:subClassOf* ?propObjConstraint@valueIndex .
-
     @* Do nothing if neither the resource class nor any of its superclasses has a cardinality for this property. *@
 
     ?resourceClass rdfs:subClassOf* ?restriction@valueIndex .
@@ -99,16 +80,13 @@
             @*
 
             Do nothing if we were asked to insert a direct link to a target that doesn't exist, is marked as deleted,
-            isn't a knora-base:Resource, or belongs to the wrong OWL class for the link property.
+            or isn't a knora-base:Resource.
 
             *@
 
             <@linkUpdate.linkTargetIri> rdf:type ?linkTargetClass@linkValueIndex ;
                 knora-base:isDeleted false .
-
             ?linkTargetClass@linkValueIndex rdfs:subClassOf+ knora-base:Resource .
-            <@linkUpdate.linkPropertyIri> knora-base:objectClassConstraint ?expectedTargetClass@linkValueIndex .
-            ?linkTargetClass@linkValueIndex rdfs:subClassOf* ?expectedTargetClass@linkValueIndex .
         }
 
         @if(linkUpdate.directLinkExists) {

--- a/webapi/src/main/twirl/queries/sparql/v1/getResourceSearchResult.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getResourceSearchResult.scala.txt
@@ -105,9 +105,10 @@ WHERE {
 
     @if(numberOfProps > 1) {
         ?resourceIri ?property ?valueObjectIri .
-        ?property knora-base:objectClassConstraint knora-base:TextValue .
-        ?valueObjectIri knora-base:valueHasString ?valueString ;
+
+        ?valueObjectIri a knora-base:TextValue ;
             knora-base:isDeleted false ;
+            knora-base:valueHasString ?valueString ;
             knora-base:valueHasOrder ?valueOrder .
 
         OPTIONAL {


### PR DESCRIPTION
This removes the checks on `objectClassConstraint` from the WHERE clauses of SPARQL updates, because of #302. I tried to implement these checks in a way that would allow `objectClassConstraint` to be inherited or overridden by subproperties, but it was too slow with Fuseki. The necessary checks are also done by the Knora API server and by the consistency checker in GraphDB, so I think it's OK to remove the additional check from the WHERE clauses of the SPARQL updates.

Closes #302.