### PR TITLE
fix (knora-ontologies): remove obsolete property

### DIFF
--- a/knora-ontologies/knora-admin.ttl
+++ b/knora-ontologies/knora-admin.ttl
@@ -244,8 +244,6 @@
 
             rdfs:comment "The URL of a web site"@en ;
 
-            rdfs:subPropertyOf :systemProperty ;
-
             :subjectClassConstraint :Institution ;
 
             :objectDatatypeConstraint xsd:anyURI .


### PR DESCRIPTION
### Summary

  - removing ``knora-base:systemProperty`` from the declaration of ``knora-base:institutionWebsite``

### Issues
  - #378 