### PR TITLE
pushing a function into a closure  …

### DIFF
--- a/salsah/src/public/js/jquery.resadd.js
+++ b/salsah/src/public/js/jquery.resadd.js
@@ -446,12 +446,15 @@
 												selection_id = attr[1].replace("<", "").replace(">", ""); // remove brackets from Iri to make it a valid URL
 											}
 										});
-										create_entry(propname, pinfo, function(ele, attr, pinfo) {
-											var selbox = $('<span>', attr).insertBefore(ele.find('.entrySep'));
-											selbox.selection('edit', {
-												selection_id: selection_id
-											});
-										});
+										create_entry(propname, pinfo, (function(sel_id) {
+											return function(ele, attr, pinfo) {
+												var selbox = $('<span>', attr).insertBefore(ele.find('.entrySep'));
+
+												selbox.selection('edit', {
+													selection_id: sel_id
+												});
+											}
+										}(selection_id)));
 										prop_status[propname].attributes = attributes; // save attributes for later use
 										break;
 									}


### PR DESCRIPTION
… to get the right variable scope on later execution

What happens here is that:
- when we create the form, we recognize a `pulldown` (line 438)
  - we work out the `selection_id` holding the choices
  - we define the function to create the inner element; the list itself (anonymous, but let's call it `create_tag_function`
  - and we create the outer element (inner and "+""x" according to the cardinality) by calling `create_entry(propname, pinfo, create_tag_function)`
  - `create_entry` calls `create_tag_function` right away and the first list accesses `selection_id` with its original value as it was just created
  - `create_entry` then sees the cardinality > 1 and builds the "+" with the click event calling `create_tag_function`
- the rest of the form is built, with other lists and `selection_id` changes
- then we click '+' on the first list, the click event calls `create_tag_function` but by then the `selection_id` has changed and we fill the second list with the content of the last list of the form

Two avoid this, I propose to create a closure to secure the scope chain (the scope of the variables).

The other solution is to move all of the code inside `create_tag_function` to force to run it each time:

    create_entry(propname, pinfo, function(ele, attr, pinfo) {
        var selection_id;
        var attrs = rtinfo.properties[pinfo].attributes.split(';');
        $.each(attrs, function() {
            var attr = this.split('=');
            if (attr[0] == 'selection' || attr[0] == 'hlist') {
                //selection_id = attr[1];
                selection_id = attr[1].replace("<", "").replace(">", ""); // remove brackets from Iri to make it a valid URL
            }
        });
        var selbox = $('<span>', attr).insertBefore(ele.find('.entrySep'));
        
        selbox.selection('edit', {
            selection_id: selection_id
        });
    });

This makes me worried about the other cases where some extra computation is done before calling `create_entry`, namely `radio` and `hlist`.

Fixes #441.