### PR TITLE
Release IRI lock if a task throws an exception instead of returning a Future

### DIFF
--- a/webapi/src/test/scala/org/knora/webapi/responders/IriLockerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/IriLockerSpec.scala
@@ -1,0 +1,167 @@
+package org.knora.webapi.responders
+
+import java.util.UUID
+
+import org.knora.webapi.{ApplicationLockException, IRI}
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+
+/**
+  * Tests [[IriLocker]].
+  */
+class IriLockerSpec extends WordSpec with Matchers {
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val SUCCESS = "success"
+    val FAILURE = "failure"
+
+    "IriLocker" should {
+        "not allow a request to acquire a lock when another request already has it" in {
+            def runLongTask(): Future[String] = Future {
+                Thread.sleep(3000)
+                SUCCESS
+            }
+
+            def runShortTask(): Future[String] = Future(SUCCESS)
+
+            val testIri: IRI = "http://example.org/test1"
+
+            val firstApiRequestID = UUID.randomUUID
+
+            IriLocker.runWithIriLock(
+                apiRequestID = firstApiRequestID,
+                iri = testIri,
+                task = () => runLongTask()
+            )
+
+            // Wait a bit to allow the first request to get the lock.
+            Thread.sleep(500)
+
+            val secondApiRequestID = UUID.randomUUID
+
+            val secondTaskResultFuture = IriLocker.runWithIriLock(
+                apiRequestID = secondApiRequestID,
+                iri = testIri,
+                task = () => runShortTask()
+            )
+
+            val secondTaskFailedWithLockTimeout = try {
+                Await.result(secondTaskResultFuture, 3.seconds)
+                false
+            } catch {
+                case ale: ApplicationLockException => true
+            }
+
+            assert(secondTaskFailedWithLockTimeout,"Second task did not get a lock timeout")
+        }
+
+        "provide reentrant locks" in {
+            def runRecursiveTask(iri: IRI, apiRequestID: UUID, count: Int): Future[String] = {
+                if (count > 0) {
+                    IriLocker.runWithIriLock(
+                        apiRequestID = apiRequestID,
+                        iri = iri,
+                        task = () => runRecursiveTask(iri, apiRequestID, count - 1)
+                    )
+                } else {
+                    Future(SUCCESS)
+                }
+            }
+
+            val testIri: IRI = "http://example.org/test2"
+
+            val firstApiRequestID = UUID.randomUUID
+            val firstTestResult = Await.result(runRecursiveTask(testIri, firstApiRequestID, 3), 1.second)
+            assert(firstTestResult == SUCCESS)
+            val secondApiRequestID = UUID.randomUUID
+            val secondTestResult = Await.result(runRecursiveTask(testIri, secondApiRequestID, 3), 1.second)
+            assert(secondTestResult == SUCCESS)
+        }
+
+        "release a lock when a task returns a failed future" in {
+            // If succeed is true, returns a successful future, otherwise returns a failed future.
+            def runTask(succeed: Boolean): Future[String] = Future {
+                if (succeed) {
+                    SUCCESS
+                } else {
+                    throw new Exception(FAILURE)
+                }
+            }
+
+            val testIri: IRI = "http://example.org/test3"
+
+            val firstApiRequestID = UUID.randomUUID
+
+            val firstTaskResultFuture = IriLocker.runWithIriLock(
+                apiRequestID = firstApiRequestID,
+                iri = testIri,
+                task = () => runTask(false)
+            )
+
+            val firstTaskFailed = try {
+                Await.result(firstTaskResultFuture, 1.second)
+                false
+            } catch {
+                case e: Exception => true
+            }
+
+            assert(firstTaskFailed, "First task did not fail")
+
+            val secondApiRequestID = UUID.randomUUID
+
+            val secondTaskResultFuture = IriLocker.runWithIriLock(
+                apiRequestID = secondApiRequestID,
+                iri = testIri,
+                task = () => runTask(true)
+            )
+
+            val secondTaskResult = Await.result(secondTaskResultFuture, 1.second)
+
+            assert(secondTaskResult == SUCCESS, "Second task did not succeed")
+        }
+
+        "release a lock when a task throws an exception instead of returning a future" in {
+            // If succeed is true, returns a successful future, otherwise throws an exception.
+            def runTask(succeed: Boolean): Future[String] = {
+                if (succeed) {
+                    Future(SUCCESS)
+                } else {
+                    throw new Exception(FAILURE)
+                }
+            }
+
+            val testIri: IRI = "http://example.org/test4"
+
+            val firstApiRequestID = UUID.randomUUID
+
+            val firstTaskResultFuture = IriLocker.runWithIriLock(
+                apiRequestID = firstApiRequestID,
+                iri = testIri,
+                task = () => runTask(false)
+            )
+
+            val firstTaskFailed = try {
+                Await.result(firstTaskResultFuture, 1.second)
+                false
+            } catch {
+                case e: Exception => true
+            }
+
+            assert(firstTaskFailed, "First task did not fail")
+
+            val secondApiRequestID = UUID.randomUUID
+
+            val secondTaskResultFuture = IriLocker.runWithIriLock(
+                apiRequestID = secondApiRequestID,
+                iri = testIri,
+                task = () => runTask(true)
+            )
+
+            val secondTaskResult = Await.result(secondTaskResultFuture, 1.second)
+
+            assert(secondTaskResult == SUCCESS, "Second task did not succeed")
+        }
+    }
+}

--- a/webapi/src/test/scala/org/knora/webapi/responders/IriLockerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/IriLockerSpec.scala
@@ -5,13 +5,14 @@ import java.util.UUID
 import org.knora.webapi.{ApplicationLockException, IRI}
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
 /**
   * Tests [[IriLocker]].
   */
 class IriLockerSpec extends WordSpec with Matchers {
+
     import scala.concurrent.ExecutionContext.Implicits.global
 
     val SUCCESS = "success"
@@ -20,7 +21,7 @@ class IriLockerSpec extends WordSpec with Matchers {
     "IriLocker" should {
         "not allow a request to acquire a lock when another request already has it" in {
             def runLongTask(): Future[String] = Future {
-                Thread.sleep(3000)
+                Thread.sleep(3500)
                 SUCCESS
             }
 
@@ -37,7 +38,7 @@ class IriLockerSpec extends WordSpec with Matchers {
             )
 
             // Wait a bit to allow the first request to get the lock.
-            Thread.sleep(500)
+            Thread.sleep(200)
 
             val secondApiRequestID = UUID.randomUUID
 
@@ -54,7 +55,7 @@ class IriLockerSpec extends WordSpec with Matchers {
                 case ale: ApplicationLockException => true
             }
 
-            assert(secondTaskFailedWithLockTimeout,"Second task did not get a lock timeout")
+            assert(secondTaskFailedWithLockTimeout, "Second task did not get a lock timeout")
         }
 
         "provide reentrant locks" in {


### PR DESCRIPTION
If the task passed to `IriLocker.runWithIriLock` handled an error by throwing an exception instead of by returning a failed `Future`, the lock would not be released. This fixes `IriLocker` so it releases the lock in that case, and adds some tests.

Please try this `IriLocker` on your branch and let me know if it fixes the problem you saw.