### PR TITLE
fix (webapi): Fix permission checking on link values

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
@@ -1230,7 +1230,7 @@ class ValuesResponderV1 extends ResponderV1 {
     @throws(classOf[NotFoundException])
     private def getLinkValue(subjectIri: IRI, predicateIri: IRI, objectIri: IRI, userProfile: UserProfileV1): Future[ValueGetResponseV1] = {
         for {
-            maybeValueQueryResult <- findLinkValueByObject(
+            maybeValueQueryResult <- findLinkValueByLinkTriple(
                 subjectIri = subjectIri,
                 predicateIri = predicateIri,
                 objectIri = objectIri,
@@ -1320,6 +1320,7 @@ class ValuesResponderV1 extends ResponderV1 {
       * @param targetResourceClass          if a direct link exists, contains the OWL class of the target resource.
       */
     case class LinkValueQueryResult(value: LinkValueV1,
+                                    linkValueIri: IRI,
                                     ownerIri: IRI,
                                     creationDate: String,
                                     projectIri: IRI,
@@ -1342,9 +1343,69 @@ class ValuesResponderV1 extends ResponderV1 {
                 triplestore = settings.triplestoreType,
                 valueIri = valueIri
             ).toString())
+
             response <- (storeManager ? SparqlSelectRequest(sparqlQuery)).mapTo[SparqlSelectResponse]
             rows: Seq[VariableResultsRow] = response.results.bindings
-        } yield sparqlQueryResults2ValueQueryResult(valueIri, rows, userProfile)
+            maybeValueQueryResult = sparqlQueryResults2ValueQueryResult(valueIri, rows, userProfile)
+
+            // If it's a link value, check that the user has permission to see the source and target resources.
+            _ = maybeValueQueryResult match {
+                case Some(valueQueryResult) =>
+                    valueQueryResult.value match {
+                        case _: LinkValueV1 => checkLinkValueSubjectAndObjectPermissions(valueIri, userProfile)
+                        case _ => ()
+                    }
+
+
+                case None => ()
+            }
+        } yield maybeValueQueryResult
+    }
+
+    /**
+      * Checks that the user has permission to see the source and target resources of a link value.
+      *
+      * @param linkValueIri the IRI of the link value.
+      * @param userProfile the profile of the user making the request.
+      * @return () if the user has the required permission, or an exception otherwise.
+      */
+    private def checkLinkValueSubjectAndObjectPermissions(linkValueIri: IRI, userProfile: UserProfileV1): Future[Unit] = {
+        for {
+            sparqlQuery <- Future(queries.sparql.v1.txt.getLinkSourceAndTargetPermissions(
+                triplestore = settings.triplestoreType,
+                linkValueIri = linkValueIri
+            ).toString())
+
+            response <- (storeManager ? SparqlSelectRequest(sparqlQuery)).mapTo[SparqlSelectResponse]
+            rows = response.results.bindings
+
+            _ = if (rows.isEmpty) {
+                throw NotFoundException(s"Link value $linkValueIri, or its source or target resource, was not found.")
+            }
+
+            rowMap = rows.head.rowMap
+            userIri = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraBase.UnknownUser)
+
+            maybeSourcePermissionCode = PermissionUtilV1.getUserPermissionV1(
+                subjectIri = rowMap("source"),
+                subjectOwner = rowMap("sourceOwner"),
+                subjectProject = rowMap("sourceProject"),
+                subjectPermissionLiteral = rowMap.get("sourcePermissions"),
+                userProfile = userProfile
+            )
+
+            maybeTargetPermissionCode = PermissionUtilV1.getUserPermissionV1(
+                subjectIri = rowMap("target"),
+                subjectOwner = rowMap("targetOwner"),
+                subjectProject = rowMap("targetProject"),
+                subjectPermissionLiteral = rowMap.get("targetPermissions"),
+                userProfile = userProfile
+            )
+
+            _ = if (maybeSourcePermissionCode.isEmpty || maybeTargetPermissionCode.isEmpty) {
+                throw ForbiddenException(s"User $userIri does not have permission to view link value $linkValueIri")
+            }
+        } yield ()
     }
 
     /**
@@ -1372,7 +1433,13 @@ class ValuesResponderV1 extends ResponderV1 {
 
             response <- (storeManager ? SparqlSelectRequest(sparqlQuery)).mapTo[SparqlSelectResponse]
             rows: Seq[VariableResultsRow] = response.results.bindings
-        } yield sparqlQueryResults2LinkValueQueryResult(rows, userProfile)
+            maybeLinkValueQueryResult = sparqlQueryResults2LinkValueQueryResult(rows, userProfile)
+
+            // Check that the user has permission to see the source and target resources.
+            _ = if (maybeLinkValueQueryResult.nonEmpty) {
+               checkLinkValueSubjectAndObjectPermissions(linkValueIri, userProfile)
+            }
+        } yield maybeLinkValueQueryResult
     }
 
     /**
@@ -1386,7 +1453,7 @@ class ValuesResponderV1 extends ResponderV1 {
       * @param userProfile  the profile of the user making the request.
       * @return an optional [[ValueGetResponseV1]] containing a [[LinkValueV1]].
       */
-    private def findLinkValueByObject(subjectIri: IRI, predicateIri: IRI, objectIri: IRI, userProfile: UserProfileV1): Future[Option[LinkValueQueryResult]] = {
+    private def findLinkValueByLinkTriple(subjectIri: IRI, predicateIri: IRI, objectIri: IRI, userProfile: UserProfileV1): Future[Option[LinkValueQueryResult]] = {
         for {
             sparqlQuery <- Future {
                 queries.sparql.v1.txt.findLinkValueByObject(
@@ -1399,11 +1466,20 @@ class ValuesResponderV1 extends ResponderV1 {
 
             response <- (storeManager ? SparqlSelectRequest(sparqlQuery)).mapTo[SparqlSelectResponse]
             rows: Seq[VariableResultsRow] = response.results.bindings
-        } yield sparqlQueryResults2LinkValueQueryResult(rows, userProfile)
+            maybeLinkValueQueryResult = sparqlQueryResults2LinkValueQueryResult(rows, userProfile)
+
+            // Check that the user has permission to see the source and target resources.
+            _ = maybeLinkValueQueryResult match {
+                case Some(linkValueQueryResult) => checkLinkValueSubjectAndObjectPermissions(linkValueQueryResult.linkValueIri, userProfile)
+                case _ => ()
+            }
+        } yield maybeLinkValueQueryResult
     }
 
     /**
-      * Converts SPARQL query results into a [[ValueQueryResult]].
+      * Converts SPARQL query results into a [[ValueQueryResult]]. Checks that the user has permission to view the value object.
+      * If the value is a link value, the caller of this method is responsible for ensuring that the user has permission to
+      * view the source and target resources.
       *
       * @param valueIri    the IRI of the value that was queried.
       * @param rows        the query result rows.
@@ -1416,6 +1492,9 @@ class ValuesResponderV1 extends ResponderV1 {
             // Convert the query results to a ApiValueV1.
             val valueProps = valueUtilV1.createValueProps(valueIri, rows)
             val value = valueUtilV1.makeValueV1(valueProps)
+
+            // Get the value's class IRI.
+            val valueClassIri = getValuePredicateObject(predicateIri = OntologyConstants.Rdf.Type, rows = rows).getOrElse(throw InconsistentTriplestoreDataException(s"Value $valueIri has no rdf:type"))
 
             // Get the IRI of the value's owner.
             val ownerIri = getValuePredicateObject(predicateIri = OntologyConstants.KnoraBase.AttachedToUser, rows = rows).getOrElse(throw InconsistentTriplestoreDataException(s"Value $valueIri has no owner"))
@@ -1433,11 +1512,31 @@ class ValuesResponderV1 extends ResponderV1 {
             val assertions = PermissionUtilV1.filterPermissionRelevantAssertionsFromValueProps(valueProps)
 
             // Get the permission code representing the user's permissions on the value.
-            val permissionCode = PermissionUtilV1.getUserPermissionV1FromAssertions(
-                subjectIri = valueIri,
-                assertions = assertions,
-                userProfile = userProfile
-            ).getOrElse {
+            //
+            // Link values created automatically for resource references in standoff
+            // are automatically visible to all users, as long as they have permission
+            // to see the source and target resources. The caller of this method is responsible
+            // for checking the permissions on the source and target resources.
+
+            val maybePermissionCode = valueClassIri match {
+                case OntologyConstants.KnoraBase.LinkValue =>
+                    val linkPredicateIri = getValuePredicateObject(predicateIri = OntologyConstants.Rdf.Predicate, rows = rows).getOrElse(throw InconsistentTriplestoreDataException(s"Link value $valueIri has no rdf:predicate"))
+
+                    PermissionUtilV1.getUserPermissionOnLinkValueV1WithValueProps(
+                        linkValueIri = valueIri,
+                        predicateIri = linkPredicateIri,
+                        valueProps = valueProps,
+                        userProfile = userProfile
+                    )
+
+                case _ => PermissionUtilV1.getUserPermissionV1FromAssertions(
+                    subjectIri = valueIri,
+                    assertions = assertions,
+                    userProfile = userProfile
+                )
+            }
+
+            val permissionCode = maybePermissionCode.getOrElse {
                 val userIri = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraBase.UnknownUser)
                 throw ForbiddenException(s"User $userIri does not have permission to see value $valueIri")
             }
@@ -1509,6 +1608,7 @@ class ValuesResponderV1 extends ResponderV1 {
             Some(
                 LinkValueQueryResult(
                     value = linkValueV1,
+                    linkValueIri = linkValueIri,
                     ownerIri = ownerIri,
                     creationDate = creationDate,
                     comment = comment,
@@ -2130,7 +2230,7 @@ class ValuesResponderV1 extends ResponderV1 {
                                    userProfile: UserProfileV1): Future[SparqlTemplateLinkUpdate] = {
         for {
         // Check whether a LinkValue already exists for this link.
-            maybeLinkValueQueryResult <- findLinkValueByObject(
+            maybeLinkValueQueryResult <- findLinkValueByLinkTriple(
                 subjectIri = sourceResourceIri,
                 predicateIri = linkPropertyIri,
                 objectIri = targetResourceIri,
@@ -2214,7 +2314,7 @@ class ValuesResponderV1 extends ResponderV1 {
                                    userProfile: UserProfileV1): Future[SparqlTemplateLinkUpdate] = {
         for {
         // Query the LinkValue to ensure that it exists and to get its contents.
-            maybeLinkValueQueryResult <- findLinkValueByObject(
+            maybeLinkValueQueryResult <- findLinkValueByLinkTriple(
                 subjectIri = sourceResourceIri,
                 predicateIri = linkPropertyIri,
                 objectIri = targetResourceIri,

--- a/webapi/src/main/twirl/queries/sparql/v1/getLinkSourceAndTargetPermissions.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getLinkSourceAndTargetPermissions.scala.txt
@@ -1,0 +1,59 @@
+@*
+ * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and André Fatton.
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ *@
+
+@import org.knora.webapi.IRI
+
+@**
+ * Returns the permission-relevant assertions on the subject and object of a link value.
+ *
+ * @param triplestore the name of the triplestore being used.
+ * @param linkValueIri the IRI of the link value.
+ *@
+@(triplestore: String,
+  linkValueIri: IRI)
+
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix knora-base: <http://www.knora.org/ontology/knora-base#>
+
+SELECT ?source ?sourceOwner ?sourceProject ?sourcePermissions ?target ?targetOwner ?targetProject ?targetPermissions
+@* Ensure that inference is not used in this query. *@
+@if(triplestore.startsWith("graphdb")) {
+    FROM <http://www.ontotext.com/explicit>
+}
+WHERE {
+    BIND(IRI("@linkValueIri") AS ?linkValue)
+
+    ?linkValue rdf:type knora-base:LinkValue ;
+               rdf:subject ?source ;
+               rdf:predicate ?predicate ;
+               rdf:object ?target ;
+               knora-base:isDeleted false .
+
+    ?source knora-base:attachedToUser ?sourceOwner ;
+             knora-base:attachedToProject ?sourceProject ;
+             knora-base:hasPermissions ?sourcePermissions ;
+             knora-base:isDeleted false .
+
+    ?target knora-base:attachedToUser ?targetOwner ;
+            knora-base:attachedToProject ?targetProject ;
+            knora-base:hasPermissions ?targetPermissions ;
+            knora-base:isDeleted false .
+}

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/ValuesResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/ValuesResponderV1Spec.scala
@@ -296,7 +296,7 @@ class ValuesResponderV1Spec extends CoreSpec() with ImplicitSender {
             }
         }
 
-        "query a text value containing Standoff (disabled because of issue 17)" ignore {
+        "query a text value containing Standoff" in {
             actorUnderTest ! ValueGetRequestV1(
                 valueIri = "http://data.knora.org/e41ab5695c/values/d3398239089e04",
                 userProfile = incunabulaUser
@@ -305,6 +305,17 @@ class ValuesResponderV1Spec extends CoreSpec() with ImplicitSender {
             expectMsgPF(timeout) {
                 case msg: ValueGetResponseV1 =>
                     checkValueGetResponseWithStandoff(msg)
+            }
+        }
+
+        "query a standoff link as an ordinary value" in {
+            actorUnderTest ! ValueGetRequestV1(
+                valueIri = "http://data.knora.org/a-thing-with-text-values/values/0",
+                userProfile = incunabulaUser
+            )
+
+            expectMsgPF(timeout) {
+                case msg: ValueGetResponseV1 => msg.rights should ===(2)
             }
         }
 


### PR DESCRIPTION
Fixes #366.

The docs say:

> Link values created automatically for resource references in standoff are automatically visible to all users, as long as they have permission to see the source and target resources.

When the values responder loads a link value, it must:

* Check the link value's permissions using `PermissionUtilV1.getUserPermissionOnLinkValueV1WithValueProps`, which takes into account the special case of standoff links.
* Check that the user has permission to view the source and target resources.