### PR TITLE
assigning a class to the box poping out to create a new entry (linked…

### DIFF
--- a/salsah/src/public/js/jquery.searchbox.js
+++ b/salsah/src/public/js/jquery.searchbox.js
@@ -48,6 +48,7 @@
 					}
 				});
 				var content = localdata.ele.sel.dialog('content');
+				content.addClass('propedit_frame');
 				if (localdata.settings.restype_id == -1) {
 					content.resadd({
 						on_submit_cb: function(data) {


### PR DESCRIPTION
… object)

fixes #413

The problem was not the computation of the position of the new box but the origin it was computing from.
When opening the new pop-up window, we missed to assign it with the class attribute `propedit_frame` this the searchbox element search for as its origin position.

So it was related to the previous `propedit_frame` and was not able to shift it position according to the scroll bar of the second pop-up window.