### PR TITLE
Add an untyped key-value store backed by the triplestore

### DIFF
--- a/knora-ontologies/knora-admin.ttl
+++ b/knora-ontologies/knora-admin.ttl
@@ -436,11 +436,11 @@
 
 :isInMap rdf:type owl:ObjectProperty ;
 
-    rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
+    rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
 
-    knora-base:subjectClassConstraint :MapEntry;
+    :subjectClassConstraint :MapEntry;
 
-    knora-base:objectClassConstraint :Map ;
+    :objectClassConstraint :Map ;
 
     rdfs:comment "Associates a MapEntry with a Map"@en .
 
@@ -448,11 +448,11 @@
 
 :mapEntryKey rdf:type owl:DatatypeProperty ;
 
-    rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
+    rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
 
-    knora-base:subjectClassConstraint :MapEntry;
+    :subjectClassConstraint :MapEntry;
 
-    knora-base:objectDatatypeConstraint xsd:string ;
+    :objectDatatypeConstraint xsd:string ;
 
     rdfs:comment "Represents the key of a MapEntry"@en .
 
@@ -460,11 +460,11 @@
 
 :mapEntryValue rdf:type owl:DatatypeProperty ;
 
-    rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
+    rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
 
-    knora-base:subjectClassConstraint :MapEntry;
+    :subjectClassConstraint :MapEntry;
 
-    knora-base:objectDatatypeConstraint xsd:string ;
+    :objectDatatypeConstraint xsd:string ;
 
     rdfs:comment "Represents the value of a MapEntry"@en .
 
@@ -638,7 +638,7 @@
 :Map rdf:type owl:Class ;
 
     rdfs:subClassOf [ rdf:type owl:Restriction ;
-                      owl:onProperty knora-base:lastModificationDate ;
+                      owl:onProperty :lastModificationDate ;
                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
                     ] ;
 
@@ -661,7 +661,7 @@
                       owl:cardinality "1"^^xsd:nonNegativeInteger
                     ],
                     [ rdf:type owl:Restriction ;
-                      owl:onProperty knora-base:lastModificationDate ;
+                      owl:onProperty :lastModificationDate ;
                       owl:cardinality "1"^^xsd:nonNegativeInteger
                     ];
 

--- a/knora-ontologies/knora-admin.ttl
+++ b/knora-ontologies/knora-admin.ttl
@@ -434,6 +434,42 @@
 
 
 
+:isInMap rdf:type owl:ObjectProperty ;
+
+    rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
+
+    knora-base:subjectClassConstraint :MapEntry;
+
+    knora-base:objectClassConstraint :Map ;
+
+    rdfs:comment "Associates a MapEntry with a Map"@en .
+
+
+
+:mapEntryKey rdf:type owl:DatatypeProperty ;
+
+    rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
+
+    knora-base:subjectClassConstraint :MapEntry;
+
+    knora-base:objectDatatypeConstraint xsd:string ;
+
+    rdfs:comment "Represents the key of a MapEntry"@en .
+
+
+
+:mapEntryValue rdf:type owl:DatatypeProperty ;
+
+    rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
+
+    knora-base:subjectClassConstraint :MapEntry;
+
+    knora-base:objectDatatypeConstraint xsd:string ;
+
+    rdfs:comment "Represents the value of a MapEntry"@en .
+
+
+
 #################################################################
 #
 #    Classes
@@ -596,6 +632,40 @@
                               ] ;
 
               rdfs:comment "Represents a project that uses Knora"@en .
+
+
+
+:Map rdf:type owl:Class ;
+
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                      owl:onProperty knora-base:lastModificationDate ;
+                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                    ] ;
+
+    rdfs:comment "Represents a simple map of key-value pairs"@en .
+
+
+
+:MapEntry rdf:type owl:Class ;
+
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                      owl:onProperty :isInMap ;
+                      owl:cardinality "1"^^xsd:nonNegativeInteger
+                    ],
+                    [ rdf:type owl:Restriction ;
+                      owl:onProperty :mapEntryKey ;
+                      owl:cardinality "1"^^xsd:nonNegativeInteger
+                    ],
+                    [ rdf:type owl:Restriction ;
+                      owl:onProperty :mapEntryValue ;
+                      owl:cardinality "1"^^xsd:nonNegativeInteger
+                    ],
+                    [ rdf:type owl:Restriction ;
+                      owl:onProperty knora-base:lastModificationDate ;
+                      owl:cardinality "1"^^xsd:nonNegativeInteger
+                    ];
+
+    rdfs:comment "Represents a key-value pair in a Map"@en .
 
 
 

