### PR TITLE
fix (limit incoming references): limit the number of incoming references

### DIFF
--- a/webapi/src/main/twirl/queries/sparql/v1/getIncomingReferencesGraphDB.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getIncomingReferencesGraphDB.scala.txt
@@ -40,22 +40,36 @@ PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
 
 SELECT ?referringResource ?linkProp ?prop ?obj ?isLinkValue ?objPred ?objObj
 WHERE {
-    BIND(IRI("@resourceIri") as ?resource)
 
-    ?resource a knora-base:Resource ;
-        knora-base:isDeleted false .
+    @*
 
-    @* Find incoming links that are subproperties of knora-base:hasLinkTo but not knora-base:isPartOf. *@
+        Find incoming links that are subproperties of knora-base:hasLinkTo but not knora-base:isPartOf.
 
-    ?referringResource knora-base:hasLinkTo ?resource ;
-        knora-base:isDeleted false .
+        Makes use of a subquery in order to limit the number of referring resources.
 
-    FILTER NOT EXISTS {
-        ?referringResource knora-base:isPartOf ?resource .
-    }
+    *@
 
-    GRAPH <http://www.ontotext.com/explicit> {
-        ?referringResource ?linkProp ?resource .
+    {
+        SELECT ?resource ?referringResource ?linkProp
+        WHERE {
+            BIND(IRI("@resourceIri") as ?resource)
+
+            ?resource a knora-base:Resource ;
+                knora-base:isDeleted false .
+
+            @* Find incoming links that are subproperties of knora-base:hasLinkTo but not knora-base:isPartOf. *@
+
+            ?referringResource knora-base:hasLinkTo ?resource ;
+                knora-base:isDeleted false .
+
+            FILTER NOT EXISTS {
+                ?referringResource knora-base:isPartOf ?resource .
+            }
+
+            GRAPH <http://www.ontotext.com/explicit> {
+                ?referringResource ?linkProp ?resource .
+            }
+        } LIMIT 50
     }
 
     {

--- a/webapi/src/main/twirl/queries/sparql/v1/getIncomingReferencesStandard.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getIncomingReferencesStandard.scala.txt
@@ -38,20 +38,34 @@ PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
 
 SELECT ?referringResource ?linkProp ?prop ?obj ?isLinkValue ?objPred ?objObj
 WHERE {
-    BIND(IRI("@resourceIri") as ?resource)
 
-    ?resource knora-base:isDeleted false .
+    @*
 
-    @* Find incoming links that are subproperties of knora-base:hasLinkTo but not knora-base:isPartOf. *@
+    Find incoming links that are subproperties of knora-base:hasLinkTo but not knora-base:isPartOf.
 
-    ?linkProp rdfs:subPropertyOf* knora-base:hasLinkTo .
+    Makes use of a subquery in order to limit the number of referring resources.
 
-    FILTER NOT EXISTS {
-        ?linkProp rdfs:subPropertyOf* knora-base:isPartOf .
+    *@
+
+    {
+        SELECT ?resource ?referringResource ?linkProp
+        WHERE {
+
+            BIND(IRI("@resourceIri") as ?resource)
+
+            ?resource knora-base:isDeleted false .
+
+            ?linkProp rdfs:subPropertyOf* knora-base:hasLinkTo .
+
+            FILTER NOT EXISTS {
+                ?linkProp rdfs:subPropertyOf* knora-base:isPartOf .
+            }
+
+            ?referringResource ?linkProp ?resource ;
+                knora-base:isDeleted false .
+
+        } LIMIT 50
     }
-
-    ?referringResource ?linkProp ?resource ;
-        knora-base:isDeleted false .
 
     {
         @* Get basic information about the source of each link. *@


### PR DESCRIPTION
Limits the number of incoming references to 50 and thereby prevents problems when writing back too many results from the triplestore