### PR TITLE
feature (webapi): selective route rejection

### DIFF
--- a/docs/rst/knora-api-server/deployment/webapi-getting-started.rst
+++ b/docs/rst/knora-api-server/deployment/webapi-getting-started.rst
@@ -169,6 +169,14 @@ Transformations that are not needed have no effect, so it is safe to use ``-t al
 The program uses the Turtle parsing and formatting library from RDF4J_. Additional transformations can
 be implemented as subclasses of ``org.eclipse.rdf4j.rio.RDFHandler``.
 
+Selectively Disabling Routes
+-----------------------------
+
+In ``application.conf`` the setting ``app.routes-to-reject`` contains a list of strings, representing
+routes which should be rejected.
+
+For Example, the string ``"v1/users"`` would lead to rejection of any route which contains this string.
+
 .. _RDF: https://www.w3.org/TR/rdf11-primer/
 .. _free software: http://www.gnu.org/philosophy/free-sw.en.html
 .. _Ontotext GraphDB: http://ontotext.com/products/graphdb/

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -346,6 +346,13 @@ app {
         }
     }
 
+    # Array containing route paths which should be rejected. This can be used to selectively disable routes
+    # in the configuration.
+    routes-to-reject = [
+        "v1/test",
+        "v2/test"
+    ]
+
     triplestore {
         dbtype = "graphdb"
         // dbtype = "embedded-jena-tdb"

--- a/webapi/src/main/scala/org/knora/webapi/KnoraService.scala
+++ b/webapi/src/main/scala/org/knora/webapi/KnoraService.scala
@@ -39,6 +39,7 @@ import org.knora.webapi.messages.v1.responder.usermessages.{UserDataV1, UserProf
 import org.knora.webapi.messages.v2.responder.SuccessResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.LoadOntologiesRequestV2
 import org.knora.webapi.responders._
+import org.knora.webapi.routing.RejectingRoute
 import org.knora.webapi.routing.admin.ListsAdminRoute
 import org.knora.webapi.routing.v1._
 import org.knora.webapi.routing.v2._
@@ -120,7 +121,8 @@ trait KnoraService {
       * All routes composed together and CORS activated.
       */
     private val apiRoutes: Route = CORS(
-        ResourcesRouteV1.knoraApiPath(system, settings, log) ~
+        RejectingRoute.knoraApiPath(system, settings, log) ~
+            ResourcesRouteV1.knoraApiPath(system, settings, log) ~
             ValuesRouteV1.knoraApiPath(system, settings, log) ~
             SipiRouteV1.knoraApiPath(system, settings, log) ~
             StandoffRouteV1.knoraApiPath(system, settings, log) ~

--- a/webapi/src/main/scala/org/knora/webapi/Settings.scala
+++ b/webapi/src/main/scala/org/knora/webapi/Settings.scala
@@ -137,6 +137,11 @@ class SettingsImpl(config: Config) extends Extension {
     val fallbackLanguage: String = config.getString("user.default-language")
 
     val profileQueries: Boolean = config.getBoolean("app.triplestore.profile-queries")
+
+    val routesToReject: Seq[String] = config.getList("app.routes-to-reject").iterator.asScala.map {
+        (mType: ConfigValue) => mType.unwrapped.toString
+    }.toSeq
+
 }
 
 object Settings extends ExtensionId[SettingsImpl] with ExtensionIdProvider {

--- a/webapi/src/main/scala/org/knora/webapi/routing/RejectingRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/RejectingRoute.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and André Fatton.
+ * This file is part of Knora.
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.routing
+
+import akka.actor.ActorSystem
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import org.knora.webapi.{Settings, SettingsImpl}
+import akka.http.scaladsl.model.StatusCodes._
+
+/**
+  * A route used for faking the image server.
+  */
+object RejectingRoute {
+
+    def knoraApiPath(_system: ActorSystem, settings: SettingsImpl, log: LoggingAdapter): Route = {
+        implicit val system = _system
+        implicit val executionContext = system.dispatcher
+        implicit val timeout = settings.defaultTimeout
+
+        path(Remaining) { wholepath =>
+                requestContext => {
+                    log.debug(s"got request: ${requestContext.toString}")
+                    val settings = Settings(system)
+                    val reject: Seq[Option[Boolean]] = settings.routesToReject.map { pathtoreject =>
+                        if (wholepath.contains(pathtoreject.toCharArray)) {
+                            Some(true)
+                        } else {
+                            None
+                        }
+                    }
+                    if (reject.flatten.nonEmpty) {
+                        requestContext.complete(NotFound, "The requested path is deactivated.")
+                    } else {
+                        requestContext.reject()
+                    }
+                }
+        }
+    }
+}

--- a/webapi/src/test/scala/org/knora/webapi/e2e/RejectingRouteE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/RejectingRouteE2ESpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and André Fatton.
+ * This file is part of Knora.
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.e2e
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.testkit.RouteTestTimeout
+import com.typesafe.config.ConfigFactory
+import org.knora.webapi.E2ESpec
+
+import scala.concurrent.duration._
+
+
+object RejectingRouteE2ESpec {
+    val config = ConfigFactory.parseString(
+        """
+          akka.loglevel = "DEBUG"
+          akka.stdout-loglevel = "DEBUG"
+          app.routes-to-reject = ["v1/test", "v2/test", "v1/groups", "v1/users"]
+        """.stripMargin)
+}
+
+/**
+  * End-to-End (E2E) test specification for testing users endpoint.
+  */
+class RejectingRouteE2ESpec extends E2ESpec(RejectingRouteE2ESpec.config) {
+
+    implicit def default(implicit system: ActorSystem) = RouteTestTimeout(5.seconds)
+
+    implicit override lazy val log = akka.event.Logging(system, this.getClass())
+
+    private val rdfDataObjects = List()
+
+
+    "The Rejecting Route" should {
+
+        "reject the 'v1/test' path" in {
+            val request = Get(baseApiUrl + s"/v1/test")
+            val response: HttpResponse = singleAwaitingRequest(request)
+
+            response.status should be(StatusCodes.NotFound)
+        }
+
+        "reject the 'v2/test' path" in {
+            val request = Get(baseApiUrl + s"/v2/test")
+            val response: HttpResponse = singleAwaitingRequest(request)
+
+            response.status should be(StatusCodes.NotFound)
+        }
+
+        "reject the 'v1/groups' path" in {
+            val request = Get(baseApiUrl + s"/v1/groups")
+            val response: HttpResponse = singleAwaitingRequest(request)
+
+            response.status should be(StatusCodes.NotFound)
+        }
+
+        "reject the 'v1/users' path" in {
+            val request = Get(baseApiUrl + s"/v1/users")
+            val response: HttpResponse = singleAwaitingRequest(request)
+
+            response.status should be(StatusCodes.NotFound)
+        }
+
+        "not reject the 'v1/projects' path, as it is not listed" in {
+            val request = Get(baseApiUrl + s"/v1/projects")
+            val response: HttpResponse = singleAwaitingRequest(request)
+
+            response.status should be(StatusCodes.OK)
+        }
+    }
+}


### PR DESCRIPTION
### Summary

- Allows defining route paths in `application.conf` which should be rejected.

### Issues

- resolves #639