### PR TITLE
Sipi login/logout

### DIFF
--- a/salsah/src/public/index.html
+++ b/salsah/src/public/index.html
@@ -216,6 +216,8 @@
 					$.ajax({
 						url: SIPI_URL + SIPI_LOGIN_ROUTE,
 						type: "POST",
+						contentType: "application/x-www-form-urlencoded; charset=UTF-8",
+						dataType: "text", // response is empty, but without explicit content-type jQuery tries to parse the answer as XML
 						data: {
 							sid: data.sid
 						},
@@ -279,6 +281,7 @@
 						xhrFields: {
 							withCredentials: true
 						},
+						dataType: "text", // response is empty, but without explicit content-type jQuery tries to parse the answer as XML
 						error: function(jqXHR, textStatus, errorThrown) {
 							if (errorThrown !== undefined) {
 								alert("Sipi returned an error: " + errorThrown);


### PR DESCRIPTION
expect content-type text from sipi on login and logout (SALSAH GUI) 

Firefox (because of jQuery) attempted to parse the empty answer as XML, resulting in an error

see https://github.com/dhlab-basel/Sipi/pull/148#issuecomment-289013080