### PR TITLE
missing to check the Rights.RESOURCE_ACCESS_DELETE value

### DIFF
--- a/salsah/src/public/js/02_searchlist.js
+++ b/salsah/src/public/js/02_searchlist.js
@@ -26,6 +26,8 @@
 */
 SALSAH.searchlist = function(ele, pele, data, params, searchtype) {
 
+	var defaultresicon = "app/icons/16x16/help.png";
+
 	//
 	// Create the paging
 	//
@@ -286,8 +288,9 @@ SALSAH.searchlist = function(ele, pele, data, params, searchtype) {
 						}))
 				);
 				tr.append($('<td>')
-						.append($('<img>').attr({src: arrele.iconsrc, title: arrele.icontitle}))
-						.append(arrele.iconlabel)
+					.append($('<img>').attr({src: arrele.iconsrc? arrele.iconsrc : defaultresicon, title: arrele.icontitle}))
+					.append(arrele.iconlabel)
+					.dragndrop('makeDraggable', 'RESID', {resid: arrele.obj_id})
 				);
 				var idx;
 				if (arrele.value.length > max_n_vals) max_n_vals = arrele.value.length;

--- a/salsah/src/public/js/imagebase.js
+++ b/salsah/src/public/js/imagebase.js
@@ -17,6 +17,8 @@
 
 $(function() {
 
+	var defaultresicon = "app/icons/16x16/help.png"
+
 	//var metadataAreaDomCreate = function(topele, winid, tabid, regnum, resource)
 	var metadataAreaDomCreate = function(topele, resource, options)
 	{
@@ -37,13 +39,12 @@ $(function() {
 		{
             //debugger;
 			propedit = $('<div>').addClass('propedit');
-			if (resource.resinfo.restype_iconsrc)
-			{
-				propedit
-				.append(
-					$('<img>').attr({src: resource.resinfo.restype_iconsrc, title: 'DRAG TO DESTINATION'}).addClass('propedit resicon').dragndrop('makeDraggable', 'RESID', {resid: resource.resdata.res_id})
-				);
-			}
+			propedit.append(
+				$('<img>')
+					.attr({src: resource.resinfo.restype_iconsrc ? resource.resinfo.restype_iconsrc : defaultresicon, title: 'DRAG TO DESTINATION'})
+					.addClass('propedit resicon')
+					.dragndrop('makeDraggable', 'RESID', {resid: resource.resdata.res_id})
+			);
 			propedit.append($('<em>').attr({title: 'resource_id=' + resource.resdata.res_id + ' person_id=' + resource.resinfo.person_id + ' lastmod=' + resource.resinfo.lastmod}).addClass('propedit label').text(resource.resinfo.restype_label + ':'));
 
 			propedit.append('&nbsp;&nbsp;');

--- a/salsah/src/public/js/imagebase.js
+++ b/salsah/src/public/js/imagebase.js
@@ -409,7 +409,7 @@ $(function() {
                     break;
                 }
                 case Rights.RESOURCE_ACCESS_MODIFY:
-                case Rights.VALUE_ACCESS_DELETE:
+                case Rights.RESOURCE_ACCESS_DELETE:
                 case Rights.RESOURCE_ACCESS_RIGHTS: {
                     rights = Rights.VALUE_ACCESS_MODIFY;
                     break;


### PR DESCRIPTION
fixes #492

this one was hard to find!

But in the end it is just a typo.

When the rights are set to 7, `aka Rights.RESOURCE_ACCESS_DELETE`, then the test doesn't recognize it (`Rights.VALUE_ACCESS_DELETE` = 4) and assigns the translated rights `Rights.VALUE_ACCESS_NONE`

```js

            switch (data.resdata.rights) {
                case Rights.RESOURCE_ACCESS_NONE: {
                    rights = Rights.VALUE_ACCESS_NONE;
                    break;
                }
                case Rights.RESOURCE_ACCESS_VIEW_RESTRICTED:
                case Rights.RESOURCE_ACCESS_VIEW: {
                    rights = Rights.VALUE_ACCESS_VIEW;
                    break;
                }
                case Rights.RESOURCE_ACCESS_ANNOTATE:
                case Rights.RESOURCE_ACCESS_EXTEND:
                case Rights.RESOURCE_ACCESS_OVERRIDE: {
                    rights = Rights.VALUE_ACCESS_ANNOTATE;
                    break;
                }
                case Rights.RESOURCE_ACCESS_MODIFY:
                case Rights.VALUE_ACCESS_DELETE:
                case Rights.RESOURCE_ACCESS_RIGHTS: {
                    rights = Rights.VALUE_ACCESS_MODIFY;
                    break;
                }
                default: {
                    rights = Rights.VALUE_ACCESS_NONE;
                }
            }
```