### PR TITLE
When requested languages aren't available, take the first one alphabetically

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
@@ -496,9 +496,15 @@ sealed trait EntityInfoV2 {
                                                 // Yes.
                                                 Some(objectWithoutLang)
                                             case None =>
-                                                // The object is not available without a language tag. Return it in
-                                                // any other language.
-                                                predicateInfo.objectsWithLang.values.headOption
+                                                // The object is not available without a language tag. Sort the
+                                                // available objects by language code to get a deterministic result,
+                                                // and return the object in the language code with the lowest sort
+                                                // order.
+                                                predicateInfo.objectsWithLang.toVector.sortBy {
+                                                    case (lang, obj) => lang
+                                                }.headOption.map {
+                                                    case (lang, obj) => obj
+                                                }
                                         }
                                 }
                         }


### PR DESCRIPTION
Fixes #627.

Fine for me because it makes it more likely that data will be returned in Arabic. :)