### PR TITLE
fix (salsah): Create multiple links in a resource, and other bug fixes

### DIFF
--- a/salsah/src/public/js/jquery.editvalue.js
+++ b/salsah/src/public/js/jquery.editvalue.js
@@ -66,6 +66,7 @@
 	var drop_btn = $('<span>').addClass('glyphicon glyphicon-minus').attr({title: strings._remove});
 	var rights_btn = $('<span>').addClass('glyphicon glyphicon-lock').attr({title: strings._rights});
 	var comment_btn = $('<span>').addClass('glyphicon glyphicon-comment').attr({title: strings._annotate});
+	var valinfo_btn = $('<span>').addClass('glyphicon glyphicon-info-sign').attr({title: strings._valinfo});
 
 	var set_button = function(btn_ele, type) {
 		switch (type) {

--- a/salsah/src/public/js/jquery.propedit.js
+++ b/salsah/src/public/js/jquery.propedit.js
@@ -219,16 +219,12 @@
 					}
 				}
 			}
-			$('<img>', {src: valueinfo_icon.src, 'class': 'propedit'}).click(function(event) {
-				SALSAH.ApiGet('values/' + encodeURIComponent(propinfo[prop].value_ids[value_index]), function(data) {
-					if (data.status == ApiErrors.OK) {
-						alert("Name: " + data.valuecreatorname + "\nDate: " + data.valuecreationdate);
-					}
-					else {
-						alert(data.errormsg);
-					}
-				});
-			}).css({cursor: 'pointer'}).appendTo(value_container);
+
+			if (prop != '__label__') {
+				$('<img>', {src: valueinfo_icon.src, 'class': 'propedit'}).on('mouseover', function(event) {
+					load_value_infowin(event, propinfo[prop].value_ids[value_index], this);
+				}).css({cursor: 'pointer'}).appendTo(value_container);
+			}
 		};
 
 		var make_add_button = function (prop_container, prop) {

--- a/salsah/src/public/js/jquery.propedit.js
+++ b/salsah/src/public/js/jquery.propedit.js
@@ -57,6 +57,10 @@
     var comment_icon = new Image();
     comment_icon.src = SITE_URL + '/app/icons/16x16/comment.png';
 
+    var valueinfo_icon = new Image();
+    valueinfo_icon.src = SITE_URL + '/app/icons/16x16/info.png';
+
+
 	$.fn.propedit = function(resdata, propinfo, project_id, optpar) {
 		var $that = this;
 
@@ -215,6 +219,16 @@
 					}
 				}
 			}
