### PR TITLE
feature (webapi): add basic Webern test data

### DIFF
--- a/webapi/_test_data/all_data/admin-data.ttl
+++ b/webapi/_test_data/all_data/admin-data.ttl
@@ -478,6 +478,7 @@ Die Internetpublikation macht das digitalisierte Korpus dieser Frühdrucke  durc
 
 <http://rdfh.ch/projects/08AE> a knora-base:knoraProject ;
   knora-base:projectShortname "webern"^^xsd:string ;
+  knora-base:projectShortcode "08AE"^^xsd:string ;
   knora-base:projectLongname "Anton Webern Gesamtausgabe"^^xsd:string ;
   knora-base:projectDescription "Historisch-kritische Edition des Gesamtschaffens von Anton Webern."^^xsd:string ;
   knora-base:projectOntology <http://www.knora.org/ontology/08AE/webern> ;

--- a/webapi/_test_data/all_data/admin-data.ttl
+++ b/webapi/_test_data/all_data/admin-data.ttl
@@ -470,3 +470,41 @@ Die Internetpublikation macht das digitalisierte Korpus dieser Frühdrucke  durc
   knora-base:isInProject <http://rdfh.ch/projects/DczxPs-sR6aZN91qV92ZmQ> ;
   knora-base:isInSystemAdminGroup "false"^^xsd:boolean ;
   knora-base:isInProjectAdminGroup <http://rdfh.ch/projects/DczxPs-sR6aZN91qV92ZmQ> .
+
+
+###################################
+# WEBERN                          #
+###################################
+
+<http://rdfh.ch/projects/08AE> a knora-base:knoraProject ;
+  knora-base:projectShortname "webern"^^xsd:string ;
+  knora-base:projectLongname "Anton Webern Gesamtausgabe"^^xsd:string ;
+  knora-base:projectDescription "Historisch-kritische Edition des Gesamtschaffens von Anton Webern."^^xsd:string ;
+  knora-base:projectOntology <http://www.knora.org/ontology/08AE/webern> ;
+  knora-base:status "true"^^xsd:boolean ;
+  knora-base:hasSelfJoinEnabled "false"^^xsd:boolean .
+
+## Project Member
+<http://rdfh.ch/users/webernProjectMember> a knora-base:User ;
+  knora-base:userid "webern-nutzer"^^xsd:string ;
+  knora-base:familyName "Webern"^^xsd:string ;
+  knora-base:givenName "Nutzer"^^xsd:string ;
+  knora-base:password "$e0801$FGl9FDIWw+D83OeNPGmD9u2VTqIkJopIQECgmb2DSWQLS0TeKSvYoWAkbEv6KxePPlCI3CP9MmVHuvnWv8/kag==$mlegCYdGXt+ghuo8i0rLjgOiNnGDW604Q5g/v7zwBPU="^^xsd:string ;
+  knora-base:email "webern-nutzer@example.ch"^^xsd:string ;
+  knora-base:preferredLanguage "de"^^xsd:string ;
+  knora-base:status "true"^^xsd:boolean ;
+  knora-base:isInProject <http://rdfh.ch/projects/08AE> ;
+  knora-base:isInSystemAdminGroup "false"^^xsd:boolean .
+
+## Project Admin
+<http://rdfh.ch/users/webernProjectAdmin> a knora-base:User ;
+  knora-base:userid "webern-admin"^^xsd:string ;
+  knora-base:familyName "Webern"^^xsd:string ;
+  knora-base:givenName "Admin"^^xsd:string ;
+  knora-base:password "$e0801$FGl9FDIWw+D83OeNPGmD9u2VTqIkJopIQECgmb2DSWQLS0TeKSvYoWAkbEv6KxePPlCI3CP9MmVHuvnWv8/kag==$mlegCYdGXt+ghuo8i0rLjgOiNnGDW604Q5g/v7zwBPU="^^xsd:string ;
+  knora-base:email "webern-admin@example.ch"^^xsd:string ;
+  knora-base:preferredLanguage "de"^^xsd:string ;
+  knora-base:status "true"^^xsd:boolean ;
+  knora-base:isInProject <http://rdfh.ch/projects/08AE> ;
+  knora-base:isInSystemAdminGroup "false"^^xsd:boolean ;
+  knora-base:isInProjectAdminGroup <http://rdfh.ch/projects/08AE> .

--- a/webapi/_test_data/all_data/permissions-data.ttl
+++ b/webapi/_test_data/all_data/permissions-data.ttl
@@ -318,6 +318,47 @@
 
 ##########################################################
 #
+# WEBERN Project Permissions
+#
+##########################################################
+
+### Administrative Permissions on ProjectMember
+<http://rdfh.ch/permissions/008-a1>
+
+                      rdf:type knora-base:AdministrativePermission ;
+
+                      knora-base:forProject <http://rdfh.ch/projects/08AE> ;
+
+                      knora-base:forGroup knora-base:ProjectMember ;
+
+                      knora-base:hasPermissions "ProjectResourceCreateAllPermission"^^xsd:string .
+
+
+### Administrative Permissions on ProjectAdmin
+<http://rdfh.ch/permissions/008-a2>
+
+                      rdf:type knora-base:AdministrativePermission ;
+
+                      knora-base:forProject <http://rdfh.ch/projects/08AE> ;
+
+                      knora-base:forGroup knora-base:ProjectAdmin ;
+
+                      knora-base:hasPermissions "ProjectResourceCreateAllPermission|ProjectAdminAllPermission"^^xsd:string .
+
+
+### Default Object Access Permissions on ProjectMember Group
+<http://rdfh.ch/permissions/008-d1>
+
+                      rdf:type knora-base:DefaultObjectAccessPermission ;
+
+                      knora-base:forProject <http://rdfh.ch/projects/08AE> ;
+
+                      knora-base:forGroup knora-base:ProjectMember ;
+
+                      knora-base:hasPermissions "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser"^^xsd:string .
+
+##########################################################
+#
 # Sweet and tasty but forbidden resource
 #
 # but of the tree of the knowledge of good and evil, thou shalt not eat of it

--- a/webapi/_test_data/all_data/permissions-data.ttl
+++ b/webapi/_test_data/all_data/permissions-data.ttl
@@ -323,7 +323,7 @@
 ##########################################################
 
 ### Administrative Permissions on ProjectMember
-<http://rdfh.ch/permissions/008-a1>
+<http://rdfh.ch/permissions/08AE/008-a1>
 
                       rdf:type knora-base:AdministrativePermission ;
 
