### PR TITLE
URI values are not supported in KnarQL

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -689,6 +689,35 @@ class SearchResponderV2 extends ResponderWithStandoffV2 {
                                             )
                                         )
 
+                                    case OntologyConstants.Xsd.Uri =>
+
+                                        // make sure that the right argument is a Uri literal
+                                        val uriLiteral: XsdLiteral = filterCompare.rightArg match {
+                                            case uriLiteral: XsdLiteral if uriLiteral.datatype.toString == OntologyConstants.Xsd.Uri => uriLiteral
+
+                                            case other => throw SparqlSearchException(s"right argument in CompareExpression for Uri property was expected to be a Uri literal, but $other is given.")
+                                        }
+
+                                        // create a variable representing the Uri literal
+                                        val uriValHasString = createUniqueVariableNameFromEntityAndProperty(queryVar, OntologyConstants.KnoraBase.ValueHasUri)
+
+                                        // add this variable to the collection of additionally created variables (needed for sorting in the prequery)
+                                        valueVariablesCreatedInFilters.put(queryVar, uriValHasString)
+
+                                        // check if operator is supported for Uri operations
+                                        if (!(filterCompare.operator.equals(CompareExpressionOperator.EQUALS) || filterCompare.operator.equals(CompareExpressionOperator.NOT_EQUALS))) {
+                                            throw SparqlSearchException(s"Filter expressions for a Uri value supports the following operators: ${CompareExpressionOperator.EQUALS}, ${CompareExpressionOperator.NOT_EQUALS}, but ${filterCompare.operator} given")
+                                        }
+
+                                        TransformedFilterExpression(
+                                            CompareExpression(uriValHasString, filterCompare.operator, uriLiteral),
+                                            Seq(
+                                                // connects the value object with the value literal
+                                                StatementPattern.makeExplicit(subj = queryVar, pred = IriRef(OntologyConstants.KnoraBase.ValueHasUri.toSmartIri), uriValHasString)
+                                            )
+                                        )
+
+
                                     case OntologyConstants.KnoraApiV2Simple.Date =>
 
                                         // make sure that the right argument is a string literal (dates are represented as knora date strings in knora-api simple)

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -1966,8 +1966,10 @@ class SearchResponderV2 extends ResponderWithStandoffV2 {
                 }.toSet
 
                 // the user may have defined Iris of dependent resources in the input query (type annotations)
+                // only add them if they are mentioned in a positive context (not negated like in a FILTER NOT EXISTS or MINUS)
                 val dependentResourceIrisFromTypeInspection: Set[IRI] = typeInspectionResult.typedEntities.collect {
-                    case (iri: TypeableIri, _: NonPropertyTypeInfo) => iri.iri.toString
+                    case (iri: TypeableIri, _: NonPropertyTypeInfo) if whereClauseWithoutAnnotations.positiveEntities.contains(IriRef(iri.iri)) =>
+                        iri.iri.toString
                 }.toSet
 
                 // the Iris of all dependent resources for all main resources

--- a/webapi/src/main/scala/org/knora/webapi/twirl/StandoffTag.scala
+++ b/webapi/src/main/scala/org/knora/webapi/twirl/StandoffTag.scala
@@ -62,6 +62,20 @@ case class StandoffTagIriAttributeV1(standoffPropertyIri: IRI, value: IRI) exten
 }
 
 /**
+  * Represents a standoff tag attribute of type URI.
+  *
+  * @param standoffPropertyIri the IRI of the standoff property
+  * @param value               the value of the standoff property.
+  */
+case class StandoffTagUriAttributeV1(standoffPropertyIri: IRI, value: String) extends StandoffTagAttributeV1 {
+
+    def stringValue = value
+
+    def rdfValue = s""""${stringValue.toString}"^^xsd:anyURI"""
+
+}
+
+/**
   * Represents a standoff tag attribute that refers to another standoff node.
   *
   * @param standoffPropertyIri the IRI of the standoff property

--- a/webapi/src/main/scala/org/knora/webapi/util/search/SparqlQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/search/SparqlQuery.scala
@@ -350,7 +350,7 @@ case class ConstructClause(statements: Seq[StatementPattern]) extends SparqlGene
   *
   * @param patterns the patterns in the WHERE clause.
   */