+			$('<img>', {src: valueinfo_icon.src, 'class': 'propedit'}).click(function(event) {
+				SALSAH.ApiGet('values/' + encodeURIComponent(propinfo[prop].value_ids[value_index]), function(data) {
+					if (data.status == ApiErrors.OK) {
+						alert("Name: " + data.valuecreatorname + "\nDate: " + data.valuecreationdate);
+					}
+					else {
+						alert(data.errormsg);
+					}
+				});
+			}).css({cursor: 'pointer'}).appendTo(value_container);
 		};
 
 		var make_add_button = function (prop_container, prop) {
@@ -1759,7 +1773,7 @@
 						tmpele.spinbox('edit');
 					}
 					else {
-						tmpele.spinbox('edit', propinfo[prop].values[value_index]);
+						tmpele.spinbox('edit', {value: propinfo[prop].values[value_index]});
 					}
 					value_container.append($('<img>', {src: save_icon.src, title: strings._save, 'class': 'propedit'}).click(function(event) {
 						postdata[propinfo[prop].valuetype_id](value_container, prop, value_index, tmpele.spinbox('value'), is_new_value);

--- a/salsah/src/public/js/jquery.resadd.js
+++ b/salsah/src/public/js/jquery.resadd.js
@@ -169,11 +169,11 @@
 						}
 					};
 
-					var create_entry = function(propname, create_tag) {
+					var create_entry = function(propname, pinfo, create_tag) {
 						var add_symbol;
 
 						prop_status[propname].td.append($('<span>').addClass('entrySep').html('&nbsp'));
-						create_tag(prop_status[propname].td, attributes);
+						create_tag(prop_status[propname].td, attributes, pinfo);
 						prop_status[propname].count = 1;
 
 						if (prop_status[propname].occurrence != '1') {
@@ -183,7 +183,8 @@
 								'name': propname
 							}, function(event) {
 								//  $(this).before(create_tag(prop_status[event.data.name].td, prop_status[event.data.name].attributes));
-								create_tag(prop_status[event.data.name].td, prop_status[event.data.name].attributes);
+
+								create_tag(prop_status[event.data.name].td, prop_status[event.data.name].attributes, pinfo);
 								prop_status[event.data.name].count++;
 								if (((prop_status[event.data.name].count == 1) &&
 										((prop_status[event.data.name].occurrence == '0-n') || (prop_status[event.data.name].occurrence == '0-1'))) ||
@@ -371,7 +372,7 @@
 								case 'text':
 									{
 										attributes.type = 'text';
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var tmpele = $('<input>', attr).css({
 												width: '85%'
 											}).dragndrop('makeDropable', function(event, dropdata) {
@@ -388,7 +389,7 @@
 									}
 								case 'textarea':
 									{
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var tmpele = $('<textarea>', attr).css({
 												width: '85%'
 											}).dragndrop('makeDropable', function(event, dropdata) {
@@ -402,7 +403,7 @@
 									}
 								case 'richtext':
 									{
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 
 											//console.log('resadd');
 											//console.log(attr);
@@ -451,7 +452,7 @@
 												selection_id = attr[1].replace("<", "").replace(">", ""); // remove brackets from Iri to make it a valid URL
 											}
 										});
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var selbox = $('<span>', attr).insertBefore(ele.find('.entrySep'));
 											selbox.selection('edit', {
 												selection_id: selection_id
@@ -471,7 +472,7 @@
 												selection_id = attr[1].replace("<", "").replace(">", ""); // remove brackets from Iri to make it a valid URL
 											}
 										});
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var radiobox = $('<span>', attr).insertBefore(ele.find('.entrySep'));
 											radiobox.selradio('edit', {
 												selection_id: selection_id
@@ -482,7 +483,7 @@
 									}
 								case 'checkbox':
 									{
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var checkbox = $('<input>', {
 											    type: "checkbox"
 											});
@@ -496,7 +497,7 @@
 									}
 								case 'spinbox':
 									{
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pfino) {
 											var spinbox = $('<span>', attr).insertBefore(ele.find('.entrySep'));
 											spinbox.spinbox('edit');
 										});
@@ -506,7 +507,7 @@
 								case 'searchbox':
 									{
 										attributes.type = 'text';
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var tmpele = $('<input>', attr).addClass('__searchbox').insertBefore(ele.find('.entrySep'));
 
 											var restype_id = -1;
@@ -561,7 +562,7 @@
 									}
 								case 'date':
 									{
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var datebox = $('<span>', attr).insertBefore(ele.find('.entrySep'));
 											datebox.dateobj('edit');
 											return datebox;
@@ -571,7 +572,7 @@
 									}
 								case 'time':
 									{
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var timebox = $('<span>', attr).insertBefore(ele.find('.entrySep'));
 											timebox.timeobj('edit');
 											if ((localdata.settings.defaultvalues !== undefined) && (localdata.settings.defaultvalues[propname])) {
@@ -584,7 +585,7 @@
 									}
 								case 'interval':
 									{
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var timebox = $('<span>', attr).insertBefore(ele.find('.entrySep'));
 											timebox.timeobj('edit', {
 												show_duration: true
@@ -609,7 +610,7 @@
 									}
 								case 'fileupload':
 									{
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var tmpele = $('<span>', attributes).insertBefore(ele.find('.entrySep'));
 											tmpele.location('edit');
 											return tmpele;
@@ -619,7 +620,7 @@
 									}
 								case 'colorpicker':
 									{
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var colbox = $('<span>', attr).insertBefore(ele.find('.entrySep'));
 											if (rtinfo.name == 'http://www.knora.org/ontology/knora-base#Region') {
 												colbox.colorpicker('edit', {
@@ -654,7 +655,7 @@
 												hlist_id = attr[1].replace("<", "").replace(">", ""); // remove brackets from Iri to make it a valid URL
 											}
 										});
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var hlistbox = $('<span>', attr).insertBefore(ele.find('.entrySep'));
 											hlistbox.hlist('edit', {
 												hlist_id: hlist_id
@@ -667,7 +668,7 @@
 
 								case 'geoname':
 									{
-										create_entry(propname, function(ele, attr) {
+										create_entry(propname, pinfo, function(ele, attr, pinfo) {
 											var geonamebox = $('<span>', attr).insertBefore(ele.find('.entrySep'));
 											geonamebox.geonames('edit', {
 												new_entry_allowed: true

--- a/salsah/src/public/js/load_infowin.js
+++ b/salsah/src/public/js/load_infowin.js
@@ -107,12 +107,49 @@ var load_infowin = function(event, res_id, obj) {
 		});
 	};
 
-	/*
-	$.__post(SITE_URL + '/ajax/get_properties.php', {res_id: res_id, type: 'html', noresedit: true, origin: origin}, function(data) {
-		if (typeof data == 'object') {
-			alert(data.MSG);
-		}
+}
+
+
+var load_value_infowin = function(event, val_id, obj) {
+	if (the_infowin_pending) return;
+
+//	window.status = 'load_infowin (' + event.pageX + ', ' + event.pageY + ') ' + the_infowin_pending;
+
+	var position_it = function(event) {
+		var xpos = event.pageX;
+		var ypos = event.pageY;
+		var win_w = $('body').width();
+		var win_h = $('body').height();
+		var w, h;
 		if (the_infowin === undefined) {
+			w = 200;
+			h = 50;
+		}
+		else {
+			w = the_infowin.outerWidth(true);
+			h = the_infowin.outerHeight(true);
+		}
+		if ((xpos + 20 + w) > win_w) {
+			xpos = xpos - w - 20;
+		}
+		else {
+			xpos += 20;
+		}
+		if ((ypos + 10 + h) > win_h) ypos = win_h - 10 - h;
+		ypos += 10;
+		return {x: xpos, y: ypos};
+	}
+
+
+	if (the_infowin === undefined) {
+		the_infowin_pending = true;
+
+
+		SALSAH.ApiGet('values/' + encodeURIComponent(val_id), function(data) {
+			if (data.status == ApiErrors.OK) {
+			window.status = 'GET...';
+
+			var pos = position_it(event);
 			the_infowin = $('<div>').addClass('searchinfowin').css({
 				position: 'absolute',
 				minHeight: '50px',
@@ -120,38 +157,49 @@ var load_infowin = function(event, res_id, obj) {
 				minWidth: '200px',
 				maxWidth: '400px',
 				overflow: 'hidden',
+				left: pos.x,
+				top: pos.y,
 				zIndex: 200
-			}).on('mousemove', function(event) {
-				event.stopImmediatePropagation();
-				position_it(event);
+			}).html('<p>' + strings._owner + ': ' + data.valuecreatorname + '<br/>' + strings._creation_date + ': ' + data.valuecreationdate + '</p>').on('mousemove', function(event) {
+				var pos = position_it(event);
+				the_infowin.css({
+					left: pos.x,
+					top: pos.y
+				});
 			}).appendTo($('body'));
-		}
-		the_infowin.html(data);
-		position_it(event);
 
-		$(obj).on('mousemove', function(event) {
-			event.stopImmediatePropagation();
-			position_it(event);
-		});
+			pos = position_it(event);
+			the_infowin.css({
+				left: pos.x,
+				top: pos.y
+			});
 
-		$(obj).on('mouseout', function(event) {
-			the_infowin.remove();
-			the_infowin = undefined;
-			$(this).off('mousemove');
-			$(this).off('mouseout');
-			$(document).off('mousemove');
-		});
+			$(obj).on('mousemove', function(event) {
+				event.stopImmediatePropagation();
+				event.preventDefault();
+				var pos = position_it(event);
+				the_infowin.css({
+					left: pos.x,
+					top: pos.y
+				});
+			});
 
-		$(document).on('mousemove', function(event){
-			if (the_infowin !== undefined) {
-				the_infowin.remove();
-				the_infowin = undefined;
-				$(document).off('mousemove');
-				$(this).off('mousemove');
-				$(this).off('mouseout');
+			$(document).on('mousemove', function(event){
+				if (the_infowin !== undefined) {
+					the_infowin.remove();
+					the_infowin = undefined;
+					$(document).off('mousemove');
+					$(obj).off('mousemove');
+					the_infowin_pending = false;
+				}
+			});
+
+			the_infowin_pending = false;
+
+			}
+			else {
+				alert(data.errormsg);
 			}
 		});
-
-	});
-	*/
+	}
 }

--- a/salsah/src/public/lang/de.json
+++ b/salsah/src/public/lang/de.json
@@ -232,6 +232,6 @@
 	"_select_all" : "Alle auswählen",
 	"_deselect_all" : "Alle abwählen",
 	"_alert_missing_restype" : "Bitte einen Resource-Typen wählen",
-	"_alert_missing_resprop" : "Bitte mindestens ein Merkmalfeld (zur Spaltenansicht) wählen."
-
+	"_alert_missing_resprop" : "Bitte mindestens ein Merkmalfeld (zur Spaltenansicht) wählen.",
+	"_valinfo" : "Informationen über den Wert"
 }

--- a/salsah/src/public/lang/de.json
+++ b/salsah/src/public/lang/de.json
@@ -233,5 +233,6 @@
 	"_deselect_all" : "Alle abwählen",
 	"_alert_missing_restype" : "Bitte einen Resource-Typen wählen",
 	"_alert_missing_resprop" : "Bitte mindestens ein Merkmalfeld (zur Spaltenansicht) wählen.",
-	"_valinfo" : "Informationen über den Wert"
+	"_valinfo" : "Informationen über den Wert",
+	"_creation_date": "Erstellungsdatum"
 }

--- a/salsah/src/public/lang/en.json
+++ b/salsah/src/public/lang/en.json
@@ -235,5 +235,6 @@
 	"_alert_missing_resprop" : "You have to choose at least one property!",
 	"_export" : "Export",
 	"_export_csv" : "Export the data as comma-separated values (csv)",
-	"_valinfo" : "Information about the value"
+	"_valinfo" : "Information about the value",
+	"_creation_date": "Creation date"
 }

--- a/salsah/src/public/lang/en.json
+++ b/salsah/src/public/lang/en.json
@@ -234,5 +234,6 @@
 	"_alert_missing_restype" : "You have to choose a resource type!",
 	"_alert_missing_resprop" : "You have to choose at least one property!",
 	"_export" : "Export",
-	"_export_csv" : "Export the data as comma-separated values (csv)"
+	"_export_csv" : "Export the data as comma-separated values (csv)",
+	"_valinfo" : "Information about the value"
 }

--- a/salsah/src/public/lang/fr.json
+++ b/salsah/src/public/lang/fr.json
@@ -226,5 +226,6 @@
 	"_salsah_help" : "SALSAH Aide",
 	"_limitsearch" : "Limiter la recherche sur",
 	"_langchangeq" : "Changer la langue de l'interface utilisateur ?",
-	"_valinfo" : "Information sur la valeur"
+	"_valinfo" : "Information sur la valeur",
+	"_creation_date": "Date de création"
 }

--- a/salsah/src/public/lang/fr.json
+++ b/salsah/src/public/lang/fr.json
@@ -225,5 +225,6 @@
 	"_hlist_node_expl" : "Clickez sur %s en-dessous pour effacer le nœud, ou sur %s pour fermer la fenêtre sans effaces le nœud!",
 	"_salsah_help" : "SALSAH Aide",
 	"_limitsearch" : "Limiter la recherche sur",
-	"_langchangeq" : "Changer la langue de l'interface utilisateur ?"
+	"_langchangeq" : "Changer la langue de l'interface utilisateur ?",
+	"_valinfo" : "Information sur la valeur"
 }

--- a/salsah/src/public/lang/it.json
+++ b/salsah/src/public/lang/it.json
@@ -173,5 +173,6 @@
 	"_salsah_help" : "SALSAH Aiuto",
 	"_limitsearch" : "Restringere la ricerca a",
 	"_langchangeq" : "Cambiare la lingua dell'interfaccia utente ?",
-    "_valinfo" : "Informazione sul valore"
+    "_valinfo" : "Informazione sul valore",
+	"_creation_date": "Data di creazione"
 }

--- a/salsah/src/public/lang/it.json
+++ b/salsah/src/public/lang/it.json
@@ -172,7 +172,6 @@
 	"_hlist_delete" : "Estinguere la gerarchia",
 	"_salsah_help" : "SALSAH Aiuto",
 	"_limitsearch" : "Restringere la ricerca a",
-	"_langchangeq" : "Cambiare la lingua dell'interfaccia utente ?"
-	
-	
+	"_langchangeq" : "Cambiare la lingua dell'interfaccia utente ?",
+    "_valinfo" : "Informazione sul valore"
 }

--- a/salsah/src/test/scala/org.knora.salsah/browser/ResourceCreationSpec.scala
+++ b/salsah/src/test/scala/org.knora.salsah/browser/ResourceCreationSpec.scala
@@ -71,7 +71,9 @@ class ResourceCreationSpec extends SalsahSpec {
                 {"path": "_test_data/demo_data/images-demo-data.ttl", "name": "http://www.knora.org/data/images"},
                 {"path": "_test_data/ontologies/beol-onto.ttl", "name": "http://www.knora.org/ontology/beol"},
                 {"path": "_test_data/ontologies/anything-onto.ttl", "name": "http://www.knora.org/ontology/anything"},
-                {"path": "_test_data/all_data/anything-data.ttl", "name": "http://www.knora.org/data/anything"}
+                {"path": "_test_data/all_data/anything-data.ttl", "name": "http://www.knora.org/data/anything"},
+                {"path": "_test_data/all_data/biblio-data.ttl", "name": "http://www.knora.org/data/biblio"},
+                {"path": "_test_data/ontologies/biblio-onto.ttl", "name": "http://www.knora.org/ontology/biblio"}
             ]
         """
 

--- a/salsah/src/test/scala/org.knora.salsah/browser/SearchAndEditSpec.scala
+++ b/salsah/src/test/scala/org.knora.salsah/browser/SearchAndEditSpec.scala
@@ -72,7 +72,9 @@ class SearchAndEditSpec extends SalsahSpec {
                 {"path": "_test_data/demo_data/images-demo-data.ttl", "name": "http://www.knora.org/data/images"},
                 {"path": "_test_data/ontologies/beol-onto.ttl", "name": "http://www.knora.org/ontology/beol"},
                 {"path": "_test_data/ontologies/anything-onto.ttl", "name": "http://www.knora.org/ontology/anything"},
-                {"path": "_test_data/all_data/anything-data.ttl", "name": "http://www.knora.org/data/anything"}
+                {"path": "_test_data/all_data/anything-data.ttl", "name": "http://www.knora.org/data/anything"},
+                {"path": "_test_data/all_data/biblio-data.ttl", "name": "http://www.knora.org/data/biblio"},
+                {"path": "_test_data/ontologies/biblio-onto.ttl", "name": "http://www.knora.org/ontology/biblio"}
             ]
         """
 

--- a/webapi/scripts/fuseki-load-test-data.sh
+++ b/webapi/scripts/fuseki-load-test-data.sh
@@ -13,3 +13,4 @@ curl -F filedata=@../_test_data/all_data/anything-data.ttl http://localhost:3030
 curl -F filedata=@../_test_data/ontologies/beol-onto.ttl http://localhost:3030/knora-test/data?graph=http://www.knora.org/ontology/beol > /dev/null
 curl -F filedata=@../_test_data/all_data/beol-data.ttl http://localhost:3030/knora-test/data?graph=http://www.knora.org/data/beol > /dev/null
 curl -F filedata=@../_test_data/ontologies/biblio-onto.ttl http://localhost:3030/knora-test/data?graph=http://www.knora.org/ontology/biblio > /dev/null
+curl -F filedata=@../_test_data/all_data/biblio-data.ttl http://localhost:3030/knora-test/data?graph=http://www.knora.org/data/biblio > /dev/null

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -157,6 +157,8 @@ object OntologyConstants {
         val LinkValue = "http://www.knora.org/ontology/knora-base#LinkValue"
         val GeonameValue = "http://www.knora.org/ontology/knora-base#GeonameValue"
 
+        val ValueCreationDate = "http://www.knora.org/ontology/knora-base#valueCreationDate"
+
         val ListNode = "http://www.knora.org/ontology/knora-base#ListNode"
 
         val IsInGroup = "http://www.knora.org/ontology/knora-base#isInGroup"

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/usermessages/UserMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/usermessages/UserMessagesV1.scala
@@ -125,6 +125,15 @@ case class UserDataV1(lang: String,
                       projects: Option[Seq[IRI]] = None, // TODO: we do not need an option here as the list could simply be empty.
                       projects_info: Seq[ProjectInfoV1] = Vector.empty[ProjectInfoV1]) {
 
+    def fullname: Option[String] = {
+        (firstname, lastname) match {
+            case (Some(firstnameStr), Some(lastnameStr)) => Some(firstnameStr + " " + lastnameStr)
+            case (Some(firstnameStr), None) => Some(firstnameStr)
+            case (None, Some(lastnameStr)) => Some(lastnameStr)
+            case (None, None) => None
+        }
+    }
+
     def toJsValue = UserDataV1JsonProtocol.userDataV1Format.write(this)
 
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/valuemessages/ValueMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/valuemessages/ValueMessagesV1.scala
@@ -183,12 +183,18 @@ case class LinkValueGetRequestV1(subjectIri: IRI, predicateIri: IRI, objectIri: 
   *
   * @param value     the single requested value.
   * @param valuetype the IRI of the value's type.
+  * @param valuecreator the username of the user who created the value.
+  * @param valuecreatorname the name of the user who created the value.
+  * @param valuecreationdate the date when the value was created.
   * @param comment   the comment on the value, if any.
   * @param rights    the user's permission on the value.
   * @param userdata  information about the user that made the request.
   */
 case class ValueGetResponseV1(valuetype: IRI,
                               value: ApiValueV1,
+                              valuecreator: String,
+                              valuecreatorname: String,
+                              valuecreationdate: String,
                               comment: Option[String] = None,
                               rights: Int,
                               userdata: UserDataV1) extends KnoraResponseV1 {
@@ -1501,7 +1507,7 @@ object ApiValueV1JsonProtocol extends DefaultJsonProtocol with NullOptions with 
 
     implicit val createFileQualityLevelFormat: RootJsonFormat[CreateFileQualityLevelV1] = jsonFormat4(CreateFileQualityLevelV1)
     implicit val createFileV1Format: RootJsonFormat[CreateFileV1] = jsonFormat3(CreateFileV1)
-    implicit val valueGetResponseV1Format: RootJsonFormat[ValueGetResponseV1] = jsonFormat5(ValueGetResponseV1)
+    implicit val valueGetResponseV1Format: RootJsonFormat[ValueGetResponseV1] = jsonFormat8(ValueGetResponseV1)
     implicit val dateValueV1Format: JsonFormat[DateValueV1] = jsonFormat3(DateValueV1)
     implicit val stillImageFileValueV1Format: JsonFormat[StillImageFileValueV1] = jsonFormat9(StillImageFileValueV1)
     implicit val movingImageFileValueV1Format: JsonFormat[MovingImageFileValueV1] = jsonFormat4(MovingImageFileValueV1)

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/UsersResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/UsersResponderV1.scala
@@ -47,18 +47,22 @@ class UsersResponderV1 extends ResponderV1 {
     }
 
     /**
-      * Gets information about a Knora user, and returns it in a [[Option[UserProfileV1]].
+      * Gets information about a Knora user, and returns it in a [[UserProfileV1]].
       *
       * @param userIri the IRI of the user.
-      * @return a [[Option[UserProfileV1]] describing the user.
+      * @return a [[UserProfileV1]] describing the user.
       */
-    private def getUserProfileV1(userIri: IRI): Future[Option[UserProfileV1]] = {
+    private def getUserProfileV1(userIri: IRI): Future[UserProfileV1] = {
         for {
             sparqlQuery <- Future(queries.sparql.v1.txt.getUser(
                 triplestore = settings.triplestoreType,
                 userIri = userIri
             ).toString())
             userDataQueryResponse <- (storeManager ? SparqlSelectRequest(sparqlQuery)).mapTo[SparqlSelectResponse]
+
+            _ = if (userDataQueryResponse.results.bindings.isEmpty) {
+                throw NotFoundException(s"User $userIri not found")
+            }
 
             groupedUserData: Map[String, Seq[String]] = userDataQueryResponse.results.bindings.groupBy(_.rowMap("p")).map {
                 case (predicate, rows) => predicate -> rows.map(_.rowMap("o"))
@@ -88,26 +92,16 @@ class UsersResponderV1 extends ResponderV1 {
                 case None => Vector.empty[IRI]
             }
 
-            userProfileV1 = {
-                if (groupedUserData.isEmpty) {
-                    None
-                } else {
-                    Some(UserProfileV1(userDataV1, groupIris, projectIris))
-                }
-            }
-
-
-        } yield userProfileV1
+        } yield UserProfileV1(userDataV1, groupIris, projectIris)
     }
 
     /**
-      * Gets information about a Knora user, and returns it in a [[Option[UserProfileV1]].
+      * Gets information about a Knora user, and returns it in a [[UserProfileV1]].
       *
       * @param username the username of the user.
-      * @return a [[Option[UserProfileV1]] describing the user.
+      * @return a [[UserProfileV1]] describing the user.
       */
-    private def getUserProfileByUsernameV1(username: String): Future[Option[UserProfileV1]] = {
-        //TODO: Need to fix UsersResponderV1 to return None and not an exception when user not found (issue #297)
+    private def getUserProfileByUsernameV1(username: String): Future[UserProfileV1] = {
         for {
             sparqlQuery <- Future(queries.sparql.v1.txt.getUserByUsername(
                 triplestore = settings.triplestoreType,
@@ -158,15 +152,6 @@ class UsersResponderV1 extends ResponderV1 {
                 projects = if (projectIris.nonEmpty) Some(projectIris) else None,
                 projects_info = projectInfos
             )
-
-            userProfileV1 = {
-                if (groupedUserData.isEmpty) {
-                    None
-                } else {
-                    Some(UserProfileV1(userDataV1, groupIris, projectIris))
-                }
-            }
-
-        } yield userProfileV1 // Some(UserProfileV1(userDataV1, groupIris, projectIris))
+        } yield UserProfileV1(userDataV1, groupIris, projectIris)
     }
 }

--- a/webapi/src/main/twirl/queries/sparql/v1/changeLink.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/changeLink.scala.txt
@@ -234,7 +234,7 @@ WHERE {
         @{throw SparqlGenerationException(s"linkUpdateForNewLink.directLinkExists must be false in this SPARQL template"); ()}
     }
 
-    MINUS {
+    FILTER NOT EXISTS {
         ?linkSource ?linkProperty ?linkTargetForNewLink .
     }
 
@@ -242,7 +242,7 @@ WHERE {
         @{throw SparqlGenerationException(s"linkUpdateForNewLink.linkValueExists must be false in this SPARQL template"); ()}
     }
 
-    MINUS {
+    FILTER NOT EXISTS {
         ?linkSource ?linkValueProperty ?currentLinkValueForNewLink .
         ?currentLinkValueForNewLink rdf:type knora-base:LinkValue ;
             rdf:subject ?linkSource ;

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/ValuesResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/ValuesResponderV1Spec.scala
@@ -316,20 +316,17 @@ class ValuesResponderV1Spec extends CoreSpec() with ImplicitSender {
                 userProfile = incunabulaUser
             )
 
-            expectMsg(
-                timeout,
-                ValueGetResponseV1(
-                    valuetype = OntologyConstants.KnoraBase.LinkValue,
-                    value = LinkValueV1(
+            expectMsgPF(timeout) {
+                case msg: ValueGetResponseV1 =>
+                    msg.valuetype should ===(OntologyConstants.KnoraBase.LinkValue)
+                    msg.value should ===(LinkValueV1(
                         subjectIri = "http://data.knora.org/8a0b1e75",
                         predicateIri = "http://www.knora.org/ontology/incunabula#partOf",
                         objectIri = zeitglöckleinIri,
                         referenceCount = 1
-                    ),
-                    rights = 2,
-                    userdata = incunabulaUser.userData
-                )
-            )
+                    ))
+                    msg.rights should ===(2)
+            }
         }
 
         "add a new version of a text value without Standoff" in {
@@ -753,20 +750,17 @@ class ValuesResponderV1Spec extends CoreSpec() with ImplicitSender {
             // Since this is the first Standoff resource reference between the source and target resources, we should
             // now have version 1 of a LinkValue, with a reference count of 1.
 
-            expectMsg(
-                timeout,
-                ValueGetResponseV1(
-                    valuetype = OntologyConstants.KnoraBase.LinkValue,
-                    value = LinkValueV1(
+            expectMsgPF(timeout) {
+                case msg: ValueGetResponseV1 =>
+                    msg.valuetype should ===(OntologyConstants.KnoraBase.LinkValue)
+                    msg.value should ===(LinkValueV1(
                         subjectIri = "http://data.knora.org/21abac2162",
                         predicateIri = OntologyConstants.KnoraBase.HasStandoffLinkTo,
                         objectIri = zeitglöckleinIri,
                         referenceCount = 1
-                    ),
-                    rights = 2,
-                    userdata = incunabulaUser.userData
-                )
-            )
+                    ))
+                    msg.rights should ===(2)
+            }
 
             val sparqlQuery = queries.sparql.v1.txt.findLinkValueByObject(
                 triplestore = settings.triplestoreType,
@@ -833,20 +827,17 @@ class ValuesResponderV1Spec extends CoreSpec() with ImplicitSender {
             // Since the new version still refers to the same resource, the reference count of the LinkValue should not
             // change.
 
-            expectMsg(
-                timeout,
-                ValueGetResponseV1(
-                    valuetype = OntologyConstants.KnoraBase.LinkValue,
-                    value = LinkValueV1(
+            expectMsgPF(timeout) {
+                case msg: ValueGetResponseV1 =>
+                    msg.valuetype should ===(OntologyConstants.KnoraBase.LinkValue)
+                    msg.value should ===(LinkValueV1(
                         subjectIri = "http://data.knora.org/21abac2162",
                         predicateIri = OntologyConstants.KnoraBase.HasStandoffLinkTo,
                         objectIri = zeitglöckleinIri,
                         referenceCount = 1
-                    ),
-                    rights = 2,
-                    userdata = incunabulaUser.userData
-                )
-            )
+                    ))
+                    msg.rights should ===(2)
+            }
 
             val sparqlQuery = queries.sparql.v1.txt.findLinkValueByObject(
                 triplestore = settings.triplestoreType,
@@ -906,20 +897,17 @@ class ValuesResponderV1Spec extends CoreSpec() with ImplicitSender {
             // Now that we've added a different TextValue that refers to the same resource, we should have version 2
             // of the LinkValue, with a reference count of 2.
 
-            expectMsg(
-                timeout,
-                ValueGetResponseV1(
-                    valuetype = OntologyConstants.KnoraBase.LinkValue,
-                    value = LinkValueV1(
+            expectMsgPF(timeout) {
+                case msg: ValueGetResponseV1 =>
+                    msg.valuetype should ===(OntologyConstants.KnoraBase.LinkValue)
+                    msg.value should ===(LinkValueV1(
                         subjectIri = "http://data.knora.org/21abac2162",
                         predicateIri = OntologyConstants.KnoraBase.HasStandoffLinkTo,
                         objectIri = zeitglöckleinIri,
                         referenceCount = 2
-                    ),
-                    rights = 2,
-                    userdata = incunabulaUser.userData
-                )
-            )
+                    ))
+                    msg.rights should ===(2)
+            }
 
             val sparqlQuery = queries.sparql.v1.txt.findLinkValueByObject(
                 triplestore = settings.triplestoreType,
@@ -967,20 +955,17 @@ class ValuesResponderV1Spec extends CoreSpec() with ImplicitSender {
 
             // Version 3 of the LinkValue should have a reference count of 1.
 
-            expectMsg(
-                timeout,
-                ValueGetResponseV1(
-                    valuetype = OntologyConstants.KnoraBase.LinkValue,
-                    value = LinkValueV1(
+            expectMsgPF(timeout) {
+                case msg: ValueGetResponseV1 =>
+                    msg.valuetype should ===(OntologyConstants.KnoraBase.LinkValue)
+                    msg.value should ===(LinkValueV1(
                         subjectIri = "http://data.knora.org/21abac2162",
                         predicateIri = OntologyConstants.KnoraBase.HasStandoffLinkTo,
                         objectIri = zeitglöckleinIri,
                         referenceCount = 1
-                    ),
-                    rights = 2,
-                    userdata = incunabulaUser.userData
-                )
-            )
+                    ))
+                    msg.rights should ===(2)
+            }
 
             val sparqlQuery = queries.sparql.v1.txt.findLinkValueByObject(
                 triplestore = settings.triplestoreType,
@@ -1106,20 +1091,17 @@ class ValuesResponderV1Spec extends CoreSpec() with ImplicitSender {
             // There should now be a new LinkValue with no previous versions and a reference count of 1, and
             // there should once again be a direct link.
 
-            expectMsg(
-                timeout,
-                ValueGetResponseV1(
-                    valuetype = OntologyConstants.KnoraBase.LinkValue,
-                    value = LinkValueV1(
+            expectMsgPF(timeout) {
+                case msg: ValueGetResponseV1 =>
+                    msg.valuetype should ===(OntologyConstants.KnoraBase.LinkValue)
+                    msg.value should ===(LinkValueV1(
                         subjectIri = "http://data.knora.org/21abac2162",
                         predicateIri = OntologyConstants.KnoraBase.HasStandoffLinkTo,
                         objectIri = zeitglöckleinIri,
                         referenceCount = 1
-                    ),
-                    rights = 2,
-                    userdata = incunabulaUser.userData
-                )
-            )
+                    ))
+                    msg.rights should ===(2)
+            }
 
             val sparqlQuery = queries.sparql.v1.txt.findLinkValueByObject(
                 triplestore = settings.triplestoreType,
@@ -1743,20 +1725,17 @@ class ValuesResponderV1Spec extends CoreSpec() with ImplicitSender {
                 userProfile = anythingUser
             )
 
-            expectMsg(
-                timeout,
-                ValueGetResponseV1(
-                    valuetype = OntologyConstants.KnoraBase.LinkValue,
-                    value = LinkValueV1(
+            expectMsgPF(timeout) {
+                case msg: ValueGetResponseV1 =>
+                    msg.valuetype should ===(OntologyConstants.KnoraBase.LinkValue)
+                    msg.value should ===(LinkValueV1(
                         subjectIri = thingWithTextValues,
                         predicateIri = OntologyConstants.KnoraBase.HasStandoffLinkTo,
                         objectIri = aThingIri,
                         referenceCount = 2
-                    ),
-                    rights = 2,
-                    userdata = anythingUser.userData
-                )
-            )
+                    ))
+                    msg.rights should ===(2)
+            }
 
             val initialLinkValueSparqlQuery = queries.sparql.v1.txt.findLinkValueByObject(
                 triplestore = settings.triplestoreType,
@@ -1811,20 +1790,17 @@ class ValuesResponderV1Spec extends CoreSpec() with ImplicitSender {
                 userProfile = anythingUser
             )
 
-            expectMsg(
-                timeout,
-                ValueGetResponseV1(
-                    valuetype = OntologyConstants.KnoraBase.LinkValue,
-                    value = LinkValueV1(
+            expectMsgPF(timeout) {
+                case msg: ValueGetResponseV1 =>
+                    msg.valuetype should ===(OntologyConstants.KnoraBase.LinkValue)
+                    msg.value should ===(LinkValueV1(
                         subjectIri = thingWithTextValues,
                         predicateIri = OntologyConstants.KnoraBase.HasStandoffLinkTo,
                         objectIri = aThingIri,
                         referenceCount = 1
-                    ),
-                    rights = 2,
-                    userdata = anythingUser.userData
-                )
-            )
+                    ))
+                    msg.rights should ===(2)
+            }
 
             // It should have a previousValue, and the direct link should still exist.
 

--- a/webapi/src/test/scala/org/knora/webapi/routing/AuthenticatorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/routing/AuthenticatorSpec.scala
@@ -79,9 +79,9 @@ class AuthenticatorSpec extends CoreSpec("AuthenticationTestSystem") with Implic
         become {
             case UserProfileByUsernameGetRequestV1(submittedUsername) => {
                 if (submittedUsername == usernameCorrect) {
-                    sender !  Some(mockUserProfileV1)
+                    sender ! mockUserProfileV1
                 } else {
-                    sender ! None
+                    sender ! akka.actor.Status.Failure(BadCredentialsException("Bad credentials"))
                 }
             }
         }


### PR DESCRIPTION
* Fixes #277.
* Fixes #309.
* Fixes #310.
* Closes #297 by changing `UsersResponderV1` not to return an `Option`, relying on exceptions instead, and changing `Authenticator` accordingly.