@@ -335,7 +335,7 @@
 
 
 ### Administrative Permissions on ProjectAdmin
-<http://rdfh.ch/permissions/008-a2>
+<http://rdfh.ch/permissions/08AE/008-a2>
 
                       rdf:type knora-base:AdministrativePermission ;
 
@@ -347,7 +347,7 @@
 
 
 ### Default Object Access Permissions on ProjectMember Group
-<http://rdfh.ch/permissions/008-d1>
+<http://rdfh.ch/permissions/08AE/008-d1>
 
                       rdf:type knora-base:DefaultObjectAccessPermission ;
 

--- a/webapi/_test_data/all_data/webern-data.ttl
+++ b/webapi/_test_data/all_data/webern-data.ttl
@@ -20,21 +20,22 @@
 # #################################################################
 # 
 # 
-# http://data.knora.org/webern/testperson1
+# http://rdfh.ch/08AE/testperson1
+# webern:testperson1
 
-<http://data.knora.org/webern/testperson1> a webern:Person, owl:NamedIndividual ;
-	webern:comment <http://data.knora.org/webern/testperson1/values/df1260ad43d5> ;
-	webern:hasAlternativeName <http://data.knora.org/webern/testperson1/values/88c91a1d-23bc-413d-b966-78b525715575> ;
-	webern:hasBiography <http://data.knora.org/webern/testperson1/values/3855051b-c47c-4e61-8cd7-76404efdc67b> ;
-	webern:hasBiographySource <http://data.knora.org/webern/testperson1/values/4ab0cfaa-479a-4cd6-946e-2b51c4b9d016> ;
-	webern:hasBirthDate <http://data.knora.org/webern/testperson1/values/6f3e4026-18bd-4039-9805-7d0d4e317690> ;
-	webern:hasBirthPlace <http://data.knora.org/webern/testperson1/values/a588947a-44e6-45fb-aec3-3d57887f038c> ;
-	webern:hasDeathDate <http://data.knora.org/webern/testperson1/values/b5349bdd-6f5d-4538-ad0f-7b9440760f55> ;
-	webern:hasDeathPlace <http://data.knora.org/webern/testperson1/values/47b2992554d5> ;
-	webern:hasFamilyName <http://data.knora.org/webern/testperson1/values/576dede4-8cc9-4e72-ac8c-8ea5dff9c668> ;
-	webern:hasGivenName <http://data.knora.org/webern/testperson1/values/20526fec-6106-4b9d-a41b-faccbe028340> ;
-	webern:hasIAFIdentifier <http://data.knora.org/webern/testperson1/values/50e58896-fd0f-49c7-9786-f9cdd4c9ce56> ;
-	webern:hasRelation <http://data.knora.org/webern/testperson1/values/f7675f26-4b01-4432-be74-9ae3aa24d2af> ;
+<http://rdfh.ch/08AE/testperson1> a webern:Person ;
+	webern:comment <http://rdfh.ch/08AE/testperson1/values/df1260ad43d5> ;
+	webern:hasAlternativeName <http://rdfh.ch/08AE/testperson1/values/88c91a1d-23bc-413d-b966-78b525715575> ;
+	webern:hasBiography <http://rdfh.ch/08AE/testperson1/values/3855051b-c47c-4e61-8cd7-76404efdc67b> ;
+	webern:hasBiographySource <http://rdfh.ch/08AE/testperson1/values/4ab0cfaa-479a-4cd6-946e-2b51c4b9d016> ;
+	webern:hasBirthDate <http://rdfh.ch/08AE/testperson1/values/6f3e4026-18bd-4039-9805-7d0d4e317690> ;
+	webern:hasBirthPlace <http://rdfh.ch/08AE/testperson1/values/a588947a-44e6-45fb-aec3-3d57887f038c> ;
+	webern:hasDeathDate <http://rdfh.ch/08AE/testperson1/values/b5349bdd-6f5d-4538-ad0f-7b9440760f55> ;
+	webern:hasDeathPlace <http://rdfh.ch/08AE/testperson1/values/47b2992554d5> ;
+	webern:hasFamilyName <http://rdfh.ch/08AE/testperson1/values/576dede4-8cc9-4e72-ac8c-8ea5dff9c668> ;
+	webern:hasGivenName <http://rdfh.ch/08AE/testperson1/values/20526fec-6106-4b9d-a41b-faccbe028340> ;
+	webern:hasIAFIdentifier <http://rdfh.ch/08AE/testperson1/values/50e58896-fd0f-49c7-9786-f9cdd4c9ce56> ;
+	webern:hasRelation <http://rdfh.ch/08AE/testperson1/values/f7675f26-4b01-4432-be74-9ae3aa24d2af> ;
 	knora-base:attachedToProject <http://rdfh.ch/projects/08AE> ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:creationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
@@ -44,10 +45,10 @@
 
 
 #
-# http://data.knora.org/webern/testperson1/values/576dede4-8cc9-4e72-ac8c-8ea5dff9c668
-# hasFamiliyName
+# http://rdfh.ch/08AE/testperson1/values/576dede4-8cc9-4e72-ac8c-8ea5dff9c668
+# hasFamilyName
 
-<http://data.knora.org/webern/testperson1/values/576dede4-8cc9-4e72-ac8c-8ea5dff9c668> a knora-base:TextValue, owl:NamedIndividual ;
+<http://rdfh.ch/08AE/testperson1/values/576dede4-8cc9-4e72-ac8c-8ea5dff9c668> a knora-base:TextValue ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
 	knora-base:isDeleted "false"^^xsd:boolean ;
@@ -56,10 +57,10 @@
 	knora-base:valueHasString "Polnauer" .
 
 # 
-# http://data.knora.org/webern/testperson1/values/20526fec-6106-4b9d-a41b-faccbe028340
+# http://rdfh.ch/08AE/testperson1/values/20526fec-6106-4b9d-a41b-faccbe028340
 # hasGivenName
 
-<http://data.knora.org/webern/testperson1/values/20526fec-6106-4b9d-a41b-faccbe028340> a knora-base:TextValue, owl:NamedIndividual ;
+<http://rdfh.ch/08AE/testperson1/values/20526fec-6106-4b9d-a41b-faccbe028340> a knora-base:TextValue ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
 	knora-base:isDeleted "false"^^xsd:boolean ;
@@ -68,10 +69,10 @@
 	knora-base:valueHasString "Josef" .
 
 # 
