### PR TITLE
fix (docs): Revert to haiku theme to fix search (#470).

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,7 +111,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'agogo'
+html_theme = 'haiku'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This attempts to fix search on knora.org by switching back from the `agogo` theme (which looks much better) to the `haiku` theme (which is ugly IMHO but was working before).