--- a/knora-ontologies/knora-base.ttl
+++ b/knora-ontologies/knora-base.ttl
@@ -896,7 +896,7 @@
 
               :subjectClassConstraint :Resource ;
 
-              :objectDatatypeConstraint xsd:dateTimeStamp .
+              :objectDatatypeConstraint xsd:dateTime .
 
 
 
@@ -910,7 +910,7 @@
 
             # No :subjectClassConstraint, because this can be used with :Resource or :Value.
 
-            :objectDatatypeConstraint xsd:dateTimeStamp .
+            :objectDatatypeConstraint xsd:dateTime .
 
 
 
@@ -1100,9 +1100,7 @@
 
                       rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
 
-                      :subjectClassConstraint :Resource ;
-
-                      :objectDatatypeConstraint xsd:dateTimeStamp .
+                      :objectDatatypeConstraint xsd:dateTime .
 
 
 
@@ -1202,7 +1200,7 @@
 
                    rdfs:subPropertyOf :valueHas ;
 
-                   :objectDatatypeConstraint xsd:dateTimeStamp .
+                   :objectDatatypeConstraint xsd:dateTime .
 
 
 

--- a/webapi/src/main/twirl/queries/sparql/v1/createMap.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/createMap.scala.txt
@@ -21,7 +21,7 @@
 @import org.knora.webapi.IRI
 
 @*
- * Creates a new knora-admin:Map. If the map already exists, this update does nothing.
+ * Creates a new knora-base:Map. If the map already exists, this update does nothing.
  *
  * @param triplestore the name of the triplestore being used.
  * @param mapNamedGraphIri the IRI of the named graph where Maps are stored.
@@ -36,11 +36,10 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
 
 INSERT {
     GRAPH ?mapNamedGraph {
-        ?map rdf:type knora-admin:Map ;
+        ?map rdf:type knora-base:Map ;
             knora-base:lastModificationDate ?currentTime .
     }
 }

--- a/webapi/src/main/twirl/queries/sparql/v1/createMap.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/createMap.scala.txt
@@ -1,0 +1,59 @@
+@*
+ * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ *@
+
+@import org.knora.webapi.IRI
+
+@*
+ * Creates a new knora-admin:Map. If the map already exists, this update does nothing.
+ *
+ * @param triplestore the name of the triplestore being used.
+ * @param mapNamedGraphIri the IRI of the named graph where Maps are stored.
+ * @param mapIri: the IRI of the Map to be created.
+ *@
+@(triplestore: String,
+  mapNamedGraphIri: IRI,
+  mapIri: IRI)
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+
+INSERT {
+    GRAPH ?mapNamedGraph {
+        ?map rdf:type knora-admin:Map ;
+            knora-base:lastModificationDate ?currentTime .
+    }
+}
+@* Ensure that inference is not used in the WHERE clause of this update. *@
+@if(triplestore.startsWith("graphdb")) {
+    USING <http://www.ontotext.com/explicit>
+}
+WHERE {
+    BIND(IRI("@mapNamedGraphIri") AS ?mapNamedGraph)
+    BIND(IRI("@mapIri") AS ?map)
+    BIND(NOW() AS ?currentTime)
+
+    FILTER NOT EXISTS {
+        ?map rdf:type ?existingMapType .
+    }
+}

--- a/webapi/src/main/twirl/queries/sparql/v1/createNewResources.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/createNewResources.scala.txt
@@ -79,5 +79,11 @@ WHERE {
         BIND(str("@res.resourceLabel") AS ?label@res.resourceIndex)
 
         @res.generateSparqlForValuesResponse.whereSparql
+
+        @* Check that the resource doesn't already exist. *@
+
+        FILTER NOT EXISTS {
+            ?resource@res.resourceIndex rdf:type ?existingResourceType@res.resourceIndex .
+        }
     }
 }