-# http://data.knora.org/webern/testperson1/values/88c91a1d-23bc-413d-b966-78b525715575
+# http://rdfh.ch/08AE/testperson1/values/88c91a1d-23bc-413d-b966-78b525715575
 # hasAlternativeName
 
-<http://data.knora.org/webern/testperson1/values/88c91a1d-23bc-413d-b966-78b525715575> a knora-base:TextValue, owl:NamedIndividual ;
+<http://rdfh.ch/08AE/testperson1/values/88c91a1d-23bc-413d-b966-78b525715575> a knora-base:TextValue ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
 	knora-base:isDeleted "false"^^xsd:boolean ;
@@ -80,10 +81,10 @@
 	knora-base:valueHasString "Josef Maximilian Polnauer" .
 
 #
-# http://data.knora.org/webern/testperson1/values/50e58896-fd0f-49c7-9786-f9cdd4c9ce56
+# http://rdfh.ch/08AE/testperson1/values/50e58896-fd0f-49c7-9786-f9cdd4c9ce56
 # hasIAFIdentifier
 
-<http://data.knora.org/webern/testperson1/values/50e58896-fd0f-49c7-9786-f9cdd4c9ce56> a knora-base:TextValue, owl:NamedIndividual ;
+<http://rdfh.ch/08AE/testperson1/values/50e58896-fd0f-49c7-9786-f9cdd4c9ce56> a knora-base:TextValue ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
 	knora-base:isDeleted "false"^^xsd:boolean ;
@@ -92,10 +93,10 @@
 	knora-base:valueHasString "1017673659" .
 
 #
-# http://data.knora.org/webern/testperson1/values/6f3e4026-18bd-4039-9805-7d0d4e317690
+# http://rdfh.ch/08AE/testperson1/values/6f3e4026-18bd-4039-9805-7d0d4e317690
 # hasBirthDate
 
-<http://data.knora.org/webern/testperson1/values/6f3e4026-18bd-4039-9805-7d0d4e317690> a knora-base:DateValue, owl:NamedIndividual ;
+<http://rdfh.ch/08AE/testperson1/values/6f3e4026-18bd-4039-9805-7d0d4e317690> a knora-base:DateValue ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
 	knora-base:isDeleted "false"^^xsd:boolean ;
@@ -109,10 +110,10 @@
     knora-base:valueHasEndPrecision "DAY" .
 
 #
-# http://data.knora.org/webern/testperson1/values/b5349bdd-6f5d-4538-ad0f-7b9440760f55
+# http://rdfh.ch/08AE/testperson1/values/b5349bdd-6f5d-4538-ad0f-7b9440760f55
 # webern:hasDeathDate
 
-<http://data.knora.org/webern/testperson1/values/b5349bdd-6f5d-4538-ad0f-7b9440760f55> a knora-base:DateValue, owl:NamedIndividual ;
+<http://rdfh.ch/08AE/testperson1/values/b5349bdd-6f5d-4538-ad0f-7b9440760f55> a knora-base:DateValue ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
 	knora-base:isDeleted "false"^^xsd:boolean ;
@@ -126,10 +127,10 @@
     knora-base:valueHasEndPrecision "DAY" .
 
 #
-# http://data.knora.org/webern/testperson1/values/a588947a-44e6-45fb-aec3-3d57887f038c
+# http://rdfh.ch/08AE/testperson1/values/a588947a-44e6-45fb-aec3-3d57887f038c
 # webern:hasBirthPlace
 
-<http://data.knora.org/webern/testperson1/values/a588947a-44e6-45fb-aec3-3d57887f038c> a knora-base:TextValue, owl:NamedIndividual ;
+<http://rdfh.ch/08AE/testperson1/values/a588947a-44e6-45fb-aec3-3d57887f038c> a knora-base:TextValue ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
 	knora-base:isDeleted "false"^^xsd:boolean ;
@@ -138,10 +139,10 @@
 	knora-base:valueHasString "Wien" .
 
 #
-# http://data.knora.org/webern/testperson1/values/47b2992554d5
+# http://rdfh.ch/08AE/testperson1/values/47b2992554d5
 # webern:hasDeathPlace
 
-<http://data.knora.org/webern/testperson1/values/47b2992554d5> a knora-base:TextValue, owl:NamedIndividual ;
+<http://rdfh.ch/08AE/testperson1/values/47b2992554d5> a knora-base:TextValue ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
 	knora-base:isDeleted "false"^^xsd:boolean ;
@@ -150,10 +151,10 @@
 	knora-base:valueHasString "Wien" .
 
 #
-# http://data.knora.org/webern/testperson1/values/3855051b-c47c-4e61-8cd7-76404efdc67b
+# http://rdfh.ch/08AE/testperson1/values/3855051b-c47c-4e61-8cd7-76404efdc67b
 # webern:hasBiography
 
-<http://data.knora.org/webern/testperson1/values/3855051b-c47c-4e61-8cd7-76404efdc67b> a knora-base:TextValue, owl:NamedIndividual ;
+<http://rdfh.ch/08AE/testperson1/values/3855051b-c47c-4e61-8cd7-76404efdc67b> a knora-base:TextValue ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
 	knora-base:isDeleted "false"^^xsd:boolean ;
@@ -162,10 +163,10 @@
 	knora-base:valueHasString "Musikstudien bei Arnold Schönberg (1909 bis 1911), Alban Berg (1911 bis 1913). Studien bei Guido Adler (1927 Promotion in Innsbruck). Beamter (bei den österreichischen Bundesbahnen, nach dem Zweiten Weltkrieg  beim Finanzministerium), Musikwissenschaftler, Bibliothekar, nach seiner Pensionierung auch Kompositionslehrer. Herausgeber des Briefwechsels Anton Webern und Hildegard Jone (stark gekürzt)." .
 
 #
-# http://data.knora.org/webern/testperson1/values/4ab0cfaa-479a-4cd6-946e-2b51c4b9d016
+# http://rdfh.ch/08AE/testperson1/values/4ab0cfaa-479a-4cd6-946e-2b51c4b9d016
 # webern:hasBiographySource
 
-<http://data.knora.org/webern/testperson1/values/4ab0cfaa-479a-4cd6-946e-2b51c4b9d016> a knora-base:TextValue, owl:NamedIndividual ;
+<http://rdfh.ch/08AE/testperson1/values/4ab0cfaa-479a-4cd6-946e-2b51c4b9d016> a knora-base:TextValue ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
 	knora-base:isDeleted "false"^^xsd:boolean ;
