### PR TITLE
add support for logical AND for a textual match

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -951,12 +951,15 @@ class SearchResponderV2 extends ResponderWithStandoffV2 {
                     // add this variable to the collection of additionally created variables (needed for sorting in the prequery)
                     valueVariablesCreatedInFilters.put(matchFunction.textValueVar, textValHasString)
 
+                    // combine search terms with a logical AND (Lucene syntax)
+                    val searchTerms: CombineSearchTerms = CombineSearchTerms(matchFunction.searchTerm)
+
                     TransformedFilterExpression(
                         None, // FILTER has been replaced by statements
                         Seq(
                             // connects the value object with the value literal
                             StatementPattern.makeExplicit(subj = matchFunction.textValueVar, pred = IriRef(OntologyConstants.KnoraBase.ValueHasString.toSmartIri), textValHasString),
-                            StatementPattern.makeExplicit(subj = textValHasString, pred = IriRef(OntologyConstants.KnoraBase.MatchesTextIndex.toSmartIri), XsdLiteral(matchFunction.searchTerm, OntologyConstants.Xsd.String.toSmartIri))
+                            StatementPattern.makeExplicit(subj = textValHasString, pred = IriRef(OntologyConstants.KnoraBase.MatchesTextIndex.toSmartIri), XsdLiteral(searchTerms.combineSearchTermsWithLogicalAnd, OntologyConstants.Xsd.String.toSmartIri))
                         )
                     )
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -1661,6 +1661,48 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
         }
 
+        "search for a book whose title contains 'Zeitglöcklein' and 'Lebens' using the contains function" in {
+
+            val sparqlSimplified =
+                """
+                  |    PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+                  |    CONSTRUCT {
+                  |
+                  |        ?mainRes knora-api:isMainResource true .
+                  |
+                  |        ?mainRes <http://0.0.0.0:3333/ontology/incunabula/simple/v2#title> ?propVal0 .
+                  |
+                  |     } WHERE {
+                  |
+                  |        ?mainRes a knora-api:Resource .
+                  |
+                  |        ?mainRes a <http://0.0.0.0:3333/ontology/incunabula/simple/v2#book> .
+                  |
+                  |        ?mainRes <http://0.0.0.0:3333/ontology/incunabula/simple/v2#title> ?propVal0 .
+                  |        <http://0.0.0.0:3333/ontology/incunabula/simple/v2#title> knora-api:objectType <http://www.w3.org/2001/XMLSchema#string> .
+                  |        ?propVal0 a <http://www.w3.org/2001/XMLSchema#string> .
+                  |
+                  |        FILTER contains(?propVal0, "Zeitglöcklein Lebens")
+                  |
+                  |     }
+                """.stripMargin
+
+            // TODO: find a better way to submit spaces as %20
+            Get("/v2/searchextended/" + URLEncoder.encode(sparqlSimplified, "UTF-8").replace("+", "%20")) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                val expectedAnswerJSONLD = FileUtil.readTextFile(new File("src/test/resources/test-data/searchR2RV2/BooksWithTitleContainingZeitgloecklein.jsonld"))
+
+                compareJSONLD(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
+
+                checkCountQuery(responseAs[String], 2)
+
+            }
+
+
+        }
+
 
 
     }


### PR DESCRIPTION
when someone submits a KnarQL query for a textual match, use the logical operator AND to make sure all the terms occur in the results. By default, Lucene uses a logical OR.