--- a/webapi/src/main/twirl/queries/sparql/v1/deleteMapEntry.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/deleteMapEntry.scala.txt
@@ -1,0 +1,66 @@
+@*
+ * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ *@
+
+@import org.knora.webapi.IRI
+
+@**
+ * Deletes an entry in a knora-admin:Map.
+ *
+ * @param triplestore the name of the triplestore being used.
+ * @param mapNamedGraphIri the IRI of the named graph where Maps are stored.
+ * @param mapIri the IRI of the knora-admin:Map in which entries are to be deleted.
+ *@
+@(triplestore: String,
+  mapNamedGraphIri: IRI,
+  mapIri: IRI,
+  mapEntryKey: String)
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+
+DELETE {
+    GRAPH ?dataNamedGraph {
+        ?mapEntry rdf:type knora-admin:MapEntry ;
+            knora-admin:isInMap ?map ;
+            knora-admin:mapEntryKey """@mapEntryKey"""^^xsd:string ;
+            knora-admin:mapEntryValue ?mapEntryValue ;
+            knora-base:lastModificationDate ?mapEntryLastModificationDate .
+    }
+}
+@* Ensure that inference is not used in the WHERE clause of this update. *@
+@if(triplestore.startsWith("graphdb")) {
+    USING <http://www.ontotext.com/explicit>
+}
+WHERE {
+    BIND(IRI("@mapNamedGraphIri") AS ?mapNamedGraph)
+    BIND(IRI("@mapIri") AS ?map)
+
+    ?map rdf:type knora-admin:Map .
+
+    ?mapEntry rdf:type knora-admin:MapEntry ;
+        knora-admin:isInMap ?map ;
+        knora-admin:mapEntryKey """@mapEntryKey"""^^xsd:string ;
+        knora-admin:mapEntryValue ?mapEntryValue ;
+        knora-base:lastModificationDate ?mapEntryLastModificationDate .
+}

--- a/webapi/src/main/twirl/queries/sparql/v1/deleteMapEntry.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/deleteMapEntry.scala.txt
@@ -21,11 +21,11 @@
 @import org.knora.webapi.IRI
 
 @**
- * Deletes an entry in a knora-admin:Map.
+ * Deletes an entry in a knora-base:Map.
  *
  * @param triplestore the name of the triplestore being used.
  * @param mapNamedGraphIri the IRI of the named graph where Maps are stored.