-case class WhereClause(patterns: Seq[QueryPattern]) extends SparqlGenerator {
+case class WhereClause(patterns: Seq[QueryPattern], positiveEntities: Set[Entity] = Set.empty[Entity]) extends SparqlGenerator {
     def toSparql: String = "WHERE {\n" + patterns.map(_.toSparql).mkString + "}\n"
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/util/search/v2/ExplicitTypeInspectorV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/search/v2/ExplicitTypeInspectorV2.scala
@@ -63,6 +63,7 @@ class ExplicitTypeInspectorV2 extends TypeInspector {
             OntologyConstants.Xsd.String,
             OntologyConstants.Xsd.Integer,
             OntologyConstants.Xsd.Decimal,
+            OntologyConstants.Xsd.Uri,
             OntologyConstants.KnoraApiV2Simple.Resource,
             OntologyConstants.KnoraApiV2Simple.Date,
             OntologyConstants.KnoraApiV2Simple.Geom,

--- a/webapi/src/main/scala/org/knora/webapi/util/search/v2/ExplicitTypeInspectorV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/search/v2/ExplicitTypeInspectorV2.scala
@@ -145,7 +145,9 @@ class ExplicitTypeInspectorV2 extends TypeInspector {
       * @return the same WHERE clause, minus any type annotations.
       */
     def removeTypeAnnotations(whereClause: WhereClause): WhereClause = {
-        WhereClause(removeTypeAnnotationsFromPatterns(whereClause.patterns))
+        whereClause.copy(
+            patterns = removeTypeAnnotationsFromPatterns(whereClause.patterns)
+        )
     }
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/util/standoff/StandoffTagUtilV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/standoff/StandoffTagUtilV1.scala
@@ -442,7 +442,7 @@ object StandoffTagUtilV1 {
 
                         val uriString: String = getDataTypeAttribute(standoffDefFromMapping, StandoffDataTypeClasses.StandoffUriTag, standoffNodeFromXML)
 
-                        val uriValue = StandoffTagIriAttributeV1(standoffPropertyIri = OntologyConstants.KnoraBase.ValueHasUri, value = stringFormatter.validateAndEscapeIri(uriString, () => throw BadRequestException(s"IRI invalid: $uriString")))
+                        val uriValue = StandoffTagUriAttributeV1(standoffPropertyIri = OntologyConstants.KnoraBase.ValueHasUri, value = stringFormatter.validateAndEscapeIri(uriString, () => throw BadRequestException(s"URI invalid: $uriString")))
 
                         val classSpecificProps = cardinalities -- StandoffProperties.systemProperties -- StandoffProperties.uriProperties
 

--- a/webapi/src/main/twirl/queries/sparql/v1/addValueVersion.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/addValueVersion.scala.txt
@@ -171,7 +171,7 @@ DELETE {
 
             case uriValue: UriValueV1 => {
 
-                ?newValue knora-base:valueHasUri """@uriValue.uri""" .
+                ?newValue knora-base:valueHasUri """@uriValue.uri"""^^xsd:anyURI .
 
             }
 

--- a/webapi/src/main/twirl/queries/sparql/v1/generateInsertStatementsForCreateValue.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/generateInsertStatementsForCreateValue.scala.txt
@@ -138,7 +138,7 @@
 
             case uriValue: UriValueV1 => {
 
-                <@newValueIri> knora-base:valueHasUri """@uriValue.uri""" .
+                <@newValueIri> knora-base:valueHasUri """@uriValue.uri"""^^xsd:anyURI .
 
             }
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/StandoffV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/StandoffV1R2RSpec.scala
@@ -952,8 +952,7 @@ class StandoffV1R2RSpec extends R2RSpec {
                 assert(status == StatusCodes.OK, "creation of a TextValue from XML returned a non successful HTTP status code: " + responseAs[String])
 
                 thirdTextValueIri.set(ResponseUtils.getStringMemberFromResponse(response, "id"))
-
-
+                
             }
 
         }

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2Spec.scala
@@ -104,7 +104,7 @@ class SearchResponderV2Spec extends CoreSpec() with ImplicitSender {
 
             actorUnderTest ! ExtendedSearchGetRequestV2(searchResponderV2SpecFullData.constructQueryForBooksWithTitleZeitgloecklein, SharedAdminTestData.anonymousUser)
 
-            // extended search sorty by resource Iri by default if no order criterion is indicated
+            // extended search sort by resource Iri by default if no order criterion is indicated
             expectMsgPF(timeout) {
                 case response: ReadResourcesSequenceV2 =>
                     compareReadResourcesSequenceV2Response(expected = searchResponderV2SpecFullData.booksWithTitleZeitgloeckleinResponse, received = response)
@@ -116,7 +116,7 @@ class SearchResponderV2Spec extends CoreSpec() with ImplicitSender {
 
             actorUnderTest ! ExtendedSearchGetRequestV2(searchResponderV2SpecFullData.constructQueryForBooksWithoutTitleZeitgloecklein, SharedAdminTestData.anonymousUser)
 
-            // extended search sorty by resource Iri by default if no order criterion is indicated
+            // extended search sort by resource Iri by default if no order criterion is indicated
             expectMsgPF(timeout) {
                 case response: ReadResourcesSequenceV2 =>
                     // TODO: do better testing once JSON-LD can be converted back into case classes

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2SpecFullData.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2SpecFullData.scala
@@ -9,6 +9,7 @@ import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.StringFormatter
 import org.knora.webapi.util.search._
 
+
 class SearchResponderV2SpecFullData {
 
     implicit lazy val system: ActorSystem = ActorSystem("webapi")
@@ -1017,87 +1018,33 @@ class SearchResponderV2SpecFullData {
         numberOfResources = 1
     )
 
+    // Dear Ben: I am aware of the fact that this code is not formatted properly and I know that this deeply disturbs you. But please leave it like this since otherwise I cannot possibly read and understand this query.
     val constructQueryForBooksWithTitleZeitgloecklein = ConstructQuery(
-        whereClause = WhereClause(patterns = Vector(
-            StatementPattern(
-                namedGraph = None,
-                obj = IriRef(
-                    iri = "http://0.0.0.0:3333/ontology/incunabula/simple/v2#book".toSmartIri
-                ),
-                pred = IriRef(
-                    iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri
-                ),
-                subj = QueryVariable(variableName = "book")
+        constructClause = ConstructClause(
+            Vector(
+                StatementPattern(QueryVariable("book"), IriRef("http://api.knora.org/ontology/knora-api/simple/v2#isMainResource".toSmartIri, None), XsdLiteral("true", "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri), None),
+                StatementPattern(QueryVariable("book"), IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri, None), QueryVariable("title"), None))
+        ),
+        whereClause = WhereClause(
+            patterns = Vector(
+                StatementPattern(QueryVariable("book"), IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None), IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#book".toSmartIri, None), None),
+                StatementPattern(QueryVariable("book"), IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None), IriRef("http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, None), None),
+                StatementPattern(QueryVariable("book"), IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri, None), QueryVariable("title"), None),
+                StatementPattern(IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri, None), IriRef("http://api.knora.org/ontology/knora-api/simple/v2#objectType".toSmartIri, None), IriRef("http://www.w3.org/2001/XMLSchema#string".toSmartIri, None), None),
+                StatementPattern(QueryVariable("title"), IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None), IriRef("http://www.w3.org/2001/XMLSchema#string".toSmartIri, None), None),
+                FilterPattern(CompareExpression(QueryVariable("title"), CompareExpressionOperator.EQUALS, XsdLiteral("Zeitglöcklein des Lebens und Leidens Christi", "http://www.w3.org/2001/XMLSchema#string".toSmartIri)))
             ),
-            StatementPattern(
-                namedGraph = None,
-                obj = IriRef(
-                    iri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri
-                ),
-                pred = IriRef(
-                    iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri
-                ),
-                subj = QueryVariable(variableName = "book")
-            ),
-            StatementPattern(
-                namedGraph = None,
-                obj = QueryVariable(variableName = "title"),
-                pred = IriRef(
-                    iri = "http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri
-                ),
-                subj = QueryVariable(variableName = "book")
-            ),
-            StatementPattern(
-                namedGraph = None,
-                obj = IriRef(
-                    iri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
-                ),
-                pred = IriRef(
-                    iri = "http://api.knora.org/ontology/knora-api/simple/v2#objectType".toSmartIri
-                ),
-                subj = IriRef(
-                    iri = "http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri
-                )
-            ),
-            StatementPattern(
-                namedGraph = None,
-                obj = IriRef(
-                    iri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
-                ),
-                pred = IriRef(
-                    iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri
-                ),
-                subj = QueryVariable(variableName = "title")
-            ),
-            FilterPattern(expression = CompareExpression(
-                rightArg = XsdLiteral(
-                    datatype = "http://www.w3.org/2001/XMLSchema#string".toSmartIri,
-                    value = "Zeitgl\u00F6cklein des Lebens und Leidens Christi"
-                ),
-                operator = CompareExpressionOperator.EQUALS,
-                leftArg = QueryVariable(variableName = "title")
-            ))
-        )), constructClause = ConstructClause(statements = Vector(
-            StatementPattern(
-                namedGraph = None,
-                obj = XsdLiteral(
-                    datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri,
-                    value = "true"
-                ),
-                pred = IriRef(
-                    iri = "http://api.knora.org/ontology/knora-api/simple/v2#isMainResource".toSmartIri
-                ),
-                subj = QueryVariable(variableName = "book")
-            ),
-            StatementPattern(
-                namedGraph = None,
-                obj = QueryVariable(variableName = "title"),
-                pred = IriRef(
-                    iri = "http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri
-                ),
-                subj = QueryVariable(variableName = "book")
+            positiveEntities = Set(IriRef("http://api.knora.org/ontology/knora-api/simple/v2#isMainResource".toSmartIri, None),
+                IriRef("http://api.knora.org/ontology/knora-api/simple/v2#objectType".toSmartIri, None),
+                IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#book".toSmartIri, None),
+                IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri, None),
+                IriRef("http://www.w3.org/2001/XMLSchema#string".toSmartIri, None),
+                IriRef("http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, None),
+                IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None),
+                QueryVariable("book"),
+                QueryVariable("title")
             )
-        ))
+        )
     )
 
     val booksWithTitleZeitgloeckleinResponse = ReadResourcesSequenceV2(
@@ -1134,88 +1081,32 @@ class SearchResponderV2SpecFullData {
         numberOfResources = 2
     )
 
+    // Dear Ben: please see my comment above
     val constructQueryForBooksWithoutTitleZeitgloecklein = ConstructQuery(
-        whereClause = WhereClause(patterns = Vector(
-            StatementPattern(
-                namedGraph = None,
-                obj = IriRef(
-                    iri = "http://0.0.0.0:3333/ontology/incunabula/simple/v2#book".toSmartIri
-                ),
-                pred = IriRef(
-                    iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri
-                ),
-                subj = QueryVariable(variableName = "book")
+        constructClause = ConstructClause(
+            Vector(
+                StatementPattern(QueryVariable("book"), IriRef("http://api.knora.org/ontology/knora-api/simple/v2#isMainResource".toSmartIri, None), XsdLiteral("true", "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri), None),
+                StatementPattern(QueryVariable("book"), IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri, None), QueryVariable("title"), None))
+        ),
+        whereClause = WhereClause(
+            patterns = Vector(
+                StatementPattern(QueryVariable("book"), IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None), IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#book".toSmartIri, None), None),
+                StatementPattern(QueryVariable("book"), IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None), IriRef("http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, None), None),
+                StatementPattern(QueryVariable("book"), IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri, None), QueryVariable("title"), None),
+                StatementPattern(IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri, None), IriRef("http://api.knora.org/ontology/knora-api/simple/v2#objectType".toSmartIri, None), IriRef("http://www.w3.org/2001/XMLSchema#string".toSmartIri, None), None),
+                StatementPattern(QueryVariable("title"), IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None), IriRef("http://www.w3.org/2001/XMLSchema#string".toSmartIri, None), None),
+                FilterPattern(CompareExpression(QueryVariable("title"), CompareExpressionOperator.NOT_EQUALS, XsdLiteral("Zeitglöcklein des Lebens und Leidens Christi", "http://www.w3.org/2001/XMLSchema#string".toSmartIri)))
             ),
-            StatementPattern(
-                namedGraph = None,
-                obj = IriRef(
-                    iri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri
-                ),
-                pred = IriRef(
-                    iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri
-                ),
-                subj = QueryVariable(variableName = "book")
-            ),
-            StatementPattern(
-                namedGraph = None,
-                obj = QueryVariable(variableName = "title"),
-                pred = IriRef(
-                    iri = "http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri
-                ),
-                subj = QueryVariable(variableName = "book")
-            ),
-            StatementPattern(
-                namedGraph = None,
-                obj = IriRef(
-                    iri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
-                ),
-                pred = IriRef(
-                    iri = "http://api.knora.org/ontology/knora-api/simple/v2#objectType".toSmartIri
-                ),
-                subj = IriRef(
-                    iri = "http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri
-                )
-            ),
-            StatementPattern(
-                namedGraph = None,
-                obj = IriRef(
-                    iri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
-                ),
-                pred = IriRef(
-                    iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri
-                ),
-                subj = QueryVariable(variableName = "title")
-            ),
-            FilterPattern(expression = CompareExpression(
-                rightArg = XsdLiteral(
-                    datatype = "http://www.w3.org/2001/XMLSchema#string".toSmartIri,
-                    value = "Zeitgl\u00F6cklein des Lebens und Leidens Christi"
-                ),
-                operator = CompareExpressionOperator.NOT_EQUALS,
-                leftArg = QueryVariable(variableName = "title")
-            ))
-        )),
-        constructClause = ConstructClause(statements = Vector(
-            StatementPattern(
-                namedGraph = None,
-                obj = XsdLiteral(
-                    datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri,
-                    value = "true"
-                ),
-                pred = IriRef(
-                    iri = "http://api.knora.org/ontology/knora-api/simple/v2#isMainResource".toSmartIri
-                ),
-                subj = QueryVariable(variableName = "book")
-            ),
-            StatementPattern(
-                namedGraph = None,
-                obj = QueryVariable(variableName = "title"),
-                pred = IriRef(
-                    iri = "http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri
-                ),
-                subj = QueryVariable(variableName = "book")
+            positiveEntities = Set(IriRef("http://api.knora.org/ontology/knora-api/simple/v2#isMainResource".toSmartIri, None),
+                IriRef("http://api.knora.org/ontology/knora-api/simple/v2#objectType".toSmartIri, None),
+                IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#book".toSmartIri, None),
+                IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#title".toSmartIri, None),
+                IriRef("http://www.w3.org/2001/XMLSchema#string".toSmartIri, None),
+                IriRef("http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, None),
+                IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None),
+                QueryVariable("book"),
+                QueryVariable("title")
             )
-        )
         )
     )
 }

--- a/webapi/src/test/scala/org/knora/webapi/util/search/v2/SearchParserV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/search/v2/SearchParserV2Spec.scala
@@ -293,6 +293,34 @@ class SearchParserV2Spec extends CoreSpec() {
                 operator = CompareExpressionOperator.LESS_THAN,
                 leftArg = QueryVariable("pubdate")
             ))
+        ), positiveEntities = Set(
+            IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#publoc".toSmartIri, None),
+            XsdLiteral("14", "http://www.w3.org/2001/XMLSchema#integer".toSmartIri),
+            QueryVariable("page"),
+            IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#publisher".toSmartIri, None),
+            IriRef("http://api.knora.org/ontology/knora-api/simple/v2#isMainResource".toSmartIri, None),
+            QueryVariable("bookPubLoc"),
+            IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#book".toSmartIri, None),
+            QueryVariable("bookLabel"),
+            IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#page".toSmartIri, None),
+            IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#seqnum".toSmartIri, None),
+            XsdLiteral("a8r", "http://www.w3.org/2001/XMLSchema#string".toSmartIri),
+            IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#pubdate".toSmartIri, None),
+            IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#isPartOf".toSmartIri, None),
+            XsdLiteral("a7r", "http://www.w3.org/2001/XMLSchema#string".toSmartIri),
+            IriRef("http://www.w3.org/2000/01/rdf-schema#label".toSmartIri, None),
+            QueryVariable("bookPublisher"),
+            XsdLiteral("16", "http://www.w3.org/2001/XMLSchema#integer".toSmartIri),
+            IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None),
+            QueryVariable("book"),
+            XsdLiteral("a9r", "http://www.w3.org/2001/XMLSchema#string".toSmartIri),
+            IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#pagenum".toSmartIri, None),
+            QueryVariable("pubdate"),
+            QueryVariable("seqnum"),
+            QueryVariable("bookType"),
+            QueryVariable("pageLabel"),
+            XsdLiteral("true", "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri),
+            QueryVariable("pageType")
         )),
         constructClause = ConstructClause(statements = Vector(
             StatementPattern(
@@ -340,7 +368,6 @@ class SearchParserV2Spec extends CoreSpec() {
             )
         ))
     )
-
 
     val QueryWithBind: String =
         """
@@ -395,7 +422,16 @@ class SearchParserV2Spec extends CoreSpec() {
                 pred = IriRef("http://0.0.0.0:3333/ontology/anything/simple/v2#hasOtherThing".toSmartIri),
                 subj = QueryVariable(variableName = "thing")
             )))
-        )),
+        ),
+            positiveEntities = Set(
+                QueryVariable("thingLabel"),
+                QueryVariable("thing"),
+                IriRef("http://www.w3.org/2000/01/rdf-schema#label".toSmartIri, None),
+                IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None),
+                QueryVariable("thingType"),
+                IriRef("http://0.0.0.0:3333/ontology/anything/simple/v2#Thing".toSmartIri, None)
+            )
+        ),
         constructClause = ConstructClause(statements = Vector(
             StatementPattern(
                 namedGraph = None,
@@ -447,7 +483,16 @@ class SearchParserV2Spec extends CoreSpec() {
                 pred = IriRef("http://0.0.0.0:3333/ontology/anything/simple/v2#hasOtherThing".toSmartIri),
                 subj = QueryVariable(variableName = "thing")
             )))
-        )),
+        ),
+            positiveEntities = Set(
+                QueryVariable("thingLabel"),
+                QueryVariable("thing"),
+                IriRef("http://www.w3.org/2000/01/rdf-schema#label".toSmartIri, None),
+                IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None),
+                QueryVariable("thingType"),
+                IriRef("http://0.0.0.0:3333/ontology/anything/simple/v2#Thing".toSmartIri, None)
+            )
+        ),
         constructClause = ConstructClause(statements = Vector(
             StatementPattern(
                 namedGraph = None,
@@ -488,7 +533,16 @@ class SearchParserV2Spec extends CoreSpec() {
             obj = IriRef("http://0.0.0.0:3333/ontology/anything/simple/v2#Thing".toSmartIri),
             pred = IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri),
             subj = QueryVariable(variableName = "thing")
-        ))),
+        )),
+            positiveEntities = Set(
+                QueryVariable("thingLabel"),
+                QueryVariable("thing"),
+                IriRef("http://www.w3.org/2000/01/rdf-schema#label".toSmartIri, None),
+                IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None),
+                QueryVariable("thingType"),
+                IriRef("http://0.0.0.0:3333/ontology/anything/simple/v2#Thing".toSmartIri, None)
+            )
+        ),
         constructClause = ConstructClause(statements = Vector(
             StatementPattern(
                 namedGraph = None,
@@ -771,7 +825,16 @@ class SearchParserV2Spec extends CoreSpec() {
                     leftArg = QueryVariable(variableName = "linkingProp")
                 )
             ))
-        )),
+        ),
+            positiveEntities = Set(
+                QueryVariable("linkingProp"),
+                QueryVariable("resource"),
+                IriRef("http://data.knora.org/a-thing".toSmartIri, None),
+                IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None),
+                IriRef("http://api.knora.org/ontology/knora-api/simple/v2#hasLinkTo".toSmartIri, None),
+                IriRef("http://0.0.0.0:3333/ontology/anything/simple/v2#Thing".toSmartIri, None)
+            )
+        ),
         constructClause = ConstructClause(statements = Vector(StatementPattern(
             obj = IriRef("http://data.knora.org/a-thing".toSmartIri),
             pred = IriRef("http://api.knora.org/ontology/knora-api/simple/v2#hasLinkTo".toSmartIri),

--- a/webapi/src/test/scala/org/knora/webapi/util/search/v2/SearchParserV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/search/v2/SearchParserV2Spec.scala
@@ -295,7 +295,6 @@ class SearchParserV2Spec extends CoreSpec() {
             ))
         ), positiveEntities = Set(
             IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#publoc".toSmartIri, None),
-            XsdLiteral("14", "http://www.w3.org/2001/XMLSchema#integer".toSmartIri),
             QueryVariable("page"),
             IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#publisher".toSmartIri, None),
             IriRef("http://api.knora.org/ontology/knora-api/simple/v2#isMainResource".toSmartIri, None),
@@ -304,22 +303,17 @@ class SearchParserV2Spec extends CoreSpec() {
             QueryVariable("bookLabel"),
             IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#page".toSmartIri, None),
             IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#seqnum".toSmartIri, None),
-            XsdLiteral("a8r", "http://www.w3.org/2001/XMLSchema#string".toSmartIri),
             IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#pubdate".toSmartIri, None),
             IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#isPartOf".toSmartIri, None),
-            XsdLiteral("a7r", "http://www.w3.org/2001/XMLSchema#string".toSmartIri),
             IriRef("http://www.w3.org/2000/01/rdf-schema#label".toSmartIri, None),
             QueryVariable("bookPublisher"),
-            XsdLiteral("16", "http://www.w3.org/2001/XMLSchema#integer".toSmartIri),
             IriRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri, None),
             QueryVariable("book"),
-            XsdLiteral("a9r", "http://www.w3.org/2001/XMLSchema#string".toSmartIri),
             IriRef("http://0.0.0.0:3333/ontology/incunabula/simple/v2#pagenum".toSmartIri, None),
             QueryVariable("pubdate"),
             QueryVariable("seqnum"),
             QueryVariable("bookType"),
             QueryVariable("pageLabel"),
-            XsdLiteral("true", "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri),
             QueryVariable("pageType")
         )),
         constructClause = ConstructClause(statements = Vector(
@@ -423,7 +417,7 @@ class SearchParserV2Spec extends CoreSpec() {
                 subj = QueryVariable(variableName = "thing")
             )))
         ),
-            positiveEntities = Set(
+            positiveEntities = Set( // note that entities from `?thing anything:hasOtherThing ?aThing .` must not be not mentioned here (unless they are also present elsewhere)
                 QueryVariable("thingLabel"),
                 QueryVariable("thing"),
                 IriRef("http://www.w3.org/2000/01/rdf-schema#label".toSmartIri, None),
@@ -484,7 +478,7 @@ class SearchParserV2Spec extends CoreSpec() {
                 subj = QueryVariable(variableName = "thing")
             )))
         ),
-            positiveEntities = Set(
+            positiveEntities = Set( // note that entities from `?thing anything:hasOtherThing ?aThing .` must not be not mentioned here (unless they are also present elsewhere)
                 QueryVariable("thingLabel"),
                 QueryVariable("thing"),
                 IriRef("http://www.w3.org/2000/01/rdf-schema#label".toSmartIri, None),


### PR DESCRIPTION
This PR adds support for a URI value in a KnarQL query (FILTER).

It also fixes a bug in the v1 templates: URI values were stored as `xsd:string`.

This also had to fixed for standoff attributes.

closes #697