### PR TITLE
Correctly process Variables contained in UNION and OPTIONAL

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -1913,8 +1913,19 @@ class SearchResponderV2 extends ResponderWithStandoffV2 {
 
                         val dependentResIris: Set[IRI] = dependentResourceVariablesConcat.flatMap {
                             dependentResVar: QueryVariable =>
-                                // Iris are concatenated, split them
-                                resultRow.rowMap(dependentResVar.variableName).split(nonTriplestoreSpecificConstructToSelectTransformer.groupConcatSeparator).toSeq
+
+                                // check if key exists (the variable could be contained in an OPTIONAL or a UNION)
+                                val dependentResIriOption: Option[IRI] = resultRow.rowMap.get(dependentResVar.variableName)
+
+                                dependentResIriOption match {
+                                    case Some(depResIri: IRI) =>
+
+                                        // Iris are concatenated, split them
+                                        depResIri.split(nonTriplestoreSpecificConstructToSelectTransformer.groupConcatSeparator).toSeq
+
+                                    case None => Set.empty[IRI] // no value present
+                                }
+
                         }
 
                         acc + (mainResIri -> dependentResIris)
@@ -1944,7 +1955,22 @@ class SearchResponderV2 extends ResponderWithStandoffV2 {
 
                         val valueObjVarToIris: Map[QueryVariable, Set[IRI]] = valueObjectVariablesConcat.map {
                             (valueObjVarConcat: QueryVariable) =>
-                                valueObjVarConcat -> resultRow.rowMap(valueObjVarConcat.variableName).split(nonTriplestoreSpecificConstructToSelectTransformer.groupConcatSeparator).toSet
+
+                                // check if key exists (the variable could be contained in an OPTIONAL or a UNION)
+                                val valueObjVarToIrisOption: Option[IRI] = resultRow.rowMap.get(valueObjVarConcat.variableName)
+
+                                val valueObjVarToIris: Set[IRI] = valueObjVarToIrisOption match {
+
+                                    case Some(valObjVarToIris) =>
+
+                                        // Iris are concatenated, split them
+                                        valObjVarToIris.split(nonTriplestoreSpecificConstructToSelectTransformer.groupConcatSeparator).toSet
+
+                                    case None => Set.empty[IRI] // no value present
+
+                                }
+
+                                valueObjVarConcat -> valueObjVarToIris
                         }.toMap
 
                         acc + (mainResIri -> valueObjVarToIris)

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -1944,7 +1944,7 @@ class SearchResponderV2 extends ResponderWithStandoffV2 {
                 // the Iris of all dependent resources for all main resources
                 val allDependentResourceIris: Set[IRI] = dependentResourceIrisPerMainResource.values.flatten.toSet ++ dependentResourceIrisFromTypeInspection
 
-                // value objects variables present in the preequery's WHERE clause
+                // value objects variables present in the prequery's WHERE clause
                 val valueObjectVariablesConcat = nonTriplestoreSpecificConstructToSelectTransformer.getValueObjectVarsGroupConcat
 
                 // for each main resource, create a Map of value object variables and their values
@@ -1957,20 +1957,20 @@ class SearchResponderV2 extends ResponderWithStandoffV2 {
                             (valueObjVarConcat: QueryVariable) =>
 
                                 // check if key exists (the variable could be contained in an OPTIONAL or a UNION)
-                                val valueObjVarToIrisOption: Option[IRI] = resultRow.rowMap.get(valueObjVarConcat.variableName)
+                                val valueObjIrisOption: Option[IRI] = resultRow.rowMap.get(valueObjVarConcat.variableName)
 
-                                val valueObjVarToIris: Set[IRI] = valueObjVarToIrisOption match {
+                                val valueObjIris: Set[IRI] = valueObjIrisOption match {
 
-                                    case Some(valObjVarToIris) =>
+                                    case Some(valObjIris) =>
 
                                         // Iris are concatenated, split them
-                                        valObjVarToIris.split(nonTriplestoreSpecificConstructToSelectTransformer.groupConcatSeparator).toSet
+                                        valObjIris.split(nonTriplestoreSpecificConstructToSelectTransformer.groupConcatSeparator).toSet
 
                                     case None => Set.empty[IRI] // no value present
 
                                 }
 
-                                valueObjVarConcat -> valueObjVarToIris
+                                valueObjVarConcat -> valueObjIris
                         }.toMap
 
                         acc + (mainResIri -> valueObjVarToIris)

--- a/webapi/src/test/resources/test-data/searchR2RV2/IncomingLinksForBook.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/IncomingLinksForBook.jsonld
@@ -1,0 +1,24 @@
+{
+  "@type" : "schema:ItemList",
+  "schema:itemListElement" : {
+    "@id" : "http://data.knora.org/881405205304",
+    "@type" : "knora-api:LinkObj",
+    "knora-api:hasLinkToValue" : {
+      "@id" : "http://data.knora.org/881405205304/values/9a126ec9-9387-4cc5-b565-0029a7344bf0",
+      "@type" : "knora-api:LinkValue",
+      "knora-api:linkValueHasTarget" : {
+        "@id" : "http://data.knora.org/8be1b7cf7103",
+        "@type" : "http://0.0.0.0:3333/ontology/incunabula/v2#book",
+        "schema:name" : "[Das] Narrenschiff (lat.)"
+      }
+    },
+    "schema:name" : "Lateinische Übersetzung"
+  },
+  "schema:numberOfItems" : 1,
+  "@context" : {
+    "schema" : "http://schema.org/",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#"
+  }
+}

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBooleanOptional.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBooleanOptional.jsonld
@@ -1,0 +1,45 @@
+{
+  "@type" : "schema:ItemList",
+  "schema:itemListElement" : [ {
+    "@id" : "http://data.knora.org/nVh9YJ1ZStSmCHb9hIdwWw",
+    "@type" : "anything:Thing",
+    "schema:name" : "excluded Charlie"
+  }, {
+    "@id" : "http://data.knora.org/project-thing-1",
+    "@type" : "anything:Thing",
+    "schema:name" : "A thing that only project members can see"
+  }, {
+    "@id" : "http://data.knora.org/project-thing-2",
+    "@type" : "anything:Thing",
+    "schema:name" : "Another thing that only project members can see"
+  }, {
+    "@id" : "http://data.knora.org/rzRrc2G1StKUMyZVjJnxuw",
+    "@type" : "anything:Thing",
+    "schema:name" : "Kilo"
+  }, {
+    "@id" : "http://data.knora.org/sHCLAGg-R5qJ6oPZPV-zOQ",
+    "@type" : "anything:Thing",
+    "schema:name" : "Golf"
+  }, {
+    "@id" : "http://data.knora.org/tPfZeNMvRVujCQqbIbvO0A",
+    "@type" : "anything:Thing",
+    "schema:name" : "Echo"
+  }, {
+    "@id" : "http://rdfh.ch/anything/uqmMo72OQ2K2xe7mkIytlg",
+    "@type" : "anything:Thing",
+    "anything:hasBoolean" : {
+      "@id" : "http://rdfh.ch/anything/WOPBNzp4TM-QxrEVt6U6hQ/values/azE8tXC6RFKv296GXYEg5Q",
+      "@type" : "knora-api:BooleanValue",
+      "knora-api:booleanValueAsBoolean" : true
+    },
+    "schema:name" : "Testding for extended search"
+  } ],
+  "schema:numberOfItems" : 7,
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "schema" : "http://schema.org/",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "anything" : "http://0.0.0.0:3333/ontology/anything/v2#"
+  }
+}

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBooleanOrDecimal.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBooleanOrDecimal.jsonld
@@ -1,0 +1,26 @@
+{
+  "@type" : "schema:ItemList",
+  "schema:itemListElement" : {
+    "@id" : "http://rdfh.ch/anything/uqmMo72OQ2K2xe7mkIytlg",
+    "@type" : "anything:Thing",
+    "anything:hasBoolean" : {
+      "@id" : "http://rdfh.ch/anything/WOPBNzp4TM-QxrEVt6U6hQ/values/azE8tXC6RFKv296GXYEg5Q",
+      "@type" : "knora-api:BooleanValue",
+      "knora-api:booleanValueAsBoolean" : true
+    },
+    "anything:hasDecimal" : {
+      "@id" : "http://rdfh.ch/anything/uqmMo72OQ2K2xe7mkIytlg/values/85et-o-STOmn2JcVqrGTCQ",
+      "@type" : "knora-api:DecimalValue",
+      "knora-api:decimalValueAsDecimal" : "2.1"
+    },
+    "schema:name" : "Testding for extended search"
+  },
+  "schema:numberOfItems" : 1,
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "schema" : "http://schema.org/",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "anything" : "http://0.0.0.0:3333/ontology/anything/v2#"
+  }
+}

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -1076,7 +1076,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
         "get a book a page points to and include the page in the results (all properties present in WHERE clause)" in {
             val sparqlSimplified =
-            """
+                """
             PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
             PREFIX incunabula: <http://0.0.0.0:3333/ontology/incunabula/simple/v2#>
 
@@ -1181,6 +1181,54 @@ class SearchRouteV2R2RSpec extends R2RSpec {
                 assert(status == StatusCodes.OK, response.toString)
 
                 val expectedAnswerJSONLD = FileUtil.readTextFile(new File("src/test/resources/test-data/searchR2RV2/bookWithIncomingPagesOnlyLink.jsonld"))
+
+                compareJSONLD(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
+
+            }
+
+        }
+
+        "get incoming links pointing to an incunbaula:book, excluding isPartOf and isRegionOf" in {
+            var sparqlSimplified =
+                """
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+                  |
+                  |CONSTRUCT {
+                  |
+                  |     ?incomingRes knora-api:isMainResource true .
+                  |
+                  |     ?incomingRes ?incomingProp <http://data.knora.org/8be1b7cf7103> .
+                  |
+                  |} WHERE {
+                  |
+                  |     ?incomingRes a knora-api:Resource .
+                  |
+                  |     ?incomingRes ?incomingProp <http://data.knora.org/8be1b7cf7103> .
+                  |
+                  |     <http://data.knora.org/8be1b7cf7103> a knora-api:Resource .
+                  |
+                  |     ?incomingProp knora-api:objectType knora-api:Resource .
+                  |
+                  |     knora-api:isRegionOf knora-api:objectType knora-api:Resource .
+                  |     knora-api:isPartOf knora-api:objectType knora-api:Resource .
+                  |
+                  |     FILTER NOT EXISTS {
+                  |         ?incomingRes  knora-api:isRegionOf <http://data.knora.org/8be1b7cf7103> .
+                  |     }
+                  |
+                  |     FILTER NOT EXISTS {
+                  |         ?incomingRes  knora-api:isPartOf <http://data.knora.org/8be1b7cf7103> .
+                  |     }
+                  |
+                  |} OFFSET 0
+                """.stripMargin
+
+            // TODO: find a better way to submit spaces as %20
+            Get("/v2/searchextended/" + URLEncoder.encode(sparqlSimplified, "UTF-8").replace("+", "%20")) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                val expectedAnswerJSONLD = FileUtil.readTextFile(new File("src/test/resources/test-data/searchR2RV2/IncomingLinksForBook.jsonld"))
 
                 compareJSONLD(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -1522,5 +1522,60 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
         }
 
+        "search for an anything:Thing that either has a Boolean value that is true or a decimal value that equals 2.1 (or both)" in {
+
+            val sparqlSimplified =
+                """
+                  |PREFIX anything: <http://0.0.0.0:3333/ontology/anything/simple/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+                  |
+                  |CONSTRUCT {
+                  |     ?thing knora-api:isMainResource true .
+                  |
+                  |     ?thing a anything:Thing .
+                  |
+                  |     ?thing anything:hasBoolean ?boolean .
+                  |
+                  |     ?thing anything:hasDecimal ?decimal .
+                  |} WHERE {
+                  |
+                  |     ?thing a anything:Thing .
+                  |     ?thing a knora-api:Resource .
+                  |
+                  |     {
+                  |         ?thing anything:hasBoolean ?boolean .
+                  |         anything:hasBoolean knora-api:objectType xsd:boolean .
+                  |
+                  |         ?boolean a xsd:boolean .
+                  |
+                  |         FILTER(?boolean = true)
+                  |     } UNION {
+                  |         ?thing anything:hasDecimal ?decimal .
+                  |         anything:hasDecimal knora-api:objectType xsd:decimal .
+                  |
+                  |         ?decimal a xsd:decimal .
+                  |
+                  |         FILTER(?decimal = 2.1)
+                  |     }
+                  |
+                  |} OFFSET 0
+                  |
+                """.stripMargin
+
+            // TODO: find a better way to submit spaces as %20
+            Get("/v2/searchextended/" + URLEncoder.encode(sparqlSimplified, "UTF-8").replace("+", "%20")) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                val expectedAnswerJSONLD = FileUtil.readTextFile(new File("src/test/resources/test-data/searchR2RV2/ThingWithBooleanOrDecimal.jsonld"))
+
+                compareJSONLD(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
+
+                checkCountQuery(responseAs[String], 1)
+
+            }
+
+        }
+
     }
 }


### PR DESCRIPTION
When processing the results of a prequery, some values may be optional (OPTIONAL and UNION).

We actually do not have to know whether a value was in a UNION or an OPTIONAL when processing the prequery's results because this is all handled in the prequery's WHERE clause. If a value was expected but not returned, the whole resource would not have been returned and would not be available for processing.

closes #686