- * @param mapIri the IRI of the knora-admin:Map in which entries are to be deleted.
+ * @param mapIri the IRI of the knora-base:Map in which entries are to be deleted.
  *@
 @(triplestore: String,
   mapNamedGraphIri: IRI,
@@ -37,14 +37,13 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
 
 DELETE {
     GRAPH ?dataNamedGraph {
-        ?mapEntry rdf:type knora-admin:MapEntry ;
-            knora-admin:isInMap ?map ;
-            knora-admin:mapEntryKey """@mapEntryKey"""^^xsd:string ;
-            knora-admin:mapEntryValue ?mapEntryValue ;
+        ?mapEntry rdf:type knora-base:MapEntry ;
+            knora-base:isInMap ?map ;
+            knora-base:mapEntryKey """@mapEntryKey"""^^xsd:string ;
+            knora-base:mapEntryValue ?mapEntryValue ;
             knora-base:lastModificationDate ?mapEntryLastModificationDate .
     }
 }
@@ -56,11 +55,11 @@ WHERE {
     BIND(IRI("@mapNamedGraphIri") AS ?mapNamedGraph)
     BIND(IRI("@mapIri") AS ?map)
 
-    ?map rdf:type knora-admin:Map .
+    ?map rdf:type knora-base:Map .
 
-    ?mapEntry rdf:type knora-admin:MapEntry ;
-        knora-admin:isInMap ?map ;
-        knora-admin:mapEntryKey """@mapEntryKey"""^^xsd:string ;
-        knora-admin:mapEntryValue ?mapEntryValue ;
+    ?mapEntry rdf:type knora-base:MapEntry ;
+        knora-base:isInMap ?map ;
+        knora-base:mapEntryKey """@mapEntryKey"""^^xsd:string ;
+        knora-base:mapEntryValue ?mapEntryValue ;
         knora-base:lastModificationDate ?mapEntryLastModificationDate .
 }

--- a/webapi/src/main/twirl/queries/sparql/v1/deleteOldEmptyMaps.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/deleteOldEmptyMaps.scala.txt
@@ -21,7 +21,7 @@
 @import org.knora.webapi.IRI
 
 @**
- * Deletes old, empty knora-admin:Map instances, along with all their entries.
+ * Deletes old, empty knora-base:Map instances, along with all their entries.
  *
  * @param triplestore the name of the triplestore being used.
  * @param mapNamedGraphIri the IRI of the named graph where Maps are stored.
@@ -37,11 +37,10 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
 
 DELETE {
     GRAPH ?dataNamedGraph {
-        ?map rdf:type knora-admin:Map ;
+        ?map rdf:type knora-base:Map ;
             knora-base:lastModificationDate ?mapLastModificationDate .
     }
 }
@@ -52,11 +51,11 @@ DELETE {
 WHERE {
     BIND(IRI("@mapNamedGraphIri") AS ?mapNamedGraph)
 
-    ?map rdf:type knora-admin:Map ;
+    ?map rdf:type knora-base:Map ;
         knora-base:lastModificationDate ?mapLastModificationDate .
 
     FILTER NOT EXISTS {
-        ?mapEntry knora-admin:isInMap ?map .
+        ?mapEntry knora-base:isInMap ?map .
     }
 
     FILTER(?mapLastModificationDate < "@oldestDateTimeToKeep"^^xsd:dateTime)

--- a/webapi/src/main/twirl/queries/sparql/v1/deleteOldEmptyMaps.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/deleteOldEmptyMaps.scala.txt
@@ -1,0 +1,63 @@
+@*
+ * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ *@
+
+@import org.knora.webapi.IRI
+
+@**
+ * Deletes old, empty knora-admin:Map instances, along with all their entries.
+ *
+ * @param triplestore the name of the triplestore being used.
+ * @param mapNamedGraphIri the IRI of the named graph where Maps are stored.
+ * @param oldestDateTimeToKeep an xsd:dateTime. Maps that contain no entries, and whose knora-base:lastModificationDate
+ * is earlier than this, will be deleted.
+ *@
+@(triplestore: String,
+  mapNamedGraphIri: IRI,
+  oldestDateTimeToKeep: String)
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+
+DELETE {
+    GRAPH ?dataNamedGraph {
+        ?map rdf:type knora-admin:Map ;
+            knora-base:lastModificationDate ?mapLastModificationDate .
+    }
+}
+@* Ensure that inference is not used in the WHERE clause of this update. *@
+@if(triplestore.startsWith("graphdb")) {
+    USING <http://www.ontotext.com/explicit>
+}
+WHERE {
+    BIND(IRI("@mapNamedGraphIri") AS ?mapNamedGraph)
+
+    ?map rdf:type knora-admin:Map ;
+        knora-base:lastModificationDate ?mapLastModificationDate .
+
+    FILTER NOT EXISTS {
+        ?mapEntry knora-admin:isInMap ?map .
+    }
+
+    FILTER(?mapLastModificationDate < "@oldestDateTimeToKeep"^^xsd:dateTime)
+}

--- a/webapi/src/main/twirl/queries/sparql/v1/deleteOldMapEntries.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/deleteOldMapEntries.scala.txt
@@ -1,0 +1,67 @@
+@*
+ * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ *@
+
+@import org.knora.webapi.IRI
+
+@**
+ * Deletes old map entries. Does not update the last modification date of the maps in which these entries were found.
+ *
+ * @param triplestore the name of the triplestore being used.
+ * @param mapNamedGraphIri the IRI of the named graph where Maps are stored.
+ * @param oldestDateTimeToKeep an xsd:dateTime. MapEntry objects whose knora-base:lastModificationDate is earlier
+ * than this will be deleted.
+ *@
+@(triplestore: String,
+  mapNamedGraphIri: IRI,
+  oldestDateTimeToKeep: String)
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+
+DELETE {
+    GRAPH ?dataNamedGraph {
+        ?mapEntry rdf:type knora-admin:MapEntry ;
+            knora-admin:isInMap ?map ;
+            knora-admin:mapEntryKey ?mapEntryKey ;
+            knora-admin:mapEntryValue ?mapEntryValue ;
+            knora-base:lastModificationDate ?mapEntryLastModificationDate .
+    }
+}
+@* Ensure that inference is not used in the WHERE clause of this update. *@
+@if(triplestore.startsWith("graphdb")) {
+    USING <http://www.ontotext.com/explicit>
+}
+WHERE {
+    BIND(IRI("@mapNamedGraphIri") AS ?mapNamedGraph)
+
+    ?map rdf:type knora-admin:Map .
+
+    ?mapEntry rdf:type knora-admin:MapEntry ;
+        knora-admin:isInMap ?map ;
+        knora-admin:mapEntryKey ?mapEntryKey ;
+        knora-admin:mapEntryValue ?mapEntryValue ;
+        knora-base:lastModificationDate ?mapEntryLastModificationDate .
+
+    FILTER(?mapEntryLastModificationDate < "@oldestDateTimeToKeep"^^xsd:dateTime)
+}

--- a/webapi/src/main/twirl/queries/sparql/v1/getMapEntries.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getMapEntries.scala.txt
@@ -21,16 +21,14 @@
 @import org.knora.webapi.IRI
 
 @**
- * Deletes old map entries. Does not update the last modification date of the maps in which these entries were found.
+ * Given the IRI of a knora-base:Map, returns the all entries in the map.
  *
  * @param triplestore the name of the triplestore being used.
- * @param mapNamedGraphIri the IRI of the named graph where Maps are stored.
- * @param oldestDateTimeToKeep an xsd:dateTime. MapEntry objects whose knora-base:lastModificationDate is earlier
- * than this will be deleted.
+ * @param mapIri the IRI of the knora-base:Map.
+ * @param mapEntryKey the key of the knora-base:MapEntry.
  *@
 @(triplestore: String,
-  mapNamedGraphIri: IRI,
-  oldestDateTimeToKeep: String)
+  mapIri: IRI)
 
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -38,29 +36,17 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
 
-DELETE {
-    GRAPH ?dataNamedGraph {
-        ?mapEntry rdf:type knora-base:MapEntry ;
-            knora-base:isInMap ?map ;
-            knora-base:mapEntryKey ?mapEntryKey ;
-            knora-base:mapEntryValue ?mapEntryValue ;
-            knora-base:lastModificationDate ?mapEntryLastModificationDate .
-    }
-}
-@* Ensure that inference is not used in the WHERE clause of this update. *@
+SELECT ?mapEntryKey ?mapEntryValue
+@* Ensure that inference is not used in this query. *@
 @if(triplestore.startsWith("graphdb")) {
-    USING <http://www.ontotext.com/explicit>
+    FROM <http://www.ontotext.com/explicit>
 }
 WHERE {
-    BIND(IRI("@mapNamedGraphIri") AS ?mapNamedGraph)
+    BIND(IRI("@mapIri") as ?map)
 
-    ?map rdf:type knora-base:Map .
+    ?map a knora-base:Map .
 
-    ?mapEntry rdf:type knora-base:MapEntry ;
-        knora-base:isInMap ?map ;
+    ?mapEntry knora-base:isInMap ?map ;
         knora-base:mapEntryKey ?mapEntryKey ;
-        knora-base:mapEntryValue ?mapEntryValue ;
-        knora-base:lastModificationDate ?mapEntryLastModificationDate .
-
-    FILTER(?mapEntryLastModificationDate < "@oldestDateTimeToKeep"^^xsd:dateTime)
+        knora-base:mapEntryValue ?mapEntryValue .
 }

--- a/webapi/src/main/twirl/queries/sparql/v1/getMapEntryValue.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getMapEntryValue.scala.txt
@@ -1,0 +1,54 @@
+@*
+ * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ *@
+
+@import org.knora.webapi.IRI
+
+@**
+ * Given the IRI of a knora-admin:Map and the key of a knora-admin:MapEntry, returns the value of the map entry.
+ *
+ * @param triplestore the name of the triplestore being used.
+ * @param mapIri the IRI of the knora-admin:Map.
+ * @param mapEntryKey the key of the knora-admin:MapEntry.
+ *@
+@(triplestore: String,
+  mapIri: IRI,
+  mapEntryKey: String)
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+
+SELECT ?mapEntryValue
+@* Ensure that inference is not used in this query. *@
+@if(triplestore.startsWith("graphdb")) {
+    FROM <http://www.ontotext.com/explicit>
+}
+WHERE {
+    BIND(IRI("@mapIri") as ?map)
+
+    ?map a knora-admin:Map .
+
+    ?mapEntry knora-admin:isInMap ?map ;
+        knora-admin:mapEntryKey """@mapEntryKey""^^xsd:string ;
+        knora-admin:mapEntryValue ?mapEntryValue .
+}

--- a/webapi/src/main/twirl/queries/sparql/v1/getMapEntryValue.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getMapEntryValue.scala.txt
@@ -21,11 +21,11 @@
 @import org.knora.webapi.IRI
 
 @**
- * Given the IRI of a knora-admin:Map and the key of a knora-admin:MapEntry, returns the value of the map entry.
+ * Given the IRI of a knora-base:Map and the key of a knora-base:MapEntry, returns the value of the map entry.
  *
  * @param triplestore the name of the triplestore being used.
- * @param mapIri the IRI of the knora-admin:Map.
- * @param mapEntryKey the key of the knora-admin:MapEntry.
+ * @param mapIri the IRI of the knora-base:Map.
+ * @param mapEntryKey the key of the knora-base:MapEntry.
  *@
 @(triplestore: String,
   mapIri: IRI,
@@ -36,7 +36,6 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
 
 SELECT ?mapEntryValue
 @* Ensure that inference is not used in this query. *@
@@ -46,9 +45,9 @@ SELECT ?mapEntryValue
 WHERE {
     BIND(IRI("@mapIri") as ?map)
 
-    ?map a knora-admin:Map .
+    ?map a knora-base:Map .
 
-    ?mapEntry knora-admin:isInMap ?map ;
-        knora-admin:mapEntryKey """@mapEntryKey""^^xsd:string ;
-        knora-admin:mapEntryValue ?mapEntryValue .
+    ?mapEntry knora-base:isInMap ?map ;
+        knora-base:mapEntryKey """@mapEntryKey""^^xsd:string ;
+        knora-base:mapEntryValue ?mapEntryValue .
 }

--- a/webapi/src/main/twirl/queries/sparql/v1/setMapEntryValue.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/setMapEntryValue.scala.txt
@@ -1,0 +1,95 @@
+@*
+ * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ *@
+
+@import org.knora.webapi.IRI
+
+@**
+ * Deletes any existing knora-admin:MapEntry for the specified key, and creates a new one. Does nothing if the
+ * containing knora-admin:Map does not exist.
+ *
+ * @param triplestore the name of the triplestore being used.
+ * @param mapNamedGraphIri the IRI of the named graph where Maps are stored.
+ * @param mapIri the IRI of the knora-admin:Map.
+ * @param mapEntryKey the key of the new MapEntry.
+ * @param mapEntryIri the IRI of the new MapEntry.
+ * @param mapEntryValue the value to be given to the new MapEntry.
+ *@
+@(triplestore: String,
+  mapNamedGraphIri: IRI,
+  mapIri: IRI,
+  mapEntryIri: IRI,
+  mapEntryKey: String,
+  mapEntryValue: String)
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+
+DELETE {
+    GRAPH ?dataNamedGraph {
+        @* Delete the existing entry, if any. *@
+        ?existingMapEntry rdf:type knora-admin:MapEntry ;
+            knora-admin:isInMap ?map ;
+            knora-admin:mapEntryKey """@mapEntryKey"""^^xsd:string ;
+            knora-admin:mapEntryValue ?existingValue ;
+            knora-base:lastModificationDate ?existingEntryLastModificationDate .
+
+        @* Delete the map's last modification date so we can update it. *@
+        ?map knora-base:lastModificationDate ?mapLastModificationDate .
+    }
+} INSERT {
+    GRAPH ?dataNamedGraph {
+        @* Create the MapEntry. *@
+        ?newMapEntry rdf:type knora-admin:MapEntry ;
+            knora-admin:isInMap ?map ;
+            knora-admin:mapEntryKey """@mapEntryKey"""^^xsd:string ;
+            knora-admin:mapEntryValue """@mapEntryValue"""^^xsd:string ;
+            knora-base:lastModificationDate ?currentTime .
+
+        @* Update the map's last modification date. *@
+        ?map knora-base:lastModificationDate ?currentTime .
+    }
+}
+@* Ensure that inference is not used in the WHERE clause of this update. *@
+@if(triplestore.startsWith("graphdb")) {
+    USING <http://www.ontotext.com/explicit>
+}
+WHERE {
+    BIND(IRI("@mapNamedGraphIri") AS ?mapNamedGraph)
+    BIND(IRI("@mapIri") AS ?map)
+    BIND(IRI("@mapEntryIri") AS ?newMapEntry)
+    BIND(NOW() AS ?currentTime)
+
+    ?map rdf:type knora-admin:Map ;
+        knora-base:lastModificationDate ?mapLastModificationDate .
+
+    @* Get the existing entry with the specified key, if any, so we can delete it. *@
+
+    OPTIONAL {
+        ?existingMapEntry rdf:type knora-admin:MapEntry ;
+            knora-admin:isInMap ?map ;
+            knora-admin:mapEntryKey """@mapEntryKey"""^^xsd:string ;
+            knora-admin:mapEntryValue ?existingValue ;
+            knora-base:lastModificationDate ?existingEntryLastModificationDate .
+    }
+}

--- a/webapi/src/main/twirl/queries/sparql/v1/setMapEntryValue.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/setMapEntryValue.scala.txt
@@ -21,12 +21,12 @@
 @import org.knora.webapi.IRI
 
 @**
- * Deletes any existing knora-admin:MapEntry for the specified key, and creates a new one. Does nothing if the
- * containing knora-admin:Map does not exist.
+ * Deletes any existing knora-base:MapEntry for the specified key, and creates a new one. Does nothing if the
+ * containing knora-base:Map does not exist.
  *
  * @param triplestore the name of the triplestore being used.
  * @param mapNamedGraphIri the IRI of the named graph where Maps are stored.
- * @param mapIri the IRI of the knora-admin:Map.
+ * @param mapIri the IRI of the knora-base:Map.
  * @param mapEntryKey the key of the new MapEntry.
  * @param mapEntryIri the IRI of the new MapEntry.
  * @param mapEntryValue the value to be given to the new MapEntry.
@@ -43,15 +43,14 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
-PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
 
 DELETE {
     GRAPH ?dataNamedGraph {
         @* Delete the existing entry, if any. *@
-        ?existingMapEntry rdf:type knora-admin:MapEntry ;
-            knora-admin:isInMap ?map ;
-            knora-admin:mapEntryKey """@mapEntryKey"""^^xsd:string ;
-            knora-admin:mapEntryValue ?existingValue ;
+        ?existingMapEntry rdf:type knora-base:MapEntry ;
+            knora-base:isInMap ?map ;
+            knora-base:mapEntryKey """@mapEntryKey"""^^xsd:string ;
+            knora-base:mapEntryValue ?existingValue ;
             knora-base:lastModificationDate ?existingEntryLastModificationDate .
 
         @* Delete the map's last modification date so we can update it. *@
@@ -60,10 +59,10 @@ DELETE {
 } INSERT {
     GRAPH ?dataNamedGraph {
         @* Create the MapEntry. *@
-        ?newMapEntry rdf:type knora-admin:MapEntry ;
-            knora-admin:isInMap ?map ;
-            knora-admin:mapEntryKey """@mapEntryKey"""^^xsd:string ;
-            knora-admin:mapEntryValue """@mapEntryValue"""^^xsd:string ;
+        ?newMapEntry rdf:type knora-base:MapEntry ;
+            knora-base:isInMap ?map ;
+            knora-base:mapEntryKey """@mapEntryKey"""^^xsd:string ;
+            knora-base:mapEntryValue """@mapEntryValue"""^^xsd:string ;
             knora-base:lastModificationDate ?currentTime .
 
         @* Update the map's last modification date. *@
@@ -80,16 +79,16 @@ WHERE {
     BIND(IRI("@mapEntryIri") AS ?newMapEntry)
     BIND(NOW() AS ?currentTime)
 
-    ?map rdf:type knora-admin:Map ;
+    ?map rdf:type knora-base:Map ;
         knora-base:lastModificationDate ?mapLastModificationDate .
 
     @* Get the existing entry with the specified key, if any, so we can delete it. *@
 
     OPTIONAL {
-        ?existingMapEntry rdf:type knora-admin:MapEntry ;
-            knora-admin:isInMap ?map ;
-            knora-admin:mapEntryKey """@mapEntryKey"""^^xsd:string ;
-            knora-admin:mapEntryValue ?existingValue ;
+        ?existingMapEntry rdf:type knora-base:MapEntry ;
+            knora-base:isInMap ?map ;
+            knora-base:mapEntryKey """@mapEntryKey"""^^xsd:string ;
+            knora-base:mapEntryValue ?existingValue ;
             knora-base:lastModificationDate ?existingEntryLastModificationDate .
     }
 }


### PR DESCRIPTION
Basic ideas:

* `knora-base:Map` and `knora-base:MapEntry` are the OWL classes.
* They're stored in a separate named graph.
* The IRI of a map can contain a path representing some kind of hierarchy. So can the key of a map entry.
* Whenever you change a map entry, you first check whether the map exists, and create it if it doesn't.
* Both maps and map entries have a `knora-base:lastModificationDate`.

Resolves #524.