@@ -175,10 +176,10 @@
 
 
 #
-# http://data.knora.org/webern/testperson1/values/f7675f26-4b01-4432-be74-9ae3aa24d2af
+# http://rdfh.ch/08AE/testperson1/values/f7675f26-4b01-4432-be74-9ae3aa24d2af
 # webern:hasRelation
 
-<http://data.knora.org/webern/testperson1/values/f7675f26-4b01-4432-be74-9ae3aa24d2af> a knora-base:TextValue, owl:NamedIndividual ;
+<http://rdfh.ch/08AE/testperson1/values/f7675f26-4b01-4432-be74-9ae3aa24d2af> a knora-base:TextValue ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
 	knora-base:isDeleted "false"^^xsd:boolean ;
@@ -187,10 +188,10 @@
 	knora-base:valueHasString "Angehöriger des Schönberg-Kreises. Freund." .
 
 #
-# http://data.knora.org/webern/testperson1/values/df1260ad43d5
+# http://rdfh.ch/08AE/testperson1/values/df1260ad43d5
 # webern:comment
 
-<http://data.knora.org/webern/testperson1/values/df1260ad43d5> a knora-base:TextValue, owl:NamedIndividual ;
+<http://rdfh.ch/08AE/testperson1/values/df1260ad43d5> a knora-base:TextValue ;
 	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
 	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
 	knora-base:isDeleted "false"^^xsd:boolean ;

