### PR TITLE
Accept function calls in filters in KnarQL

### DIFF
--- a/webapi/WebapiBuild.sbt
+++ b/webapi/WebapiBuild.sbt
@@ -91,7 +91,7 @@ lazy val webApiCommonSettings = Seq(
     name := "webapi",
     version := "0.1.0-beta",
     ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) },
-    scalaVersion := "2.12.1"
+    scalaVersion := "2.12.3"
 )
 
 lazy val webApiLibs = Seq(
@@ -206,8 +206,8 @@ lazy val library =
         val xmlunitCore            = "org.xmlunit"                   % "xmlunit-core"             % "2.1.1"
 
         // other
-        val rdf4jRioTurtle         = "org.eclipse.rdf4j"             % "rdf4j-rio-turtle"         % "2.2.1"
-        val rdf4jQueryParserSparql = "org.eclipse.rdf4j"             % "rdf4j-queryparser-sparql" % "2.2.1"
+        val rdf4jRioTurtle         = "org.eclipse.rdf4j"             % "rdf4j-rio-turtle"         % "2.2.4"
+        val rdf4jQueryParserSparql = "org.eclipse.rdf4j"             % "rdf4j-queryparser-sparql" % "2.2.4"
         val scallop                = "org.rogach"                   %% "scallop"                  % "2.0.5"
         val gwtServlet             = "com.google.gwt"                % "gwt-servlet"              % "2.8.0"
         val sayonHE                = "net.sf.saxon"                  % "Saxon-HE"                 % "9.7.0-14"

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -127,6 +127,7 @@ class SearchResponderV2 extends ResponderWithStandoffV2 {
                 case compareExpr: CompareExpression => CompareExpression(leftArg = preprocessFilterExpression(compareExpr.leftArg), operator = compareExpr.operator, rightArg = preprocessFilterExpression(compareExpr.rightArg))
                 case andExpr: AndExpression => AndExpression(leftArg = preprocessFilterExpression(andExpr.leftArg), rightArg = preprocessFilterExpression(andExpr.rightArg))
                 case orExpr: OrExpression => OrExpression(leftArg = preprocessFilterExpression(orExpr.leftArg), rightArg = preprocessFilterExpression(orExpr.rightArg))
+                case functionCallExpr: FunctionCallExpression => FunctionCallExpression(functionIri = functionCallExpr.functionIri, args = functionCallExpr.args.map(arg => preprocessEntity(arg)))
             }
         }
 

--- a/webapi/src/main/scala/org/knora/webapi/util/search/SparqlQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/search/SparqlQuery.scala
@@ -264,6 +264,16 @@ case class OrExpression(leftArg: Expression, rightArg: Expression) extends Expre
 }
 
 /**
+  * Represents a function call in a filter.
+  *
+  * @param functionIri the IRI of the function.
+  * @param args the arguments passed to the function.
+  */
+case class FunctionCallExpression(functionIri: IriRef, args: Seq[Entity]) extends Expression {
+    def toSparql: String = s"<$functionIri>(${args.map(_.toSparql).mkString(", ")})"
+}
+
+/**
   * Represents a FILTER pattern in a query.
   *
   * @param expression the expression in the FILTER.

--- a/webapi/src/main/scala/org/knora/webapi/util/search/v2/SearchParserV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/search/v2/SearchParserV2.scala
@@ -635,6 +635,18 @@ object SearchParserV2 {
 
                     case sparqlVar: algebra.Var => makeEntity(sparqlVar)
 
+                    case functionCall: algebra.FunctionCall =>
+                        val functionIri = IriRef(functionCall.getURI.toSmartIri)
+                        val args: Seq[Entity] = functionCall.getArgs.asScala.map(arg => makeFilterExpression(arg)).map {
+                            case entity: Entity => entity
+                            case other => throw SparqlSearchException(s"Unsupported argument in function: $other")
+                        }
+
+                        FunctionCallExpression(
+                            functionIri = functionIri,
+                            args = args
+                        )
+
                     case other => throw SparqlSearchException(s"Unsupported FILTER expression: $other")
                 }
             }


### PR DESCRIPTION
This allows `SearchParserV2` to accept function calls in filters in KnarQL. A function call is represented as a `FunctionCallExpression`, which has an IRI identifying the function and a sequence of `Entity` arguments.