### PR TITLE
Make TransformData fix “test” labels on regions

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -73,6 +73,7 @@ object OntologyConstants {
         val MovingImageRepresentation = "http://www.knora.org/ontology/knora-base#MovingImageRepresentation"
         val StillImageRepresentation = "http://www.knora.org/ontology/knora-base#StillImageRepresentation"
         val TextRepresentation = "http://www.knora.org/ontology/knora-base#TextRepresentation"
+        val Region = "http://www.knora.org/ontology/knora-base#Region"
 
         val AbstractResourceClasses = Set(
             Resource,
@@ -124,6 +125,7 @@ object OntologyConstants {
         val HasDDDFileValue = "http://www.knora.org/ontology/knora-base#hasDDDFileValue"
         val HasTextFileValue = "http://www.knora.org/ontology/knora-base#hasTextFileValue"
         val HasDocumentFileValue = "http://www.knora.org/ontology/knora-base#hasDocumentFileValue"
+        val HasComment = "http://www.knora.org/ontology/knora-base#hasComment"
 
         val IsPreview = "http://www.knora.org/ontology/knora-base#isPreview"
         val ResourceIcon = "http://www.knora.org/ontology/knora-base#resourceIcon"


### PR DESCRIPTION
Before SALSAH correctly supported labels, labels were hard-coded as `test`, and this affected regions created by the BEOL project. This pull request adds a `regionlabels` transformation to `TransformData`, which looks for regions whose `rdfs:label` is `test`, and replaces each one's label with the `valueHasString` of its `hasComment`.