--- a/webapi/_test_data/all_data/webern-data.ttl
+++ b/webapi/_test_data/all_data/webern-data.ttl
@@ -1,0 +1,204 @@
+@prefix : <http://www.knora.org/data/08AE/webern#> .
+@prefix dc: <http://www.knora.org/ontology/dc#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .
+@prefix salsah-gui: <http://www.knora.org/ontology/salsah-gui#> .
+@prefix webern: <http://www.knora.org/ontology/08AE/webern#> .
+
+#
+# 
+# 
+# #################################################################
+# #
+# #    Individuals
+# #
+# #################################################################
+# 
+# 
+# http://data.knora.org/webern/testperson1
+
+<http://data.knora.org/webern/testperson1> a webern:Person, owl:NamedIndividual ;
+	webern:comment <http://data.knora.org/webern/testperson1/values/df1260ad43d5> ;
+	webern:hasAlternativeName <http://data.knora.org/webern/testperson1/values/88c91a1d-23bc-413d-b966-78b525715575> ;
+	webern:hasBiography <http://data.knora.org/webern/testperson1/values/3855051b-c47c-4e61-8cd7-76404efdc67b> ;
+	webern:hasBiographySource <http://data.knora.org/webern/testperson1/values/4ab0cfaa-479a-4cd6-946e-2b51c4b9d016> ;
+	webern:hasBirthDate <http://data.knora.org/webern/testperson1/values/6f3e4026-18bd-4039-9805-7d0d4e317690> ;
+	webern:hasBirthPlace <http://data.knora.org/webern/testperson1/values/a588947a-44e6-45fb-aec3-3d57887f038c> ;
+	webern:hasDeathDate <http://data.knora.org/webern/testperson1/values/b5349bdd-6f5d-4538-ad0f-7b9440760f55> ;
+	webern:hasDeathPlace <http://data.knora.org/webern/testperson1/values/47b2992554d5> ;
+	webern:hasFamilyName <http://data.knora.org/webern/testperson1/values/576dede4-8cc9-4e72-ac8c-8ea5dff9c668> ;
+	webern:hasGivenName <http://data.knora.org/webern/testperson1/values/20526fec-6106-4b9d-a41b-faccbe028340> ;
+	webern:hasIAFIdentifier <http://data.knora.org/webern/testperson1/values/50e58896-fd0f-49c7-9786-f9cdd4c9ce56> ;
+	webern:hasRelation <http://data.knora.org/webern/testperson1/values/f7675f26-4b01-4432-be74-9ae3aa24d2af> ;
+	knora-base:attachedToProject <http://rdfh.ch/projects/08AE> ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:creationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:hasPermissions "CR knora-base:ProjectMember,knora-base:Creator|V knora-base:KnownUser|RV knora-base:UnknownUser" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	rdfs:label "Test person for Webern" .
+
+
+#
+# http://data.knora.org/webern/testperson1/values/576dede4-8cc9-4e72-ac8c-8ea5dff9c668
+# hasFamiliyName
+
+<http://data.knora.org/webern/testperson1/values/576dede4-8cc9-4e72-ac8c-8ea5dff9c668> a knora-base:TextValue, owl:NamedIndividual ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	knora-base:valueCreationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:valueHasOrder "0"^^xsd:integer ;
+	knora-base:valueHasString "Polnauer" .
+
+# 
+# http://data.knora.org/webern/testperson1/values/20526fec-6106-4b9d-a41b-faccbe028340
+# hasGivenName
+
+<http://data.knora.org/webern/testperson1/values/20526fec-6106-4b9d-a41b-faccbe028340> a knora-base:TextValue, owl:NamedIndividual ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	knora-base:valueCreationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:valueHasOrder "0"^^xsd:integer ;
+	knora-base:valueHasString "Josef" .
+
+# 
+# http://data.knora.org/webern/testperson1/values/88c91a1d-23bc-413d-b966-78b525715575
+# hasAlternativeName
+
+<http://data.knora.org/webern/testperson1/values/88c91a1d-23bc-413d-b966-78b525715575> a knora-base:TextValue, owl:NamedIndividual ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	knora-base:valueCreationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:valueHasOrder "0"^^xsd:integer ;
+	knora-base:valueHasString "Josef Maximilian Polnauer" .
+
+#
+# http://data.knora.org/webern/testperson1/values/50e58896-fd0f-49c7-9786-f9cdd4c9ce56
+# hasIAFIdentifier
+
+<http://data.knora.org/webern/testperson1/values/50e58896-fd0f-49c7-9786-f9cdd4c9ce56> a knora-base:TextValue, owl:NamedIndividual ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	knora-base:valueCreationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:valueHasOrder "0"^^xsd:integer ;
+	knora-base:valueHasString "1017673659" .
+
+#
+# http://data.knora.org/webern/testperson1/values/6f3e4026-18bd-4039-9805-7d0d4e317690
+# hasBirthDate
+
+<http://data.knora.org/webern/testperson1/values/6f3e4026-18bd-4039-9805-7d0d4e317690> a knora-base:DateValue, owl:NamedIndividual ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	knora-base:valueCreationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:valueHasOrder "0"^^xsd:integer ;
+	knora-base:valueHasString "2011-10-24" ;
+	knora-base:valueHasCalendar "GREGORIAN" ;
+    knora-base:valueHasStartJDN 2455859 ;
+    knora-base:valueHasStartPrecision "DAY" ;
+    knora-base:valueHasEndJDN 2455859 ;
+    knora-base:valueHasEndPrecision "DAY" .
+
+#
+# http://data.knora.org/webern/testperson1/values/b5349bdd-6f5d-4538-ad0f-7b9440760f55
+# webern:hasDeathDate
+
+<http://data.knora.org/webern/testperson1/values/b5349bdd-6f5d-4538-ad0f-7b9440760f55> a knora-base:DateValue, owl:NamedIndividual ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	knora-base:valueCreationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:valueHasOrder "0"^^xsd:integer ;
+	knora-base:valueHasString "2011-10-24" ;
+	knora-base:valueHasCalendar "GREGORIAN" ;
+    knora-base:valueHasStartJDN 2455859 ;
+    knora-base:valueHasStartPrecision "DAY" ;
+    knora-base:valueHasEndJDN 2455859 ;
+    knora-base:valueHasEndPrecision "DAY" .
+
+#
+# http://data.knora.org/webern/testperson1/values/a588947a-44e6-45fb-aec3-3d57887f038c
+# webern:hasBirthPlace
+
+<http://data.knora.org/webern/testperson1/values/a588947a-44e6-45fb-aec3-3d57887f038c> a knora-base:TextValue, owl:NamedIndividual ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	knora-base:valueCreationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:valueHasOrder "0"^^xsd:integer ;
+	knora-base:valueHasString "Wien" .
+
+#
+# http://data.knora.org/webern/testperson1/values/47b2992554d5
+# webern:hasDeathPlace
+
+<http://data.knora.org/webern/testperson1/values/47b2992554d5> a knora-base:TextValue, owl:NamedIndividual ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	knora-base:valueCreationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:valueHasOrder "0"^^xsd:integer ;
+	knora-base:valueHasString "Wien" .
+
+#
+# http://data.knora.org/webern/testperson1/values/3855051b-c47c-4e61-8cd7-76404efdc67b
+# webern:hasBiography
+
+<http://data.knora.org/webern/testperson1/values/3855051b-c47c-4e61-8cd7-76404efdc67b> a knora-base:TextValue, owl:NamedIndividual ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	knora-base:valueCreationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:valueHasOrder "0"^^xsd:integer ;
+	knora-base:valueHasString "Musikstudien bei Arnold Schönberg (1909 bis 1911), Alban Berg (1911 bis 1913). Studien bei Guido Adler (1927 Promotion in Innsbruck). Beamter (bei den österreichischen Bundesbahnen, nach dem Zweiten Weltkrieg  beim Finanzministerium), Musikwissenschaftler, Bibliothekar, nach seiner Pensionierung auch Kompositionslehrer. Herausgeber des Briefwechsels Anton Webern und Hildegard Jone (stark gekürzt)." .
+
+#
+# http://data.knora.org/webern/testperson1/values/4ab0cfaa-479a-4cd6-946e-2b51c4b9d016
+# webern:hasBiographySource
+
+<http://data.knora.org/webern/testperson1/values/4ab0cfaa-479a-4cd6-946e-2b51c4b9d016> a knora-base:TextValue, owl:NamedIndividual ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	knora-base:valueCreationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:valueHasOrder "0"^^xsd:integer ;
+	knora-base:valueHasString "https://www.wien.gv.at/wiki/index.php/Josef_Polnauer" .
+
+
+#
+# http://data.knora.org/webern/testperson1/values/f7675f26-4b01-4432-be74-9ae3aa24d2af
+# webern:hasRelation
+
+<http://data.knora.org/webern/testperson1/values/f7675f26-4b01-4432-be74-9ae3aa24d2af> a knora-base:TextValue, owl:NamedIndividual ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	knora-base:valueCreationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:valueHasOrder "0"^^xsd:integer ;
+	knora-base:valueHasString "Angehöriger des Schönberg-Kreises. Freund." .
+
+#
+# http://data.knora.org/webern/testperson1/values/df1260ad43d5
+# webern:comment
+
+<http://data.knora.org/webern/testperson1/values/df1260ad43d5> a knora-base:TextValue, owl:NamedIndividual ;
+	knora-base:attachedToUser <http://rdfh.ch/users/webernProjectMember> ;
+	knora-base:hasPermissions "CR knora-base:Creator|D knora-base:ProjectMember" ;
+	knora-base:isDeleted "false"^^xsd:boolean ;
+	knora-base:valueCreationDate "2017-12-01T17:00:00Z"^^xsd:dateTimeStamp ;
+	knora-base:valueHasOrder "0"^^xsd:integer ;
+	knora-base:valueHasString "Vgl. Eintrag 'Polnauer, Josef Maximilian' in Österreichisches Musiklexikon (online edition)." .
+
+
+
+#
+# Generated by the OWL API (version 4.2.6.20160910-2108) https://github.com/owlcs/owlapi

