### PR TITLE
fix (webapi): CORS problems

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/KnoraService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/KnoraService.scala
@@ -27,7 +27,6 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.pattern._
 import akka.stream.ActorMaterializer
-import ch.megard.akka.http.cors.CorsDirectives._
 import org.knora.webapi.http.CORSSupport.CORS
 import org.knora.webapi.messages.v1.responder.ontologymessages.{LoadOntologiesRequest, LoadOntologiesResponse}
 import org.knora.webapi.messages.v1.responder.usermessages.{UserDataV1, UserProfileV1}
@@ -91,11 +90,6 @@ trait KnoraService {
       * A user representing the Knora API server, used for initialisation on startup.
       */
     private val systemUser = UserProfileV1(userData = UserDataV1(lang = "en"), isSystemUser = true)
-
-    /**
-      * Brings the CORS rejection handler into scope
-      */
-    implicit def corsRejection = corsRejectionHandler
 
     /**
       * Bring the Knora exception handler into scope, which is responsible for converting our exceptions to HttpResponses

--- a/webapi/src/main/scala/org/knora/webapi/KnoraService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/KnoraService.scala
@@ -92,11 +92,6 @@ trait KnoraService {
     private val systemUser = UserProfileV1(userData = UserDataV1(lang = "en"), isSystemUser = true)
 
     /**
-      * Bring the Knora exception handler into scope, which is responsible for converting our exceptions to HttpResponses
-      */
-    implicit def knoraExceptionHandler = KnoraExceptionHandler(settings, log)
-
-    /**
       * All routes composed together and CORS activated.
       */
     private val apiRoutes = CORS (
@@ -111,7 +106,9 @@ trait KnoraService {
                 GraphDataRouteV1.knoraApiPath(system, settings, log) ~
                 ProjectsRouteV1.knoraApiPath(system, settings, log) ~
                 CkanRouteV1.knoraApiPath(system, settings, log) ~
-                StoreRouteV1.knoraApiPath(system, settings, log)
+                StoreRouteV1.knoraApiPath(system, settings, log),
+        settings,
+        log
     )
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/http/CORSSupport.scala
+++ b/webapi/src/main/scala/org/knora/webapi/http/CORSSupport.scala
@@ -22,11 +22,11 @@ package org.knora.webapi.http
 
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.headers.HttpOriginRange
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{Directives, RejectionHandler, Route}
 import ch.megard.akka.http.cors.CorsDirectives._
-import ch.megard.akka.http.cors.{CorsSettings, HttpHeaderRange}
+import ch.megard.akka.http.cors.{CorsDirectives, CorsSettings, HttpHeaderRange}
 
-object CORSSupport {
+object CORSSupport extends Directives {
 
     val corsSettings = CorsSettings.defaultSettings.copy(
         allowGenericHttpRequests = true,
@@ -42,7 +42,11 @@ object CORSSupport {
       * @param route the route for which CORS support is enabled
       * @return the enabled route.
       */
-    def CORS(route: Route): Route = cors(corsSettings) {
-        route
+    def CORS(route: Route): Route = handleRejections(CorsDirectives.corsRejectionHandler) {
+        cors(corsSettings) {
+            handleRejections(RejectionHandler.default) {
+                route
+            }
+        }
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/http/CORSSupport.scala
+++ b/webapi/src/main/scala/org/knora/webapi/http/CORSSupport.scala
@@ -33,7 +33,7 @@ object CORSSupport {
         allowCredentials = true,
         allowedOrigins = HttpOriginRange.*,
         allowedHeaders = HttpHeaderRange.*,
-        allowedMethods = List(GET, PUT, POST, HEAD, OPTIONS),
+        allowedMethods = List(GET, PUT, POST, DELETE, HEAD, OPTIONS),
         maxAge = Some(30 * 60)
     )
 

--- a/webapi/src/main/scala/org/knora/webapi/http/CORSSupport.scala
+++ b/webapi/src/main/scala/org/knora/webapi/http/CORSSupport.scala
@@ -20,11 +20,13 @@
 
 package org.knora.webapi.http
 
+import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.headers.HttpOriginRange
 import akka.http.scaladsl.server.{Directives, RejectionHandler, Route}
 import ch.megard.akka.http.cors.CorsDirectives._
 import ch.megard.akka.http.cors.{CorsDirectives, CorsSettings, HttpHeaderRange}
+import org.knora.webapi.{KnoraExceptionHandler, SettingsImpl}
 
 object CORSSupport extends Directives {
 
@@ -38,14 +40,20 @@ object CORSSupport extends Directives {
     )
 
     /**
-      * Adds CORS support to a route. This is a convenience method.
+      * Adds CORS support to a route. Also, any exceptions thrown inside the route are handled by
+      * the [[KnoraExceptionHandler]]. Finally, all rejections are handled by the [[CorsDirectives.corsRejectionHandler]]
+      * so that all responses (correct and failures) have the correct CORS headers attached.
       * @param route the route for which CORS support is enabled
       * @return the enabled route.
       */
-    def CORS(route: Route): Route = handleRejections(CorsDirectives.corsRejectionHandler) {
-        cors(corsSettings) {
-            handleRejections(RejectionHandler.default) {
-                route
+    def CORS(route: Route, settings: SettingsImpl, log: LoggingAdapter): Route = {
+        handleRejections(CorsDirectives.corsRejectionHandler) {
+            cors(corsSettings) {
+                handleRejections(RejectionHandler.default) {
+                    handleExceptions(KnoraExceptionHandler(settings, log)) {
+                        route
+                    }
+                }
             }
         }
     }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
@@ -200,10 +200,10 @@ class ValuesResponderV1 extends ResponderV1 {
         } yield apiResponse
 
         for {
-        // Don't allow anonymous users to update values.
+        // Don't allow anonymous users to create values.
             userIri <- createValueRequest.userProfile.userData.user_id match {
                 case Some(iri) => Future(iri)
-                case None => Future.failed(ForbiddenException("Anonymous users aren't allowed to update values"))
+                case None => Future.failed(ForbiddenException("Anonymous users aren't allowed to create values"))
             }
 
             // Do the remaining pre-update checks and the update while holding an update lock on the resource.

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/CORSSupportV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/CORSSupportV1E2ESpec.scala
@@ -18,13 +18,15 @@ package org.knora.webapi.e2e.v1
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpMethods._
-import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.{`Access-Control-Allow-Methods`, _}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import com.typesafe.config.ConfigFactory
 import org.knora.webapi.E2ESpec
 import org.knora.webapi.http.CORSSupport
+import org.knora.webapi.messages.v1.store.triplestoremessages.{RdfDataObject, TriplestoreJsonProtocol}
+import spray.json._
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -40,13 +42,29 @@ object CORSSupportV1E2ESpec {
 /**
   * End-to-end test specification for testing [[CORSSupport]].
   */
-class CORSSupportV1E2ESpec extends E2ESpec(CORSSupportV1E2ESpec.config) {
+class CORSSupportV1E2ESpec extends E2ESpec(CORSSupportV1E2ESpec.config) with TriplestoreJsonProtocol {
 
     /* set the timeout for the route test */
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(new DurationInt(180).second)
 
     val exampleOrigin = HttpOrigin("http://example.com")
     val corsSettings = CORSSupport.corsSettings
+
+    private val rdfDataObjects = List(
+        RdfDataObject(path = "../knora-ontologies/knora-base.ttl", name = "http://www.knora.org/ontology/knora-base"),
+        RdfDataObject(path = "../knora-ontologies/knora-dc.ttl", name = "http://www.knora.org/ontology/dc"),
+        RdfDataObject(path = "../knora-ontologies/salsah-gui.ttl", name = "http://www.knora.org/ontology/salsah-gui"),
+        RdfDataObject(path = "_test_data/ontologies/incunabula-onto.ttl", name = "http://www.knora.org/ontology/incunabula"),
+        RdfDataObject(path = "_test_data/all_data/incunabula-data.ttl", name = "http://www.knora.org/data/incunabula"),
+        RdfDataObject(path = "_test_data/ontologies/images-demo-onto.ttl", name = "http://www.knora.org/ontology/images"),
+        RdfDataObject(path = "_test_data/demo_data/images-demo-data.ttl", name = "http://www.knora.org/data/images")
+    )
+
+    "Load test data" in {
+        // send POST to 'v1/store/ResetTriplestoreContent'
+        val request = Post(baseApiUrl + "/v1/store/ResetTriplestoreContent", HttpEntity(ContentTypes.`application/json`, rdfDataObjects.toJson.compactPrint))
+        singleAwaitingRequest(request, 300.seconds)
+    }
 
     "A Route with enabled CORS support " should {
 
@@ -77,6 +95,36 @@ class CORSSupportV1E2ESpec extends E2ESpec(CORSSupportV1E2ESpec.config) {
 
             response.status should equal(StatusCodes.BadRequest)
             entity should equal("CORS: invalid method 'PATCH'")
+        }
+
+        "send `Access-Control-Allow-Origin` header when the Knora resource is found " in {
+            val request = Get(baseApiUrl + "/v1/resources/" + java.net.URLEncoder.encode("http://data.knora.org/0cb8286054d5", "utf-8")) ~> Origin(exampleOrigin)
+            val response = singleAwaitingRequest(request)
+
+            response.status should equal(StatusCodes.OK)
+            response.headers should contain allElementsOf Seq(
+                `Access-Control-Allow-Origin`(exampleOrigin)
+            )
+        }
+
+        "send `Access-Control-Allow-Origin` header when the Knora resource is NOT found " in {
+            val request = Get(baseApiUrl + "/v1/resources/" + java.net.URLEncoder.encode("http://data.knora.org/nonexistent", "utf-8")) ~> Origin(exampleOrigin)
+            val response = singleAwaitingRequest(request)
+
+            response.status should equal(StatusCodes.NotFound)
+            response.headers should contain allElementsOf Seq(
+                `Access-Control-Allow-Origin`(exampleOrigin)
+            )
+        }
+
+        "send `Access-Control-Allow-Origin` header when the api endpoint route is NOT found " in {
+            val request = Get(baseApiUrl + "/NotFound") ~> Origin(exampleOrigin)
+            val response = singleAwaitingRequest(request)
+
+            response.status should equal(StatusCodes.NotFound)
+            response.headers should contain allElementsOf Seq(
+                `Access-Control-Allow-Origin`(exampleOrigin)
+            )
         }
 
     }


### PR DESCRIPTION
- Resolves #306: DELETE method was missing in CORS configuration
- Resolves #304: `Access-Control-Allow-Origin` is missing in response header and thus the browser blocks the answer (in responses with status code other than 200).