### PR TITLE
chain of trust

### DIFF
--- a/salsah/src/public/index.html
+++ b/salsah/src/public/index.html
@@ -4,7 +4,7 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<meta name="creator" content="Lukas Rosenthaler" />
 	<title>System for Annotation and Linkage of Sources in Arts and Humanities</title>
-	<script src="http://code.jquery.com/jquery-2.1.4.min.js"></script>
+	<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
 	<script src="vendor/jQuery/jquery-ui.min.js"></script>
 	<script src="vendor/jQuery/jquery.sortElements.js"></script>
 	<script src="vendor/jQuery/jquery.mousewheel.min.js"></script>


### PR DESCRIPTION
"a chain is only as strong as its weakest link" and this `http` link will stop you from being called `https` (in modern browsers)