--- a/webapi/_test_data/ontologies/webern-onto.ttl
+++ b/webapi/_test_data/ontologies/webern-onto.ttl
@@ -1,0 +1,419 @@
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dc: <http://www.knora.org/ontology/dc#> .
+@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .
+@prefix salsah-gui: <http://www.knora.org/ontology/salsah-gui#> .
+@base <http://www.knora.org/ontology/08AE/webern> .
+
+@prefix : <http://www.knora.org/ontology/08AE/webern#> .
+
+<http://www.knora.org/ontology/08AE/webern> rdf:type owl:Ontology .
+
+    ##########################################################
+    #
+    # PROPERTIES
+    #
+    ##########################################################
+
+
+    ### ###########################################
+    ### webern:hasFamilyName
+
+    :hasFamilyName rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint :person ;
+
+              knora-base:objectClassConstraint knora-base:TextValue ;
+
+              rdfs:subPropertyOf knora-base:hasValue ;
+
+              rdfs:label "Nachname"@de ,
+                         "family name"@en ,
+                         "nom de famille"@fr ,
+                         "nome di famiglia"@it ;
+
+              rdfs:comment """Repräsentiert den Nachnamen einer Person."""@de ,
+                           """Represents the family name of a person."""@en ,
+                           """Représente le nom de famille d'une personne."""@fr ,
+                           """Rappresenta il nome di famiglia di una persona."""@it ;
+
+              salsah-gui:guiElement salsah-gui:SimpleText ;
+
+              salsah-gui:guiOrder "1"^^xsd:integer .
+
+    ### ###########################################
+    ### webern:hasGivenName
+
+    :hasGivenName rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint :person ;
+
+              knora-base:objectClassConstraint knora-base:TextValue ;
+
+              rdfs:subPropertyOf knora-base:hasValue ;
+
+              rdfs:label "Vorname"@de ,
+                         "given name"@en ,
+                         "prénom"@fr ,
+                         "nome di battesimo"@it ;
+
+              rdfs:comment """Repräsentiert den Vornamen einer Person."""@de ,
+                           """Represents the given name of a person."""@en ,
+                           """Représente le prénom d'une personne."""@fr ,
+                           """Rappresenta il nome di battesimo di una persona."""@it ;
+
+              salsah-gui:guiElement salsah-gui:SimpleText ;
+
+              salsah-gui:guiOrder "2"^^xsd:integer .
+
+    ### ###########################################
+    ### webern:hasAlternativeName
+
+    :hasAlternativeName rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint :person ;
+
+              knora-base:objectClassConstraint knora-base:TextValue ;
+
+              rdfs:subPropertyOf knora-base:hasValue ;
+
+              rdfs:label "anderer Name"@de ,
+                         "other names"@en ,
+                         "autres noms"@fr ,
+                         "altri nomi"@it ;
+
+              rdfs:comment """Repräsentiert alternative Namen einer Person."""@de ,
+                           """Represents alternative names of a person."""@en ,
+                           """Représente le nom alternatif d'une personne."""@fr ,
+                           """Rappresenta i nomi alternativi di una persona."""@it ;
+
+              salsah-gui:guiElement salsah-gui:Richtext ;
+
+              salsah-gui:guiOrder "3"^^xsd:integer .
+
+    ### ###########################################
+    ### webern:hasIAFIdentifier
+
+    :hasIAFIdentifier rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint :person ;
+
+              knora-base:objectClassConstraint knora-base:TextValue ;
+
+              rdfs:subPropertyOf knora-base:hasValue ;
+
+              rdfs:label "Gemeinsame Normdatei (GND)"@de ,
+                         "Integrated Authority File (IAF)"@en ,
+                         "Gemeinsame Normdatei (GND)"@fr ,
+                         "Gemeinsame Normdatei (GND)"@it ;
+
+              rdfs:comment """Repräsentiert die einer Person zugeordnete GND-Nummer."""@de ,
+                           """Represents the IAF number assigned to a person."""@en ,
+                           """Représente le numéro GND attribué à une personne."""@fr ,
+                           """Rappresenta il numero GND assegnato ad una persona."""@it ;
+
+              salsah-gui:guiElement salsah-gui:SimpleText ;
+
+              salsah-gui:guiOrder "4"^^xsd:integer .
+
+    ### ###########################################
+    ### webern:hasBirthPlace
+
+    :hasBirthPlace rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint :person ;
+
+              knora-base:objectClassConstraint knora-base:TextValue ;
+
+              rdfs:subPropertyOf knora-base:hasValue ;
+
+              rdfs:label "Geburtsort"@de ,
+                         "place of birth"@en ,
+                         "lieu de naissance"@fr ,
+                         "luogo di nascita"@it ;
+
+              rdfs:comment """Repräsentiert den Geburtsort einer Person."""@de ,
+                           """Represents the place of birth of a person."""@en ,
+                           """Représente le lieu de naissance d'une personne."""@fr ,
+                           """Rappresenta il luogo di nascita di una persona."""@it ;
+
+              salsah-gui:guiElement salsah-gui:SimpleText ;
+
+              salsah-gui:guiOrder "5"^^xsd:integer .
+
+    ### ###########################################
+    ### webern:hasBirthDate
+
+    :hasBirthDate rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint :person ;
+
+              knora-base:objectClassConstraint knora-base:DateValue ;
+
+              rdfs:subPropertyOf knora-base:hasValue ;
+
+              rdfs:label "Geburtdatum"@de ,
+                         "date of birth"@en ,
+                         "date de naissance"@fr ,
+                         "data di nascita"@it ;
+
+              rdfs:comment """Repräsentiert das Geburtsdatum einer Person."""@de ,
+                           """Represents the date of birth of a person."""@en ,
+                           """Représente la date de naissance d'une personne."""@fr ,
+                           """Rappresenta la data di nascita di una persona."""@it ;
+
+              salsah-gui:guiElement salsah-gui:Date ;
+
+              salsah-gui:guiOrder "6"^^xsd:integer .
+
+    ### ###########################################
+    ### webern:hasDeathDate
+
+    :hasDeathDate rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint :person ;
+
+              knora-base:objectClassConstraint knora-base:DateValue ;
+
+              rdfs:subPropertyOf knora-base:hasValue ;
+
+              rdfs:label "Sterbedatum"@de ,
+                         "date of death"@en ,
+                         "date de décès"@fr ,
+                         "data del decesso"@it ;
+
+              rdfs:comment """Repräsentiert das Geburtsdatum einer Person."""@de ,
+                           """Represents the date of death of a person."""@en ,
+                           """Représente la date de décès d'une personne."""@fr ,
+                           """Rappresenta la data del decesso di una persona."""@it ;
+
+              salsah-gui:guiElement salsah-gui:Date ;
+
+              salsah-gui:guiOrder "7"^^xsd:integer .
+
+    ### ###########################################
+    ### webern:hasDeathPlace
+
+    :hasDeathPlace rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint :person ;
+
+              knora-base:objectClassConstraint knora-base:TextValue ;
+
+              rdfs:subPropertyOf knora-base:hasValue ;
+
+              rdfs:label "Sterbesort"@de ,
+                         "place of death"@en ,
+                         "lieu de décès"@fr ,
+                         "luogo del decesso"@it ;
+
+              rdfs:comment """Repräsentiert den Sterbeort einer Person."""@de ,
+                           """Represents the place of death of a person."""@en ,
+                           """Représente le lieu de décès d'une personne."""@fr ,
+                           """Rappresenta il luogo del decesso di una persona."""@it ;
+
+              salsah-gui:guiElement salsah-gui:SimpleText ;
+
+              salsah-gui:guiOrder "8"^^xsd:integer .
+
+    ### ###########################################
+    ### webern:hasDeathPlace
+
+    :hasDeathPlace rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint :person ;
+
+              knora-base:objectClassConstraint knora-base:TextValue ;
+
+              rdfs:subPropertyOf knora-base:hasValue ;
+
+              rdfs:label "Sterbesort"@de ,
+                         "place of death"@en ,
+                         "lieu de décès"@fr ,
+                         "luogo del decesso"@it ;
+
+              rdfs:comment """Repräsentiert den Sterbeort einer Person."""@de ,
+                           """Represents the place of death of a person."""@en ,
+                           """Représente le lieu de décès d'une personne."""@fr ,
+                           """Rappresenta il luogo del decesso di una persona."""@it ;
+
+              salsah-gui:guiElement salsah-gui:SimpleText ;
+
+              salsah-gui:guiOrder "8"^^xsd:integer .
+
+    ### ###########################################
+    ### webern:hasBiography
+
+    :hasBiography rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint :person ;
+
+              knora-base:objectClassConstraint knora-base:TextValue ;
+
+              rdfs:subPropertyOf knora-base:hasValue ;
+
+              rdfs:label "Biographie"@de ,
+                         "biography"@en ,
+                         "biographie"@fr ,
+                         "biografia"@it ;
+
+              rdfs:comment """Repräsentiert die Biografie einer Person."""@de ,
+                           """Represents the biography of a person."""@en ,
+                           """Représente la biographie d'une personne."""@fr ,
+                           """Rappresenta la biografia di una persona."""@it ;
+
+              salsah-gui:guiElement salsah-gui:Richtext ;
+
+              salsah-gui:guiOrder "9"^^xsd:integer .
+
+    ### ###########################################
+    ### webern:hasBiographySource
+
+    :hasBiographySource rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint :person ;
+
+              knora-base:objectClassConstraint knora-base:TextValue ;
+
+              rdfs:subPropertyOf knora-base:hasValue ;
+
+              rdfs:label "Quellen zur Biographie"@de ,
+                         "biography sources"@en ,
+                         "sources de la biographie"@fr ,
+                         "fonti della biografia"@it ;
+
+              rdfs:comment """Repräsentiert Quellen zur Biografie einer Person."""@de ,
+                           """Represents sources for the biography of a person."""@en ,
+                           """Représente les sources de la biographie d'une personne."""@fr ,
+                           """Rappresenta le fonti della biografia di una persona."""@it ;
+
+              salsah-gui:guiElement salsah-gui:Richtext ;
+
+              salsah-gui:guiOrder "10"^^xsd:integer .
+
+    ### ###########################################
+    ### webern:hasRelation
+
+    :hasRelation rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint :person ;
+
+              knora-base:objectClassConstraint knora-base:TextValue ;
+
+              rdfs:subPropertyOf knora-base:hasValue ;
+
+              rdfs:label "Bezug zu Webern"@de ,
+                         "relation with Webern"@en ,
+                         "relation avec Webern "@fr ,
+                         "relazione con Webern"@it ;
+
+              rdfs:comment """Repräsentiert den Bezug einer Person zu Webern."""@de ,
+                           """Represents the relation of a person with Webern."""@en ,
+                           """Représente la relation d'une personne avec Webern."""@fr ,
+                           """Rappresenta la relazione di una persona con Webern."""@it ;
+
+              salsah-gui:guiElement salsah-gui:Richtext ;
+
+              salsah-gui:guiOrder "11"^^xsd:integer .
+
+    ### ###########################################
+    ### webern:comment
+
+    :comment rdf:type owl:ObjectProperty ;
+
+              knora-base:subjectClassConstraint knora-base:Resource ;
+
+              knora-base:objectClassConstraint knora-base:TextValue ;
+
+              rdfs:subPropertyOf knora-base:hasComment ;
+
+              rdfs:label "Kommentar"@de ,
+                         "Comment"@en ,
+                         "Commentaire"@fr ,
+                         "Commento"@it ;
+
+              rdfs:comment """Repräsentiert einen Kommentar zur Ressource."""@de ,
+                           """Represents a comment on the resource."""@en ,
+                           """Représente un commentaire sur la ressource."""@fr ,
+                           """Rappresenta un commento sulla risorsa."""@it ;
+
+              salsah-gui:guiElement salsah-gui:Richtext ;
+
+              salsah-gui:guiOrder "20"^^xsd:integer .
+
+
+    ##########################################################
+    #
+    # RESOURCES
+    #
+    ##########################################################
+
+
+
+    ### ###########################################
+    ### webern:Person
+
+    :person rdf:type owl:Class ;
+
+        rdfs:subClassOf knora-base:Resource, foaf:Person ,
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :hasFamilyName ;
+                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                        ],
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :hasGivenName ;
+                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                        ],
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :hasAlternativeName ;
+                          owl:minCardinality "0"^^xsd:nonNegativeInteger
+                        ],
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :hasIAFIdentifier ;
+                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                        ],
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :hasBirthPlace ;
+                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                        ],
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :hasBirthDate ;
+                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                        ],
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :hasDeathDate ;
+                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                        ],
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :hasDeathPlace ;
+                          owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                        ],
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :hasBiography ;
+                          owl:minCardinality "0"^^xsd:nonNegativeInteger
+                        ],
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :hasBiographySource ;
+                          owl:minCardinality "0"^^xsd:nonNegativeInteger
+                        ],
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :hasRelation ;
+                          owl:minCardinality "0"^^xsd:nonNegativeInteger
+                        ],
+                        [ rdf:type owl:Restriction ;
+                          owl:onProperty :comment ;
+                          owl:minCardinality "0"^^xsd:nonNegativeInteger
+                        ] ;
+
+        knora-base:resourceIcon "person.png" ;
+
+        rdfs:label "Person"@de ,
+                   "Person"@en ,
+                   "Personne"@fr ,
+                   "Persona"@it ;
+
+        rdfs:comment "A resource representing a person"@en .

