### PR TITLE
fix (ontology responder): ignore knora-base:resourceProperty 

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -117,6 +117,7 @@ object OntologyConstants {
 
         val PreviousValue = "http://www.knora.org/ontology/knora-base#previousValue"
 
+        val ResourceProperty = "http://www.knora.org/ontology/knora-base#resourceProperty"
         val HasValue = "http://www.knora.org/ontology/knora-base#hasValue"
         val HasFileValue = "http://www.knora.org/ontology/knora-base#hasFileValue"
         val HasStillImageFileValue = "http://www.knora.org/ontology/knora-base#hasStillImageFileValue"

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/OntologyResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/OntologyResponderV1.scala
@@ -224,8 +224,8 @@ class OntologyResponderV1 extends ResponderV1 {
             resourceDefsGrouped: Map[IRI, Seq[VariableResultsRow]] = resourceDefsRows.groupBy(_.rowMap("resourceClass"))
             resourceClassIris = resourceDefsGrouped.keySet
 
-            // Group the rows representing property definitions by property IRI. Exclude knora-base:hasValue, which is never used directly.
-            propertyDefsGrouped: Map[IRI, Seq[VariableResultsRow]] = propertyDefsRows.groupBy(_.rowMap("prop")) - OntologyConstants.KnoraBase.HasValue
+            // Group the rows representing property definitions by property IRI. Exclude knora-base:resourceProperty and knora-base:hasValue, which is never used directly.
+            propertyDefsGrouped: Map[IRI, Seq[VariableResultsRow]] = propertyDefsRows.groupBy(_.rowMap("prop")) - OntologyConstants.KnoraBase.ResourceProperty - OntologyConstants.KnoraBase.HasValue
             propertyIris = propertyDefsGrouped.keySet
 
             // Group the rows representing value class relations by value class IRI.

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/OntologyResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/OntologyResponderV1Spec.scala
@@ -76,7 +76,11 @@ class OntologyResponderV1Spec extends CoreSpec() with ImplicitSender {
         RdfDataObject(path = "../knora-ontologies/knora-base.ttl", name = "http://www.knora.org/ontology/knora-base"),
         RdfDataObject(path = "../knora-ontologies/knora-dc.ttl", name = "http://www.knora.org/ontology/dc"),
         RdfDataObject(path = "../knora-ontologies/salsah-gui.ttl", name = "http://www.knora.org/ontology/salsah-gui"),
-        RdfDataObject(path = "_test_data/ontologies/incunabula-onto.ttl", name = "http://www.knora.org/ontology/incunabula")
+        RdfDataObject(path = "_test_data/ontologies/incunabula-onto.ttl", name = "http://www.knora.org/ontology/incunabula"),
+        RdfDataObject(path = "_test_data/ontologies/images-demo-onto.ttl", name = "http://www.knora.org/ontology/images"),
+        RdfDataObject(path = "_test_data/ontologies/anything-onto.ttl", name = "http://www.knora.org/ontology/anything"),
+        RdfDataObject(path = "_test_data/ontologies/beol-onto.ttl", name = "http://www.knora.org/ontology/beol"),
+        RdfDataObject(path = "_test_data/ontologies/biblio-onto.ttl", name = "http://www.knora.org/ontology/biblio")
     )
 
     // The default timeout for receiving reply messages from actors.
@@ -1188,6 +1192,19 @@ class OntologyResponderV1Spec extends CoreSpec() with ImplicitSender {
             expectMsgPF(timeout) {
                 case msg: PropertyTypesForNamedGraphResponseV1 =>
                     checkPropertyTypesForNamedGraphIncunabula(received = msg, expected = propertyTypesForNamedGraphIncunabula)
+            }
+        }
+
+        "get all the properties for all vocabularies" in {
+            actorUnderTest ! PropertyTypesForNamedGraphGetRequestV1(
+                namedGraph = None,
+                userProfile = OntologyResponderV1Spec.userProfileWithEnglish
+            )
+
+            expectMsgPF(timeout) {
+                case msg: PropertyTypesForNamedGraphResponseV1 =>
+                    // simply checks that no error occurred when getting the property definitions for all vocabularies
+                    ()
             }
         }
     }


### PR DESCRIPTION
`knora-base:resourceProperty` has to be ignored since it is never used directly.

The query <http://localhost:3333/v1/propertylists?vocabulary=0> for property definitions for all vocabularies failed because of this error: 
> Property http://www.knora.org/ontology/knora-base#resourceProperty has no knora-base:objectClassConstraint

I added a test that now detects this problem (this test was missing and thus we did not find about about this).
