### PR TITLE
build (travis): fix build after travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
+dist: trusty
 sudo: required
 git:
-    depth: 5
+    depth: 1
 language: scala
 scala:
-- 2.11.7
+- 2.12.1
 jdk:
 - oraclejdk8
 cache:


### PR DESCRIPTION
### Summary

Travis-ci.org upgraded their base image used for running automated tests. This somehow broke our builds. After changing the config to use their newest image, builds are working again.

### Issues

Resolves #504 