--- a/webapi/_test_data/ontologies/webern-onto.ttl
+++ b/webapi/_test_data/ontologies/webern-onto.ttl
@@ -25,7 +25,7 @@
 
     :hasFamilyName rdf:type owl:ObjectProperty ;
 
-              knora-base:subjectClassConstraint :person ;
+              knora-base:subjectClassConstraint :Person ;
 
               knora-base:objectClassConstraint knora-base:TextValue ;
 
@@ -50,7 +50,7 @@
 
     :hasGivenName rdf:type owl:ObjectProperty ;
 
-              knora-base:subjectClassConstraint :person ;
+              knora-base:subjectClassConstraint :Person ;
 
               knora-base:objectClassConstraint knora-base:TextValue ;
 
@@ -75,7 +75,7 @@
 
     :hasAlternativeName rdf:type owl:ObjectProperty ;
 
-              knora-base:subjectClassConstraint :person ;
+              knora-base:subjectClassConstraint :Person ;
 
               knora-base:objectClassConstraint knora-base:TextValue ;
 
@@ -100,7 +100,7 @@
 
     :hasIAFIdentifier rdf:type owl:ObjectProperty ;
 
-              knora-base:subjectClassConstraint :person ;
+              knora-base:subjectClassConstraint :Person ;
 
               knora-base:objectClassConstraint knora-base:TextValue ;
 
