### PR TITLE
Wip/sipi logout

### DIFF
--- a/salsah/src/public/index.html
+++ b/salsah/src/public/index.html
@@ -251,6 +251,7 @@
 					$.ajax({
 						url: SIPI_URL + SIPI_LOGOUT_ROUTE,
 						type: "POST",
+                        contentType: "application/x-www-form-urlencoded; charset=UTF-8",
 						xhrFields: {
 							withCredentials: true
 						},

--- a/salsah/src/public/index.html
+++ b/salsah/src/public/index.html
@@ -251,7 +251,7 @@
 					$.ajax({
 						url: SIPI_URL + SIPI_LOGOUT_ROUTE,
 						type: "POST",
-                        contentType: "application/x-www-form-urlencoded; charset=UTF-8",
+						contentType: "application/x-www-form-urlencoded; charset=UTF-8",
 						xhrFields: {
 							withCredentials: true
 						},


### PR DESCRIPTION
forcing the contentType:
- it keeps Sipi happy because it expects a contentType with each request
- it keeps security concerned browser happy by not blocking the request for CORS checking