### PR TITLE
Configure graphdb for production

### DIFF
--- a/webapi/scripts/graphdb-se-knora-prod-repository-config.ttl.tmpl
+++ b/webapi/scripts/graphdb-se-knora-prod-repository-config.ttl.tmpl
@@ -16,5 +16,8 @@
        sail:sailType "owlim:Sail" ;
        owlim:base-URL "http://data.knora.org/" ;
        owlim:repository-type "file-repository" ;
+       owlim:query-timeout "2" ;
+       owlim:throw-QueryEvaluationException-on-timeout "true";
+       owlim:query-limit-results "50000";
       ]
    ].

--- a/webapi/scripts/graphdb-se-knora-test-repository-config.ttl.tmpl
+++ b/webapi/scripts/graphdb-se-knora-test-repository-config.ttl.tmpl
@@ -16,5 +16,8 @@
        sail:sailType "owlim:Sail" ;
        owlim:base-URL "http://data.knora.org/" ;
        owlim:repository-type "file-repository" ;
+       owlim:query-timeout "2" ;
+       owlim:throw-QueryEvaluationException-on-timeout "true";
+       owlim:query-limit-results "50000";
       ]
    ].

--- a/webapi/scripts/graphdb-se-knora-test-unit-repository-config.ttl.tmpl
+++ b/webapi/scripts/graphdb-se-knora-test-unit-repository-config.ttl.tmpl
@@ -16,5 +16,8 @@
        sail:sailType "owlim:Sail" ;
        owlim:base-URL "http://data.knora.org/" ;
        owlim:repository-type "file-repository" ;
+       owlim:query-timeout "2" ;
+       owlim:throw-QueryEvaluationException-on-timeout "true";
+       owlim:query-limit-results "50000";
       ]
    ].


### PR DESCRIPTION
try to find a reasonable setup that prevents the triplestore from crashing but does not break normal queries