@@ -125,7 +125,7 @@
 
     :hasBirthPlace rdf:type owl:ObjectProperty ;
 
-              knora-base:subjectClassConstraint :person ;
+              knora-base:subjectClassConstraint :Person ;
 
               knora-base:objectClassConstraint knora-base:TextValue ;
 
@@ -150,7 +150,7 @@
 
     :hasBirthDate rdf:type owl:ObjectProperty ;
 
-              knora-base:subjectClassConstraint :person ;
+              knora-base:subjectClassConstraint :Person ;
 
               knora-base:objectClassConstraint knora-base:DateValue ;
 
@@ -175,7 +175,7 @@
 
     :hasDeathDate rdf:type owl:ObjectProperty ;
 
-              knora-base:subjectClassConstraint :person ;
+              knora-base:subjectClassConstraint :Person ;
 
               knora-base:objectClassConstraint knora-base:DateValue ;
 
@@ -200,7 +200,7 @@
 
     :hasDeathPlace rdf:type owl:ObjectProperty ;
 
-              knora-base:subjectClassConstraint :person ;
+              knora-base:subjectClassConstraint :Person ;
 
               knora-base:objectClassConstraint knora-base:TextValue ;
 
@@ -225,7 +225,7 @@
 
     :hasDeathPlace rdf:type owl:ObjectProperty ;
 
-              knora-base:subjectClassConstraint :person ;
+              knora-base:subjectClassConstraint :Person ;
 
               knora-base:objectClassConstraint knora-base:TextValue ;
 
@@ -250,7 +250,7 @@
 
     :hasBiography rdf:type owl:ObjectProperty ;
 
-              knora-base:subjectClassConstraint :person ;
+              knora-base:subjectClassConstraint :Person ;
 
               knora-base:objectClassConstraint knora-base:TextValue ;
 
@@ -275,7 +275,7 @@
 
     :hasBiographySource rdf:type owl:ObjectProperty ;
 
-              knora-base:subjectClassConstraint :person ;
+              knora-base:subjectClassConstraint :Person ;
 
               knora-base:objectClassConstraint knora-base:TextValue ;
 
@@ -300,7 +300,7 @@
 
     :hasRelation rdf:type owl:ObjectProperty ;
 
-              knora-base:subjectClassConstraint :person ;
+              knora-base:subjectClassConstraint :Person ;
 
               knora-base:objectClassConstraint knora-base:TextValue ;
 
@@ -357,7 +357,7 @@
     ### ###########################################
     ### webern:Person
 
-    :person rdf:type owl:Class ;
+    :Person rdf:type owl:Class ;
 
         rdfs:subClassOf knora-base:Resource, foaf:Person ,
                         [ rdf:type owl:Restriction ;

--- a/webapi/_test_data/queries/webern/find_webern_person.rql
+++ b/webapi/_test_data/queries/webern/find_webern_person.rql
@@ -1,0 +1,12 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX webern: <http://www.knora.org/ontology/08AE/webern#>
+
+SELECT *
+WHERE {
+	?s a foaf:Person .
+    ?s knora-base:attachedToProject ?project .
+
+    ?project knora-base:projectShortname "webern" .
+
+} LIMIT 100

--- a/webapi/_test_data/queries/webern/relation_via_schoenberg.rql
+++ b/webapi/_test_data/queries/webern/relation_via_schoenberg.rql
@@ -1,0 +1,21 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+PREFIX webern: <http://www.knora.org/ontology/08AE/webern#>
+
+SELECT (CONCAT(?first, ' ', ?last) AS ?fullname) ?string
+WHERE {
+    ?s a foaf:Person ;
+    	knora-base:attachedToProject ?project .
+    ?project knora-base:projectShortname "webern" .
+
+	?s webern:hasRelation ?relation ;
+    	webern:hasFamilyName ?familyName ;
+    	webern:hasGivenName ?givenName .
+
+    ?relation knora-base:valueHasString ?string .
+    FILTER regex(str(?string), "Schönberg") .
+
+    ?familyName knora-base:valueHasString ?last .
+    ?givenName knora-base:valueHasString ?first .
+
+} LIMIT 100

--- a/webapi/scripts/graphdb-knora-test-data.expect
+++ b/webapi/scripts/graphdb-knora-test-data.expect
@@ -48,6 +48,10 @@ send "load ../_test_data/all_data/biblio-data.ttl into http://www.knora.org/data
 expect $prompt
 send "load ../_test_data/ontologies/example.ttl into http://www.knora.org/ontology/0001/example .\r"
 expect $prompt
+send "load ../_test_data/ontologies/webern-onto.ttl into http://www.knora.org/ontology/08AE/webern .\r"
+expect $prompt
+send "load ../_test_data/all_data/webern-data.ttl into http://www.knora.org/data/08AE/webern .\r"
+expect $prompt
 send "close .\r"
 expect $prompt
 send "exit .\r"


### PR DESCRIPTION
This small PR adds some basic Webern test data to the webapi (`graphdb-knora-test.expect`) after @subotic was so kind to explain where the necessary steps have to be taken.

It includes
- creation of `webern-onto.ttl`, 
- creation of `webern-data.ttl`,
- additions of project and test user to `admin-data.ttl` and 
- additions of permissions to `permissions-data.ttl`

Everything is loaded to graphdb without errors here.

Also, I added a new folder `queries` inside `webapi` to store SPARQL query files that can be used to test the data. For now, there are two very basic queries for the Webern data.