### PR TITLE
fix (extended search date LT_EQ GT_EQ): fix wrong conditions for date comparison

### DIFF
--- a/docs/rst/knora-api-server/api_v1/reading-and-searching-resources.rst
+++ b/docs/rst/knora-api-server/api_v1/reading-and-searching-resources.rst
@@ -252,9 +252,9 @@ Explanation of the comparison operators:
     In case of a date value type, inequality is given if the dates do not overlap in any way, meaning that a date starts after the end of the defined period or ends before the beginning of the defined period
     (dates are internally always treated as periods, see above).
   - ``GT``: checks if a resource's value is *greater than* the search value. In case of a date value type, it assures that a period begins after the indicated period's end.
-  - ``GT_EQ``: checks if a resource's value *equals or is greater than* the search value. In case of a date value type, it assures that a period's start equals the end of the indicated period or the period begins after the indicated period's end.
+  - ``GT_EQ``: checks if a resource's value *equals or is greater than* the search value. In case of a date value type, it assures that the periods overlap in any way (see ``EQ``) **or** that the period starts after the indicated period's end (see ``GT``).
   - ``LT``: checks if a resource's value is *lower than* the search value. In case of a date value type, it assures that a period ends before the indicated period's start.
-  - ``LT_EQ``: checks if a resource's value *equals or is lower than* the search value. In case of a date value type, it assures that a period's end equals the beginning of the indicated period or the period ends before the indicated period's start.
+  - ``LT_EQ``: checks if a resource's value *equals or is lower than* the search value. In case of a date value type, it assures that the periods overlap in any way (see ``EQ``) **or** that the period ends before the indicated period's start (see ``LT``).
   - ``EXISTS``: checks if an instance of the indicated property type *exists* for a resource. **Please always provide an empty search value when using EXISTS: "searchval="**. Otherwise, the query syntax rules would be violated.
   - ``MATCH``: checks if a resource's text value *matches* the search value. The behaviour depends on the used triplestore's full text index.
   - ``LIKE``: checks if the search value is contained in a resource's text value.

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/SearchRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/SearchRouteV1.scala
@@ -60,26 +60,26 @@ object SearchRouteV1 extends Authenticator {
 
         // only one value is expected
         val restypeIri: Option[IRI] = params.get("filter_by_restype") match {
-            case Some(List(restype: IRI)) => Some(InputValidation.toIri(restype, () => throw BadRequestException(s"Unexpected param 'filter_by_restype' for extended search: $restype")))
+            case Some(List(restype: IRI)) => Some(InputValidation.toIri(restype, () => throw BadRequestException(s"Value for param 'filter_by_restype' for extended search $restype is not a valid Iri. Please make sure that it was correctly URL encoded.")))
             case other => None
         }
 
         // only one value is expected
         val projectIri: Option[IRI] = params.get("filter_by_project") match {
-            case Some(List(project: IRI)) => Some(InputValidation.toIri(project, () => throw BadRequestException(s"Unexpected param 'filter_by_project' for extended search: $project")))
+            case Some(List(project: IRI)) => Some(InputValidation.toIri(project, () => throw BadRequestException(s"Value for param 'filter_by_project' for extended search $project is not a valid Iri. Please make sure that it was correctly URL encoded.")))
             case other => None
         }
 
         // only one value is expected
         val ownerIri: Option[IRI] = params.get("filter_by_owner") match {
-            case Some(List(owner: IRI)) => Some(InputValidation.toIri(owner, () => throw BadRequestException(s"Unexpected param 'filter_by_owner' for extended search: $owner")))
+            case Some(List(owner: IRI)) => Some(InputValidation.toIri(owner, () => throw BadRequestException(s"Value for param 'filter_by_owner' for extended search $owner is not a valid Iri. Please make sure that it was correctly URL encoded.")))
             case other => None
         }
 
         // here, also multiple values can be given
         val propertyIri: Seq[IRI] = params.get("property_id") match {
             case Some(propertyList: Seq[IRI]) => propertyList.map(
-                prop => InputValidation.toIri(prop, () => throw BadRequestException(s"Unexpected param 'property_id' for extended search: $prop"))
+                prop => InputValidation.toIri(prop, () => throw BadRequestException(s"Value for param 'property_id' for extended search $prop is not a valid Iri. Please make sure that it was correctly URL encoded."))
             )
             case other => Nil
         }

--- a/webapi/src/main/twirl/queries/sparql/v1/searchExtendedGraphDB.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/searchExtendedGraphDB.scala.txt
@@ -381,10 +381,20 @@ WHERE {
 
                     case "http://www.knora.org/ontology/knora-base#DateValue" => {
 
-                        ?valueObject@index knora-base:valueHasStartJDN ?dateStart@index .
+                        ?valueObject@index knora-base:valueHasEndJDN ?dateEnd@index .
                         ?valueObject@index knora-base:valueHasString ?dateString@index .
 
-                        FILTER (?dateStart@index >= @searchCriterion.dateEnd)
+                        @*
+
+                        Logically, GT_EQ is the negation of LT (see below):
+
+                        FILTER (!(?dateEnd@index < @searchCriterion.dateStart))
+
+                        This can be further simplified to the expression stated below.
+
+                        *@
+
+                        FILTER(?dateEnd@index >= @searchCriterion.dateStart)
                         BIND(?dateString@index as ?literal@index)
 
                     }
@@ -453,10 +463,20 @@ WHERE {
 
                     case "http://www.knora.org/ontology/knora-base#DateValue" => {
 
-                        ?valueObject@index knora-base:valueHasEndJDN ?dateEnd@index .
+                        ?valueObject@index knora-base:valueHasStartJDN ?dateStart@index .
                         ?valueObject@index knora-base:valueHasString ?dateString@index .
 
-                        FILTER (?dateEnd@index <= @searchCriterion.dateStart)
+                        @*
+
+                        Logically, LT_EQ is the negation of GT (see above):
+
+                        FILTER (!(?dateStart@index > @searchCriterion.dateEnd))
+
+                        This can be further simplified to the expression stated below.
+
+                        *@
+
+                        FILTER (?dateStart@index <= @searchCriterion.dateEnd)
                         BIND(?dateString@index as ?literal@index)
 
                     }

--- a/webapi/src/main/twirl/queries/sparql/v1/searchExtendedStandard.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/searchExtendedStandard.scala.txt
@@ -367,10 +367,10 @@ WHERE {
 
                     case "http://www.knora.org/ontology/knora-base#DateValue" => {
 
-                        ?valueObject@index knora-base:valueHasStartJDN ?dateStart@index .
+                        ?valueObject@index knora-base:valueHasEndJDN ?dateEnd@index .
                         ?valueObject@index knora-base:valueHasString ?dateString@index .
 
-                        FILTER (?dateStart@index >= @searchCriterion.dateEnd)
+                        FILTER(?dateEnd@index >= @searchCriterion.dateStart)
                         BIND(?dateString@index as ?literal@index)
 
                     }
@@ -439,10 +439,10 @@ WHERE {
 
                     case "http://www.knora.org/ontology/knora-base#DateValue" => {
 
-                        ?valueObject@index knora-base:valueHasEndJDN ?dateEnd@index .
+                        ?valueObject@index knora-base:valueHasStartJDN ?dateStart@index .
                         ?valueObject@index knora-base:valueHasString ?dateString@index .
 
-                        FILTER (?dateEnd@index <= @searchCriterion.dateStart)
+                        FILTER (?dateStart@index <= @searchCriterion.dateEnd)
                         BIND(?dateString@index as ?literal@index)
 
                     }

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/SearchResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/SearchResponderV1Spec.scala
@@ -596,7 +596,7 @@ class SearchResponderV1Spec extends CoreSpec() with ImplicitSender {
             }
         }
 
-        "return 5 books when we search for all books whose publication date is greater than or equal to January 1495 (Julian date) in the Incunabula test data" in {
+        "return 7 books when we search for all books whose publication date is greater than or equal to January 1495 (Julian date) in the Incunabula test data" in {
             // http://localhost:3333/v1/search/?searchtype=extended&filter_by_restype=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23book&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23pubdate&compop=GT_EQ&searchval=JULIAN:1495-01
             actorUnderTest ! ExtendedSearchGetRequestV1(
                 userProfile = incunabulaUser,
@@ -609,11 +609,11 @@ class SearchResponderV1Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case response: SearchGetResponseV1 => response.subjects.size should ===(5)
+                case response: SearchGetResponseV1 => response.subjects.size should ===(7)
             }
         }
 
-        "return 13 books when we search for all books whose publication date is less than or equal to December 1495 (Julian date) in the Incunabula test data" in {
+        "return 15 books when we search for all books whose publication date is less than or equal to December 1495 (Julian date) in the Incunabula test data" in {
             // http://localhost:3333/v1/search/?searchtype=extended&filter_by_restype=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23book&property_id=http%3A%2F%2Fwww.knora.org%2Fontology%2Fincunabula%23pubdate&compop=LT_EQ&searchval=JULIAN:1495-12
             actorUnderTest ! ExtendedSearchGetRequestV1(
                 userProfile = incunabulaUser,
@@ -626,7 +626,7 @@ class SearchResponderV1Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case response: SearchGetResponseV1 => response.subjects.size should ===(13)
+                case response: SearchGetResponseV1 => response.subjects.size should ===(15)
             }
         }
 


### PR DESCRIPTION
The conditions for LT_EQ and GT_EQ were wrong. Logically, they are simply the negations of GT and LT, respectively.

closes  https://github.com/dhlab-basel/Knora/issues/575