### PR TITLE
refactor (webapi): authentication

### DIFF
--- a/webapi/WebapiBuild.sbt
+++ b/webapi/WebapiBuild.sbt
@@ -133,6 +133,7 @@ lazy val webApiLibs = Seq(
     // authentication
     "org.bouncycastle" % "bcprov-jdk15on" % "1.56",
     "org.springframework.security" % "spring-security-core" % "4.2.1.RELEASE",
+    //"io.igl" %% "jwt" % "1.2.0",
     // caching
     "net.sf.ehcache" % "ehcache" % "2.10.0",
     // monitoring - disabled for now

--- a/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
@@ -25,7 +25,11 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{HttpCookie, HttpCookiePair}
-import akka.http.scaladsl.server.RequestContext
+import akka.http.scaladsl.server.AuthenticationFailedRejection.CredentialsMissing
+import akka.http.scaladsl.server.directives.BasicDirectives.{extractExecutionContext, provide}
+import akka.http.scaladsl.server.directives.RouteDirectives.reject
+import akka.http.scaladsl.server.directives.{AuthenticationDirective, BasicDirectives, Credentials, RouteDirectives}
+import akka.http.scaladsl.server.{AuthenticationFailedRejection, Directive1, RequestContext, Route}
 import akka.pattern._
 import akka.util.{ByteString, Timeout}
 import com.typesafe.scalalogging.Logger
@@ -37,12 +41,34 @@ import org.slf4j.LoggerFactory
 import spray.json.{JsNumber, JsObject, JsString}
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Success, Try}
 
 
 // needs Java 1.8 !!!
 import java.util.Base64
+
+
+trait KnoraSecurityDirectives extends Authenticator{
+
+
+
+    def authenticate[T]: Directive1[T] =
+        extractExecutionContext.flatMap { implicit ec =>
+
+        }
+}
+
+trait KnoraAuthenticationDirective[T] extends Directive1[T] {
+
+}
+object KnoraAuthenticationDirective {
+    implicit def apply[T](other: Directive1[T]): KnoraAuthenticationDirective[T] =
+        new KnoraAuthenticationDirective[T] { def tapply(inner: Tuple1[T] ⇒ Route) = other.tapply(inner) }
+}
+
+
+
 
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/UsersRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/UsersRouteV1.scala
@@ -25,13 +25,13 @@ import akka.http.scaladsl.server.Route
 import org.apache.commons.validator.routines.UrlValidator
 import org.knora.webapi._
 import org.knora.webapi.messages.v1.responder.usermessages._
-import org.knora.webapi.routing.{Authenticator, RouteUtilV1}
+import org.knora.webapi.routing.{KnoraSecurityDirectives, _}
 import org.knora.webapi.util.InputValidation
 
 /**
   * Provides a spray-routing function for API routes that deal with lists.
   */
-object UsersRouteV1 extends Authenticator {
+object UsersRouteV1 extends KnoraSecurityDirectives {
 
     /* bring json protocol into scope */
     import UserV1JsonProtocol._
@@ -49,8 +49,8 @@ object UsersRouteV1 extends Authenticator {
 
         path("v1" / "users" / "iri" / Segment) {value =>
             get {
-                requestContext =>
-                    val userProfile = getUserProfileV1(requestContext)
+                requestContext => authenticate[UserProfileV1] { userProfile =>
+                    //val userProfile = getUserProfileV1(requestContext)
                     val userIri = InputValidation.toIri(value, () => throw BadRequestException(s"Invalid user IRI $value"))
                     val requestMessage = UserProfileByIRIGetRequestV1(userIri, UserProfileType.RESTRICTED, userProfile)
                     RouteUtilV1.runJsonRoute(
@@ -60,6 +60,7 @@ object UsersRouteV1 extends Authenticator {
                         responderManager,
                         log
                     )
+                }
             }
         } ~
         path("v1" / "users" / "email" / Segment) {value =>


### PR DESCRIPTION
### Summary

- Add support for different UserProfile versions, e.g. `UserProfileV1`, `UserProfileV2`, etc.
- Add support for authentication using JSON Web Token

### Issues

 - resolves #171