### PR TITLE
Use types from the triplestore in predicate objects in ontologies

### DIFF
--- a/docs/rst/00-release-notes/v1.3.0.rst
+++ b/docs/rst/00-release-notes/v1.3.0.rst
@@ -45,5 +45,8 @@ New features:
 Bugfixes:
 ---------
 
+- When API v2 served ``knora-api`` (default schema), ``salsah-gui:guiElement`` and ``salsah-gui:guiAttribute`` were not shown in properties in that ontology.
+- The predicate ``salsah-gui:guiOrder`` was not accepted when creating a property via API v2.
+
 .. _release: https://github.com/dhlab-basel/Knora/releases/tag/v1.3.0
 .. _v1.3.0 milestone: https://github.com/dhlab-basel/Knora/milestone/7

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -733,6 +733,11 @@ object OntologyConstants {
         val GuiElementProp: IRI = SalsahGuiPrefixExpansion + "guiElement"
         val GuiAttributeDefinition: IRI = SalsahGuiPrefixExpansion + "guiAttributeDefinition"
         val GuiElementClass: IRI = SalsahGuiPrefixExpansion + "Guielement"
+
+        val Geometry: IRI = SalsahGuiPrefixExpansion + "Geometry"
+        val Colorpicker: IRI = SalsahGuiPrefixExpansion + "Colorpicker"
+        val Fileupload: IRI = SalsahGuiPrefixExpansion + "Fileupload"
+        val Richtext: IRI = SalsahGuiPrefixExpansion + "Richtext"
     }
 
     object KnoraApiV2Simple {

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/ontologymessages/OntologyMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/ontologymessages/OntologyMessagesV1.scala
@@ -284,7 +284,7 @@ class PredicateInfoV1(predicateInfoV2: PredicateInfoV2) {
     def objects: Set[String] = predicateInfoV2.objects.filter {
         case StringLiteralV2(_, Some(_)) => false
         case _ => true
-    }.map(_.toString)
+    }.map(_.toString).toSet
 
     /**
       * Returns the objects of the predicate that have language codes: a Map of language codes to literals.
@@ -337,7 +337,7 @@ sealed trait EntityInfoV1 {
       * @return the predicate's objects, or an empty set if this entity doesn't have the specified predicate.
       */
     def getPredicateStringObjectsWithoutLang(predicateIri: IRI): Set[String] = {
-        entityInfoContent.getPredicateStringLiteralObjectsWithoutLang(predicateIri.toSmartIri)
+        entityInfoContent.getPredicateStringLiteralObjectsWithoutLang(predicateIri.toSmartIri).toSet
     }
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/ontologymessages/OntologyMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/ontologymessages/OntologyMessagesV1.scala
@@ -22,6 +22,7 @@ package org.knora.webapi.messages.v1.responder.ontologymessages
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import org.knora.webapi._
+import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.messages.v1.responder.standoffmessages.StandoffDataTypeClasses
 import org.knora.webapi.messages.v1.responder.usermessages.UserProfileV1
 import org.knora.webapi.messages.v1.responder.{KnoraRequestV1, KnoraResponseV1}
@@ -280,12 +281,17 @@ class PredicateInfoV1(predicateInfoV2: PredicateInfoV2) {
     /**
       * Returns the objects of the predicate that have no language codes.
       */
-    def objects: Set[String] = predicateInfoV2.objects
+    def objects: Set[String] = predicateInfoV2.objects.filter {
+        case StringLiteralV2(_, Some(_)) => false
+        case _ => true
+    }.map(_.toString)
 
     /**
       * Returns the objects of the predicate that have language codes: a Map of language codes to literals.
       */
-    def objectsWithLang: Map[String, String] = predicateInfoV2.objectsWithLang
+    def objectsWithLang: Map[String, String] = predicateInfoV2.objects.collect {
+        case StringLiteralV2(str, Some(lang)) => lang -> str
+    }.toMap
 }
 
 /**
@@ -299,7 +305,7 @@ sealed trait EntityInfoV1 {
     /**
       * Returns a [[Map]] of predicate IRIs to [[PredicateInfoV1]] objects.
       */
-    def predicates: Map[IRI, PredicateInfoV1] = {
+    lazy val predicates: Map[IRI, PredicateInfoV1] = {
         entityInfoContent.predicates.map {
             case (smartIri, predicateInfoV2) => smartIri.toString -> new PredicateInfoV1(predicateInfoV2)
         }
@@ -315,20 +321,23 @@ sealed trait EntityInfoV1 {
       *         if the predicate has no objects.
       */
     def getPredicateObject(predicateIri: IRI, preferredLangs: Option[(String, String)] = None): Option[String] = {
-        entityInfoContent.getPredicateLiteralObject(
+        entityInfoContent.getPredicateStringLiteralObject(
             predicateIri = predicateIri.toSmartIri,
             preferredLangs = preferredLangs
-        )
+        ) match {
+            case Some(obj) => Some(obj)
+            case None => predicates.get(predicateIri).flatMap(_.objects.headOption)
+        }
     }
 
     /**
-      * Returns all the objects specified for a given predicate.
+      * Returns all the string (non-IRI) objects specified without language tags for a given predicate.
       *
       * @param predicateIri the IRI of the predicate.
       * @return the predicate's objects, or an empty set if this entity doesn't have the specified predicate.
       */
-    def getPredicateObjectsWithoutLang(predicateIri: IRI): Set[String] = {
-        entityInfoContent.getPredicateLiteralsWithoutLang(predicateIri.toSmartIri)
+    def getPredicateStringObjectsWithoutLang(predicateIri: IRI): Set[String] = {
+        entityInfoContent.getPredicateStringLiteralObjectsWithoutLang(predicateIri.toSmartIri)
     }
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2Simple.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2Simple.scala
@@ -21,7 +21,7 @@
 package org.knora.webapi.messages.v2.responder.ontologymessages
 
 import org.knora.webapi._
-import org.knora.webapi.messages.store.triplestoremessages.{IriLiteralV2, LiteralV2, StringLiteralV2}
+import org.knora.webapi.messages.store.triplestoremessages.{OntologyLiteralV2, SmartIriLiteralV2, StringLiteralV2}
 import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality.KnoraCardinalityInfo
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.{SmartIri, StringFormatter}
@@ -1136,7 +1136,7 @@ object KnoraApiV2Simple {
       * @return a [[PredicateInfoV2]].
       */
     private def makePredicate(predicateIri: IRI,
-                              objects: Set[LiteralV2] = Set.empty[LiteralV2],
+                              objects: Seq[OntologyLiteralV2] = Seq.empty[OntologyLiteralV2],
                               objectsWithLang: Map[String, String] = Map.empty[String, String]): PredicateInfoV2 = {
         PredicateInfoV2(
             predicateIri = predicateIri.toSmartIri,
@@ -1165,14 +1165,14 @@ object KnoraApiV2Simple {
                              objectType: Option[IRI] = None): ReadPropertyInfoV2 = {
         val propTypePred = makePredicate(
             predicateIri = OntologyConstants.Rdf.Type,
-            objects = Set(IriLiteralV2(propertyType))
+            objects = Seq(SmartIriLiteralV2(propertyType.toSmartIri))
         )
 
         val maybeSubjectTypePred = subjectType.map {
             subjType =>
                 makePredicate(
                     predicateIri = OntologyConstants.KnoraApiV2Simple.SubjectType,
-                    objects = Set(IriLiteralV2(subjType))
+                    objects = Seq(SmartIriLiteralV2(subjType.toSmartIri))
                 )
         }
 
@@ -1180,7 +1180,7 @@ object KnoraApiV2Simple {
             objType =>
                 makePredicate(
                     predicateIri = OntologyConstants.KnoraApiV2Simple.ObjectType,
-                    objects = Set(IriLiteralV2(objType))
+                    objects = Seq(SmartIriLiteralV2(objType.toSmartIri))
                 )
         }
 
@@ -1216,7 +1216,7 @@ object KnoraApiV2Simple {
 
         val rdfType = OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
             predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-            objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+            objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
         )
 
         ReadClassInfoV2(
@@ -1253,7 +1253,7 @@ object KnoraApiV2Simple {
 
         val rdfType = OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
             predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-            objects = Set(IriLiteralV2(OntologyConstants.Rdfs.Datatype))
+            objects = Seq(SmartIriLiteralV2(OntologyConstants.Rdfs.Datatype.toSmartIri))
         )
 
         ReadClassInfoV2(

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2Simple.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2Simple.scala
@@ -21,6 +21,7 @@
 package org.knora.webapi.messages.v2.responder.ontologymessages
 
 import org.knora.webapi._
+import org.knora.webapi.messages.store.triplestoremessages.{IriLiteralV2, LiteralV2, StringLiteralV2}
 import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality.KnoraCardinalityInfo
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.{SmartIri, StringFormatter}
@@ -1135,12 +1136,13 @@ object KnoraApiV2Simple {
       * @return a [[PredicateInfoV2]].
       */
     private def makePredicate(predicateIri: IRI,
-                              objects: Set[String] = Set.empty[String],
+                              objects: Set[LiteralV2] = Set.empty[LiteralV2],
                               objectsWithLang: Map[String, String] = Map.empty[String, String]): PredicateInfoV2 = {
         PredicateInfoV2(
             predicateIri = predicateIri.toSmartIri,
-            objects = objects,
-            objectsWithLang = objectsWithLang
+            objects = objects ++ objectsWithLang.map {
+                case (lang, str) => StringLiteralV2(str, Some(lang))
+            }
         )
     }
 
@@ -1163,14 +1165,14 @@ object KnoraApiV2Simple {
                              objectType: Option[IRI] = None): ReadPropertyInfoV2 = {
         val propTypePred = makePredicate(
             predicateIri = OntologyConstants.Rdf.Type,
-            objects = Set(propertyType)
+            objects = Set(IriLiteralV2(propertyType))
         )
 
         val maybeSubjectTypePred = subjectType.map {
             subjType =>
                 makePredicate(
                     predicateIri = OntologyConstants.KnoraApiV2Simple.SubjectType,
-                    objects = Set(subjType)
+                    objects = Set(IriLiteralV2(subjType))
                 )
         }
 
@@ -1178,7 +1180,7 @@ object KnoraApiV2Simple {
             objType =>
                 makePredicate(
                     predicateIri = OntologyConstants.KnoraApiV2Simple.ObjectType,
-                    objects = Set(objType)
+                    objects = Set(IriLiteralV2(objType))
                 )
         }
 
@@ -1214,7 +1216,7 @@ object KnoraApiV2Simple {
 
         val rdfType = OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
             predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-            objects = Set(OntologyConstants.Owl.Class)
+            objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
         )
 
         ReadClassInfoV2(
@@ -1251,7 +1253,7 @@ object KnoraApiV2Simple {
 
         val rdfType = OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
             predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-            objects = Set(OntologyConstants.Rdfs.Datatype)
+            objects = Set(IriLiteralV2(OntologyConstants.Rdfs.Datatype))
         )
 
         ReadClassInfoV2(

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2WithValueObjects.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2WithValueObjects.scala
@@ -21,6 +21,7 @@
 package org.knora.webapi.messages.v2.responder.ontologymessages
 
 import org.knora.webapi._
+import org.knora.webapi.messages.store.triplestoremessages.{IriLiteralV2, LiteralV2, StringLiteralV2}
 import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality.KnoraCardinalityInfo
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.{SmartIri, StringFormatter}
@@ -947,12 +948,12 @@ object KnoraApiV2WithValueObjects {
         isEditable = true,
         predicates = Seq(
             makePredicate(
-                predicateIri = OntologyConstants.SalsahGui.GuiElementProp,
-                objects = Set(OntologyConstants.SalsahGui.Colorpicker)
+                predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
+                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Colorpicker))
             ),
             makePredicate(
-                predicateIri = OntologyConstants.SalsahGui.GuiAttribute,
-                objects = Set("ncolors=8")
+                predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiAttribute,
+                objects = Set(StringLiteralV2("ncolors=8"))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -982,12 +983,12 @@ object KnoraApiV2WithValueObjects {
         isEditable = true,
         predicates = Seq(
             makePredicate(
-                predicateIri = OntologyConstants.SalsahGui.GuiElementProp,
-                objects = Set(OntologyConstants.SalsahGui.Geometry)
+                predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
+                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Geometry))
             ),
             makePredicate(
-                predicateIri = OntologyConstants.SalsahGui.GuiAttribute,
-                objects = Set("width=95%;rows=4;wrap=soft")
+                predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiAttribute,
+                objects = Set(StringLiteralV2("width=95%;rows=4;wrap=soft"))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1017,8 +1018,8 @@ object KnoraApiV2WithValueObjects {
         isEditable = true,
         predicates = Seq(
             makePredicate(
-                predicateIri = OntologyConstants.SalsahGui.GuiElementProp,
-                objects = Set(OntologyConstants.SalsahGui.Richtext)
+                predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
+                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Richtext))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1047,8 +1048,8 @@ object KnoraApiV2WithValueObjects {
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.HasValue),
         predicates = Seq(
             makePredicate(
-                predicateIri = OntologyConstants.SalsahGui.GuiElementProp,
-                objects = Set(OntologyConstants.SalsahGui.Fileupload)
+                predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
+                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1078,8 +1079,8 @@ object KnoraApiV2WithValueObjects {
         isEditable = true,
         predicates = Seq(
             makePredicate(
-                predicateIri = OntologyConstants.SalsahGui.GuiElementProp,
-                objects = Set(OntologyConstants.SalsahGui.Fileupload)
+                predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
+                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1109,8 +1110,8 @@ object KnoraApiV2WithValueObjects {
         isEditable = true,
         predicates = Seq(
             makePredicate(
-                predicateIri = OntologyConstants.SalsahGui.GuiElementProp,
-                objects = Set(OntologyConstants.SalsahGui.Fileupload)
+                predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
+                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1140,8 +1141,8 @@ object KnoraApiV2WithValueObjects {
         isEditable = true,
         predicates = Seq(
             makePredicate(
-                predicateIri = OntologyConstants.SalsahGui.GuiElementProp,
-                objects = Set(OntologyConstants.SalsahGui.Fileupload)
+                predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
+                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1171,8 +1172,8 @@ object KnoraApiV2WithValueObjects {
         isEditable = true,
         predicates = Seq(
             makePredicate(
-                predicateIri = OntologyConstants.SalsahGui.GuiElementProp,
-                objects = Set(OntologyConstants.SalsahGui.Fileupload)
+                predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
+                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1202,8 +1203,8 @@ object KnoraApiV2WithValueObjects {
         isEditable = true,
         predicates = Seq(
             makePredicate(
-                predicateIri = OntologyConstants.SalsahGui.GuiElementProp,
-                objects = Set(OntologyConstants.SalsahGui.Fileupload)
+                predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
+                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1233,8 +1234,8 @@ object KnoraApiV2WithValueObjects {
         isEditable = true,
         predicates = Seq(
             makePredicate(
-                predicateIri = OntologyConstants.SalsahGui.GuiElementProp,
-                objects = Set(OntologyConstants.SalsahGui.Fileupload)
+                predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
+                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -2671,12 +2672,13 @@ object KnoraApiV2WithValueObjects {
       * @return a [[PredicateInfoV2]].
       */
     private def makePredicate(predicateIri: IRI,
-                              objects: Set[String] = Set.empty[String],
+                              objects: Set[LiteralV2] = Set.empty[LiteralV2],
                               objectsWithLang: Map[String, String] = Map.empty[String, String]): PredicateInfoV2 = {
         PredicateInfoV2(
             predicateIri = predicateIri.toSmartIri,
-            objects = objects,
-            objectsWithLang = objectsWithLang
+            objects = objects ++ objectsWithLang.map {
+                case (lang, str) => StringLiteralV2(str, Some(lang))
+            }
         )
     }
 
@@ -2706,14 +2708,14 @@ object KnoraApiV2WithValueObjects {
                              objectType: Option[IRI] = None): ReadPropertyInfoV2 = {
         val propTypePred = makePredicate(
             predicateIri = OntologyConstants.Rdf.Type,
-            objects = Set(propertyType)
+            objects = Set(IriLiteralV2(propertyType))
         )
 
         val maybeSubjectTypePred = subjectType.map {
             subjType =>
                 makePredicate(
                     predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType,
-                    objects = Set(subjType)
+                    objects = Set(IriLiteralV2(subjType))
                 )
         }
 
@@ -2721,7 +2723,7 @@ object KnoraApiV2WithValueObjects {
             objType =>
                 makePredicate(
                     predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType,
-                    objects = Set(objType)
+                    objects = Set(IriLiteralV2(objType))
                 )
         }
 
@@ -2765,7 +2767,7 @@ object KnoraApiV2WithValueObjects {
                           inheritedCardinalities: Map[SmartIri, KnoraCardinalityInfo] = Map.empty[SmartIri, KnoraCardinalityInfo]): ReadClassInfoV2 = {
         val rdfType = OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
             predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-            objects = Set(OntologyConstants.Owl.Class)
+            objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
         )
 
         ReadClassInfoV2(

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2WithValueObjects.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2WithValueObjects.scala
@@ -21,7 +21,7 @@
 package org.knora.webapi.messages.v2.responder.ontologymessages
 
 import org.knora.webapi._
-import org.knora.webapi.messages.store.triplestoremessages.{IriLiteralV2, LiteralV2, StringLiteralV2}
+import org.knora.webapi.messages.store.triplestoremessages.{OntologyLiteralV2, SmartIriLiteralV2, StringLiteralV2}
 import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality.KnoraCardinalityInfo
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.{SmartIri, StringFormatter}
@@ -949,11 +949,11 @@ object KnoraApiV2WithValueObjects {
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
-                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Colorpicker))
+                objects = Seq(SmartIriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Colorpicker.toSmartIri))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiAttribute,
-                objects = Set(StringLiteralV2("ncolors=8"))
+                objects = Seq(StringLiteralV2("ncolors=8"))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -984,11 +984,11 @@ object KnoraApiV2WithValueObjects {
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
-                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Geometry))
+                objects = Seq(SmartIriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Geometry.toSmartIri))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiAttribute,
-                objects = Set(StringLiteralV2("width=95%;rows=4;wrap=soft"))
+                objects = Seq(StringLiteralV2("width=95%;rows=4;wrap=soft"))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1019,7 +1019,7 @@ object KnoraApiV2WithValueObjects {
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
-                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Richtext))
+                objects = Seq(SmartIriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Richtext.toSmartIri))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1049,7 +1049,7 @@ object KnoraApiV2WithValueObjects {
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
-                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
+                objects = Seq(SmartIriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload.toSmartIri))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1080,7 +1080,7 @@ object KnoraApiV2WithValueObjects {
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
-                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
+                objects = Seq(SmartIriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload.toSmartIri))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1111,7 +1111,7 @@ object KnoraApiV2WithValueObjects {
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
-                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
+                objects = Seq(SmartIriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload.toSmartIri))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1142,7 +1142,7 @@ object KnoraApiV2WithValueObjects {
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
-                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
+                objects = Seq(SmartIriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload.toSmartIri))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1173,7 +1173,7 @@ object KnoraApiV2WithValueObjects {
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
-                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
+                objects = Seq(SmartIriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload.toSmartIri))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1204,7 +1204,7 @@ object KnoraApiV2WithValueObjects {
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
-                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
+                objects = Seq(SmartIriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload.toSmartIri))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -1235,7 +1235,7 @@ object KnoraApiV2WithValueObjects {
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp,
-                objects = Set(IriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload))
+                objects = Seq(SmartIriLiteralV2(OntologyConstants.SalsahGuiApiV2WithValueObjects.Fileupload.toSmartIri))
             ),
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -2672,7 +2672,7 @@ object KnoraApiV2WithValueObjects {
       * @return a [[PredicateInfoV2]].
       */
     private def makePredicate(predicateIri: IRI,
-                              objects: Set[LiteralV2] = Set.empty[LiteralV2],
+                              objects: Seq[OntologyLiteralV2] = Seq.empty[OntologyLiteralV2],
                               objectsWithLang: Map[String, String] = Map.empty[String, String]): PredicateInfoV2 = {
         PredicateInfoV2(
             predicateIri = predicateIri.toSmartIri,
@@ -2708,14 +2708,14 @@ object KnoraApiV2WithValueObjects {
                              objectType: Option[IRI] = None): ReadPropertyInfoV2 = {
         val propTypePred = makePredicate(
             predicateIri = OntologyConstants.Rdf.Type,
-            objects = Set(IriLiteralV2(propertyType))
+            objects = Seq(SmartIriLiteralV2(propertyType.toSmartIri))
         )
 
         val maybeSubjectTypePred = subjectType.map {
             subjType =>
                 makePredicate(
                     predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType,
-                    objects = Set(IriLiteralV2(subjType))
+                    objects = Seq(SmartIriLiteralV2(subjType.toSmartIri))
                 )
         }
 
@@ -2723,7 +2723,7 @@ object KnoraApiV2WithValueObjects {
             objType =>
                 makePredicate(
                     predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType,
-                    objects = Set(IriLiteralV2(objType))
+                    objects = Seq(SmartIriLiteralV2(objType.toSmartIri))
                 )
         }
 
@@ -2767,7 +2767,7 @@ object KnoraApiV2WithValueObjects {
                           inheritedCardinalities: Map[SmartIri, KnoraCardinalityInfo] = Map.empty[SmartIri, KnoraCardinalityInfo]): ReadClassInfoV2 = {
         val rdfType = OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
             predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-            objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+            objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
         )
 
         ReadClassInfoV2(

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/OntologyResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/OntologyResponderV1.scala
@@ -198,7 +198,7 @@ class OntologyResponderV1 extends Responder {
                                     vocabulary = entityInfo.ontologyIri,
                                     occurrence = cardinalityInfo.cardinality.toString,
                                     valuetype_id = OntologyConstants.KnoraBase.LinkValue,
-                                    attributes = valueUtilV1.makeAttributeString(entityInfo.getPredicateObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute) + valueUtilV1.makeAttributeRestype(entityInfo.getPredicateObject(OntologyConstants.KnoraBase.ObjectClassConstraint).getOrElse(throw InconsistentTriplestoreDataException(s"Property $propertyIri has no knora-base:objectClassConstraint")))),
+                                    attributes = valueUtilV1.makeAttributeString(entityInfo.getPredicateStringObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute) + valueUtilV1.makeAttributeRestype(entityInfo.getPredicateObject(OntologyConstants.KnoraBase.ObjectClassConstraint).getOrElse(throw InconsistentTriplestoreDataException(s"Property $propertyIri has no knora-base:objectClassConstraint")))),
                                     gui_name = entityInfo.getPredicateObject(OntologyConstants.SalsahGui.GuiElementProp).map(iri => SalsahGuiConversions.iri2SalsahGuiElement(iri)),
                                     guiorder = cardinalityInfo.guiOrder
                                 )
@@ -213,7 +213,7 @@ class OntologyResponderV1 extends Responder {
                                     vocabulary = entityInfo.ontologyIri,
                                     occurrence = cardinalityInfo.cardinality.toString,
                                     valuetype_id = entityInfo.getPredicateObject(OntologyConstants.KnoraBase.ObjectClassConstraint).getOrElse(throw InconsistentTriplestoreDataException(s"Property $propertyIri has no knora-base:objectClassConstraint")),
-                                    attributes = valueUtilV1.makeAttributeString(entityInfo.getPredicateObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute)),
+                                    attributes = valueUtilV1.makeAttributeString(entityInfo.getPredicateStringObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute)),
                                     gui_name = entityInfo.getPredicateObject(OntologyConstants.SalsahGui.GuiElementProp).map(iri => SalsahGuiConversions.iri2SalsahGuiElement(iri)),
                                     guiorder = cardinalityInfo.guiOrder
                                 )
@@ -404,7 +404,7 @@ class OntologyResponderV1 extends Responder {
                                 description = entityInfo.getPredicateObject(predicateIri = OntologyConstants.Rdfs.Comment, preferredLangs = Some(userProfile.userData.lang, settings.fallbackLanguage)),
                                 vocabulary = entityInfo.ontologyIri,
                                 valuetype_id = OntologyConstants.KnoraBase.LinkValue,
-                                attributes = valueUtilV1.makeAttributeString(entityInfo.getPredicateObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute) + valueUtilV1.makeAttributeRestype(entityInfo.getPredicateObject(OntologyConstants.KnoraBase.ObjectClassConstraint).getOrElse(throw InconsistentTriplestoreDataException(s"Property $propertyIri has no knora-base:objectClassConstraint")))),
+                                attributes = valueUtilV1.makeAttributeString(entityInfo.getPredicateStringObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute) + valueUtilV1.makeAttributeRestype(entityInfo.getPredicateObject(OntologyConstants.KnoraBase.ObjectClassConstraint).getOrElse(throw InconsistentTriplestoreDataException(s"Property $propertyIri has no knora-base:objectClassConstraint")))),
                                 gui_name = entityInfo.getPredicateObject(OntologyConstants.SalsahGui.GuiElementProp).map(iri => SalsahGuiConversions.iri2SalsahGuiElement(iri))
                             )
 
@@ -416,7 +416,7 @@ class OntologyResponderV1 extends Responder {
                                 description = entityInfo.getPredicateObject(predicateIri = OntologyConstants.Rdfs.Comment, preferredLangs = Some(userProfile.userData.lang, settings.fallbackLanguage)),
                                 vocabulary = entityInfo.ontologyIri,
                                 valuetype_id = entityInfo.getPredicateObject(OntologyConstants.KnoraBase.ObjectClassConstraint).getOrElse(throw InconsistentTriplestoreDataException(s"Property $propertyIri has no knora-base:objectClassConstraint")),
-                                attributes = valueUtilV1.makeAttributeString(entityInfo.getPredicateObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute)),
+                                attributes = valueUtilV1.makeAttributeString(entityInfo.getPredicateStringObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute)),
                                 gui_name = entityInfo.getPredicateObject(OntologyConstants.SalsahGui.GuiElementProp).map(iri => SalsahGuiConversions.iri2SalsahGuiElement(iri))
                             )
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
@@ -674,7 +674,7 @@ class ResourcesResponderV1 extends Responder {
                             guielement = propertyEntityInfo.getPredicateObject(OntologyConstants.SalsahGui.GuiElementProp).map(guiElementIri => SalsahGuiConversions.iri2SalsahGuiElement(guiElementIri)),
                             label = propertyEntityInfo.getPredicateObject(predicateIri = OntologyConstants.Rdfs.Label, preferredLangs = Some(userProfile.userData.lang, settings.fallbackLanguage)),
                             occurrence = Some(propsAndCardinalities(propertyIri).cardinality.toString),
-                            attributes = (propertyEntityInfo.getPredicateObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute) + valueUtilV1.makeAttributeRestype(propertyEntityInfo.getPredicateObject(OntologyConstants.KnoraBase.ObjectClassConstraint).getOrElse(throw InconsistentTriplestoreDataException(s"Property $propertyIri has no knora-base:objectClassConstraint")))).mkString(";"),
+                            attributes = (propertyEntityInfo.getPredicateStringObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute) + valueUtilV1.makeAttributeRestype(propertyEntityInfo.getPredicateObject(OntologyConstants.KnoraBase.ObjectClassConstraint).getOrElse(throw InconsistentTriplestoreDataException(s"Property $propertyIri has no knora-base:objectClassConstraint")))).mkString(";"),
                             value_rights = Nil
                         )
 
@@ -686,7 +686,7 @@ class ResourcesResponderV1 extends Responder {
                             guielement = propertyEntityInfo.getPredicateObject(OntologyConstants.SalsahGui.GuiElementProp).map(guiElementIri => SalsahGuiConversions.iri2SalsahGuiElement(guiElementIri)),
                             label = propertyEntityInfo.getPredicateObject(predicateIri = OntologyConstants.Rdfs.Label, preferredLangs = Some(userProfile.userData.lang, settings.fallbackLanguage)),
                             occurrence = Some(propsAndCardinalities(propertyIri).cardinality.toString),
-                            attributes = propertyEntityInfo.getPredicateObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute).mkString(";"),
+                            attributes = propertyEntityInfo.getPredicateStringObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute).mkString(";"),
                             value_rights = Nil
                         )
                     }
@@ -2383,9 +2383,9 @@ class ResourcesResponderV1 extends Responder {
                 attributes = propertyEntityInfo match {
                     case Some(entityInfo) =>
                         if (entityInfo.isLinkProp) {
-                            (entityInfo.getPredicateObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute) + valueUtilV1.makeAttributeRestype(entityInfo.getPredicateObject(OntologyConstants.KnoraBase.ObjectClassConstraint).getOrElse(throw InconsistentTriplestoreDataException(s"Property $propertyIri has no knora-base:objectClassConstraint")))).mkString(";")
+                            (entityInfo.getPredicateStringObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute) + valueUtilV1.makeAttributeRestype(entityInfo.getPredicateObject(OntologyConstants.KnoraBase.ObjectClassConstraint).getOrElse(throw InconsistentTriplestoreDataException(s"Property $propertyIri has no knora-base:objectClassConstraint")))).mkString(";")
                         } else {
-                            entityInfo.getPredicateObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute).mkString(";")
+                            entityInfo.getPredicateStringObjectsWithoutLang(OntologyConstants.SalsahGui.GuiAttribute).mkString(";")
                         }
                     case None => ""
                 },

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -33,7 +33,7 @@ import org.knora.webapi.messages.v1.responder.standoffmessages.StandoffDataTypeC
 import org.knora.webapi.messages.v1.responder.usermessages.UserProfileV1
 import org.knora.webapi.messages.v2.responder.SuccessResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality.{KnoraCardinalityInfo, OwlCardinalityInfo}
-import org.knora.webapi.messages.v2.responder.ontologymessages.{Cardinality, _}
+import org.knora.webapi.messages.v2.responder.ontologymessages._
 import org.knora.webapi.responders.{IriLocker, Responder}
 import org.knora.webapi.util.ActorUtil.{future2Message, handleUnexpectedMessage}
 import org.knora.webapi.util.IriConversions._
@@ -619,11 +619,14 @@ class OntologyResponderV2 extends Responder {
                 val attributeDefs: Set[SalsahGuiAttributeDefinition] = guiElementIndividual.predicates.get(OntologyConstants.SalsahGui.GuiAttributeDefinition.toSmartIri) match {
                     case Some(predicateInfo) =>
                         predicateInfo.objects.map {
-                            attributeDefStr =>
+                            case StringLiteralV2(attributeDefStr, None) =>
                                 stringFormatter.toSalsahGuiAttributeDefinition(
                                     attributeDefStr,
                                     throw InconsistentTriplestoreDataException(s"Invalid salsah-gui:guiAttributeDefinition in $guiElementIri: $attributeDefStr")
                                 )
+
+                            case other =>
+                                throw InconsistentTriplestoreDataException(s"Invalid salsah-gui:guiAttributeDefinition in $guiElementIri: $other")
                         }
 
                     case None => Set.empty[SalsahGuiAttributeDefinition]
@@ -645,12 +648,13 @@ class OntologyResponderV2 extends Responder {
         val predicates = propertyInfoContent.predicates
 
         // Find out which salsah-gui:Guielement the property uses, if any.
-        val maybeGuiElementIri: Option[IRI] = predicates.get(OntologyConstants.SalsahGui.GuiElementProp.toSmartIri).flatMap(_.objects.headOption)
+        val maybeGuiElementPred: Option[PredicateInfoV2] = predicates.get(OntologyConstants.SalsahGui.GuiElementProp.toSmartIri)
+        val maybeGuiElementIri: Option[SmartIri] = maybeGuiElementPred.map(_.requireIriObject(throw InconsistentTriplestoreDataException(s"Property $propertyIri has an invalid object for ${OntologyConstants.SalsahGui.GuiElementProp}")))
 
         // Get that Guielement's attribute definitions, if any.
         val guiAttributeDefs: Set[SalsahGuiAttributeDefinition] = maybeGuiElementIri match {
             case Some(guiElementIri) =>
-                allGuiAttributeDefinitions.getOrElse(guiElementIri.toSmartIri, errorFun(s"Property $propertyIri has salsah-gui:guiElement $guiElementIri, which doesn't exist"))
+                allGuiAttributeDefinitions.getOrElse(guiElementIri, errorFun(s"Property $propertyIri has salsah-gui:guiElement $guiElementIri, which doesn't exist"))
 
             case None => Set.empty[SalsahGuiAttributeDefinition]
         }
@@ -666,12 +670,15 @@ class OntologyResponderV2 extends Responder {
 
                 // Syntactically validate each attribute.
                 guiAttributePred.objects.map {
-                    guiAttributeObj =>
+                    case StringLiteralV2(guiAttributeObj, None) =>
                         stringFormatter.toSalsahGuiAttribute(
                             s = guiAttributeObj,
                             attributeDefs = guiAttributeDefs,
                             errorFun = errorFun(s"Property $propertyIri contains an invalid salsah-gui:guiAttribute: $guiAttributeObj")
                         )
+
+                    case other =>
+                        errorFun(s"Property $propertyIri contains an invalid salsah-gui:guiAttribute: $other")
                 }
 
             case None => Set.empty[SalsahGuiAttribute]
@@ -910,7 +917,7 @@ class OntologyResponderV2 extends Responder {
 
                     SubClassInfoV2(
                         id = subClassIri,
-                        label = classInfo.entityInfoContent.getPredicateLiteralObject(
+                        label = classInfo.entityInfoContent.getPredicateStringLiteralObject(
                             predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
                             preferredLangs = Some(userProfile.userData.lang, settings.fallbackLanguage)
                         ).getOrElse(throw InconsistentTriplestoreDataException(s"Resource class $subClassIri has no rdfs:label"))
@@ -2114,7 +2121,7 @@ class OntologyResponderV2 extends Responder {
 
                 propertyDef.predicates.get(OntologyConstants.KnoraBase.SubjectClassConstraint.toSmartIri) match {
                     case Some(subjectClassConstraintPred) =>
-                        val subjectClassConstraint = subjectClassConstraintPred.objects.head.toSmartIri
+                        val subjectClassConstraint = subjectClassConstraintPred.requireIriObject(throw InconsistentTriplestoreDataException(s"Property $propertyIri has an invalid object for ${OntologyConstants.KnoraBase.SubjectClassConstraint}"))
 
                         if (!allBaseClassIris.contains(subjectClassConstraint)) {
                             val hasOrWouldInherit = if (internalClassDef.directCardinalities.contains(propertyIri)) {
@@ -2239,7 +2246,8 @@ class OntologyResponderV2 extends Responder {
 
                 // Check that the subject class constraint, if provided, designates a Knora resource class that exists.
 
-                maybeSubjectClassConstraint: Option[SmartIri] = internalPropertyDef.predicates.get(OntologyConstants.KnoraBase.SubjectClassConstraint.toSmartIri).flatMap(_.objects.headOption.map(_.toSmartIri))
+                maybeSubjectClassConstraintPred: Option[PredicateInfoV2] = internalPropertyDef.predicates.get(OntologyConstants.KnoraBase.SubjectClassConstraint.toSmartIri)
+                maybeSubjectClassConstraint = maybeSubjectClassConstraintPred.map(_.requireIriObject(throw BadRequestException("Invalid knora-api:subjectType")))
 
                 _ = maybeSubjectClassConstraint.foreach {
                     subjectClassConstraint =>
@@ -2422,7 +2430,10 @@ class OntologyResponderV2 extends Responder {
 
                 // Check that the new labels/comments are different from the current ones.
 
-                currentLabelsOrComments: Map[String, String] = currentReadPropertyInfo.entityInfoContent.predicates.getOrElse(changePropertyLabelsOrCommentsRequest.predicateToUpdate, throw InconsistentTriplestoreDataException(s"Property $internalPropertyIri has no ${changePropertyLabelsOrCommentsRequest.predicateToUpdate}")).objectsWithLang
+                currentLabelsOrComments: Set[LiteralV2] = currentReadPropertyInfo.entityInfoContent.predicates.getOrElse(
+                    changePropertyLabelsOrCommentsRequest.predicateToUpdate,
+                    throw InconsistentTriplestoreDataException(s"Property $internalPropertyIri has no ${changePropertyLabelsOrCommentsRequest.predicateToUpdate}")
+                ).objects
 
                 _ = if (currentLabelsOrComments == changePropertyLabelsOrCommentsRequest.newObjects) {
                     throw BadRequestException(s"The submitted objects of ${changePropertyLabelsOrCommentsRequest.propertyIri} are the same as the current ones in property ${changePropertyLabelsOrCommentsRequest.propertyIri}")
@@ -2466,7 +2477,9 @@ class OntologyResponderV2 extends Responder {
 
                 unescapedNewLabelOrCommentPredicate: PredicateInfoV2 = PredicateInfoV2(
                     predicateIri = changePropertyLabelsOrCommentsRequest.predicateToUpdate,
-                    objectsWithLang = changePropertyLabelsOrCommentsRequest.newObjects
+                    objects = changePropertyLabelsOrCommentsRequest.newObjects.map {
+                        obj: LiteralV2 => obj
+                    }
                 ).unescape
 
                 unescapedNewPropertyDef: PropertyInfoContentV2 = currentReadPropertyInfo.entityInfoContent.copy(
@@ -2580,7 +2593,10 @@ class OntologyResponderV2 extends Responder {
 
                 // Check that the new labels/comments are different from the current ones.
 
-                currentLabelsOrComments = currentReadClassInfo.entityInfoContent.predicates.getOrElse(changeClassLabelsOrCommentsRequest.predicateToUpdate, throw InconsistentTriplestoreDataException(s"Class $internalClassIri has no ${changeClassLabelsOrCommentsRequest.predicateToUpdate}")).objectsWithLang
+                currentLabelsOrComments = currentReadClassInfo.entityInfoContent.predicates.getOrElse(
+                    changeClassLabelsOrCommentsRequest.predicateToUpdate,
+                    throw InconsistentTriplestoreDataException(s"Class $internalClassIri has no ${changeClassLabelsOrCommentsRequest.predicateToUpdate}")
+                ).objects
 
                 _ = if (currentLabelsOrComments == changeClassLabelsOrCommentsRequest.newObjects) {
                     throw BadRequestException(s"The submitted objects of ${changeClassLabelsOrCommentsRequest.predicateToUpdate} are the same as the current ones in class ${changeClassLabelsOrCommentsRequest.classIri}")
@@ -2614,7 +2630,9 @@ class OntologyResponderV2 extends Responder {
 
                 unescapedNewLabelOrCommentPredicate = PredicateInfoV2(
                     predicateIri = changeClassLabelsOrCommentsRequest.predicateToUpdate,
-                    objectsWithLang = changeClassLabelsOrCommentsRequest.newObjects
+                    objects = changeClassLabelsOrCommentsRequest.newObjects.map {
+                        obj: LiteralV2 => obj
+                    }
                 ).unescape
 
                 unescapedNewClassDef: ClassInfoContentV2 = currentReadClassInfo.entityInfoContent.copy(
@@ -2728,34 +2746,13 @@ class OntologyResponderV2 extends Responder {
       * @return a map of smart IRIs to [[PredicateInfoV2]] objects.
       */
     private def getEntityPredicatesFromConstructResponse(entityDefMap: Map[IRI, Seq[LiteralV2]]): Map[SmartIri, PredicateInfoV2] = {
-        // TODO: when refactoring PredicateInfoV2 to use LiteralV2, rewrite this method accordingly.
-
         entityDefMap.map {
             case (predIriStr: IRI, predObjs: Seq[LiteralV2]) =>
                 val predicateIri = predIriStr.toSmartIri
 
-                val objectsWithLang: Map[String, String] = predObjs.collect {
-                    case StringLiteralV2(value, Some(language)) => (language, value)
-                }.toMap
-
-                val objectsWithoutLang = predObjs.foldLeft(Set.empty[String]) {
-                    case (acc, obj) =>
-                        obj match {
-                            case stringLiteral: StringLiteralV2 =>
-                                if (stringLiteral.language.isEmpty) {
-                                    acc + stringLiteral.value
-                                } else {
-                                    acc
-                                }
-
-                            case otherLiteral => acc + otherLiteral.toString
-                        }
-                }
-
                 val predicateInfo = PredicateInfoV2(
                     predicateIri = predicateIri,
-                    objects = objectsWithoutLang,
-                    objectsWithLang = objectsWithLang
+                    objects = predObjs.toSet
                 )
 
                 predicateIri -> predicateInfo
@@ -3002,7 +2999,7 @@ class OntologyResponderV2 extends Responder {
             // make a map of superproperty IRIs to superproperty constraint values.
             superPropertyConstraintValues: Map[SmartIri, SmartIri] = superPropertyInfos.flatMap {
                 superPropertyInfo =>
-                    superPropertyInfo.entityInfoContent.predicates.get(constraintPredicateIri).flatMap(_.objects.headOption.map(_.toSmartIri)).map {
+                    superPropertyInfo.entityInfoContent.predicates.get(constraintPredicateIri).map(_.requireIriObject(throw InconsistentTriplestoreDataException(s"Property ${superPropertyInfo.entityInfoContent.propertyIri} has an invalid object for $constraintPredicateIri"))).map {
                         superPropertyConstraintValue => superPropertyInfo.entityInfoContent.propertyIri -> superPropertyConstraintValue
                     }
             }.toMap
@@ -3153,7 +3150,7 @@ class OntologyResponderV2 extends Responder {
         val newPredicates: Map[SmartIri, PredicateInfoV2] = (internalPropertyDef.predicates - OntologyConstants.KnoraBase.ObjectClassConstraint.toSmartIri) +
             (OntologyConstants.KnoraBase.ObjectClassConstraint.toSmartIri -> PredicateInfoV2(
                 predicateIri = OntologyConstants.KnoraBase.ObjectClassConstraint.toSmartIri,
-                objects = Set(OntologyConstants.KnoraBase.LinkValue)
+                objects = Set(IriLiteralV2(OntologyConstants.KnoraBase.LinkValue))
             ))
 
         internalPropertyDef.copy(

--- a/webapi/src/main/scala/org/knora/webapi/util/jsonld/JsonLDUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/jsonld/JsonLDUtil.scala
@@ -247,7 +247,7 @@ case class JsonLDArray(value: Seq[JsonLDValue]) extends JsonLDValue {
       *
       * @return a map of language keys to values.
       */
-    def toObjsWithLang: Set[LiteralV2] = {
+    def toObjsWithLang: Seq[StringLiteralV2] = {
         value.map {
             case obj: JsonLDObject =>
                 val lang = obj.requireString("@language", stringFormatter.toSparqlEncodedString)
@@ -261,7 +261,7 @@ case class JsonLDArray(value: Seq[JsonLDValue]) extends JsonLDValue {
 
             case other => throw BadRequestException(s"Expected JSON-LD object: $other")
         }
-    }.toSet
+    }
 }
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/util/jsonld/JsonLDUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/jsonld/JsonLDUtil.scala
@@ -22,6 +22,7 @@ package org.knora.webapi.util.jsonld
 
 import com.github.jsonldjava.core.{JsonLdOptions, JsonLdProcessor}
 import com.github.jsonldjava.utils.JsonUtils
+import org.knora.webapi.messages.store.triplestoremessages.{LiteralV2, StringLiteralV2}
 import org.knora.webapi.util.{JavaUtil, SmartIri, StringFormatter}
 import org.knora.webapi.{BadRequestException, IRI, LanguageCodes}
 
@@ -241,12 +242,12 @@ case class JsonLDArray(value: Seq[JsonLDValue]) extends JsonLDValue {
 
     /**
       * Tries to interpret the elements of this array as JSON-LD objects containing `@language` and `@value`,
-      * and returns the results as a map of language codes to values. Throws [[BadRequestException]]
+      * and returns the results as a set of [[StringLiteralV2]]. Throws [[BadRequestException]]
       * if the array can't be interpreted in this way.
       *
       * @return a map of language keys to values.
       */
-    def toObjsWithLang: Map[String, String] = {
+    def toObjsWithLang: Set[LiteralV2] = {
         value.map {
             case obj: JsonLDObject =>
                 val lang = obj.requireString("@language", stringFormatter.toSparqlEncodedString)
@@ -256,11 +257,11 @@ case class JsonLDArray(value: Seq[JsonLDValue]) extends JsonLDValue {
                 }
 
                 val text = obj.requireString("@value", stringFormatter.toSparqlEncodedString)
-                lang -> text
+                StringLiteralV2(text, Some(lang))
 
             case other => throw BadRequestException(s"Expected JSON-LD object: $other")
         }
-    }.toMap
+    }.toSet
 }
 
 /**

--- a/webapi/src/main/twirl/queries/sparql/v2/changeClassLabelsOrComments.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/changeClassLabelsOrComments.scala.txt
@@ -41,7 +41,7 @@
   ontologyIri: SmartIri,
   classIri: SmartIri,
   predicateToUpdate: SmartIri,
-  newObjects: Set[StringLiteralV2],
+  newObjects: Seq[StringLiteralV2],
   lastModificationDate: Instant,
   currentTime: Instant)
 

--- a/webapi/src/main/twirl/queries/sparql/v2/changeClassLabelsOrComments.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/changeClassLabelsOrComments.scala.txt
@@ -18,7 +18,10 @@
  * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
  *@
 
+@import org.knora.webapi.SparqlGenerationException
 @import org.knora.webapi.util.SmartIri
+@import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
+
 @import java.time.Instant
 
 @*
@@ -38,7 +41,7 @@
   ontologyIri: SmartIri,
   classIri: SmartIri,
   predicateToUpdate: SmartIri,
-  newObjects: Map[String, String],
+  newObjects: Set[StringLiteralV2],
   lastModificationDate: Instant,
   currentTime: Instant)
 
@@ -57,9 +60,9 @@ DELETE {
     GRAPH ?ontologyNamedGraph {
         ?ontology knora-base:lastModificationDate "@currentTime"^^xsd:dateTimeStamp .
 
-        @for((newObjLang, newObjText) <- newObjects) {
+        @for(newObject <- newObjects) {
 
-            ?class <@predicateToUpdate> """@newObjText"""@@@newObjLang .
+            ?class <@predicateToUpdate> """@{newObject.value}"""@@@{newObject.language.getOrElse(throw SparqlGenerationException("No language code given in object of predicate $predicateToUpdate: $newObject"))} .
 
         }
     }

--- a/webapi/src/main/twirl/queries/sparql/v2/changePropertyLabelsOrComments.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/changePropertyLabelsOrComments.scala.txt
@@ -42,7 +42,7 @@
   propertyIri: SmartIri,
   maybeLinkValuePropertyIri: Option[SmartIri],
   predicateToUpdate: SmartIri,
-  newObjects: Set[StringLiteralV2],
+  newObjects: Seq[StringLiteralV2],
   lastModificationDate: Instant,
   currentTime: Instant)
 

--- a/webapi/src/main/twirl/queries/sparql/v2/changePropertyLabelsOrComments.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/changePropertyLabelsOrComments.scala.txt
@@ -18,7 +18,9 @@
  * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
  *@
 
+@import org.knora.webapi.SparqlGenerationException
 @import org.knora.webapi.util.SmartIri
+@import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 @import java.time.Instant
 
 @*
@@ -40,7 +42,7 @@
   propertyIri: SmartIri,
   maybeLinkValuePropertyIri: Option[SmartIri],
   predicateToUpdate: SmartIri,
-  newObjects: Map[String, String],
+  newObjects: Set[StringLiteralV2],
   lastModificationDate: Instant,
   currentTime: Instant)
 
@@ -71,9 +73,9 @@ DELETE {
     GRAPH ?ontologyNamedGraph {
         ?ontology knora-base:lastModificationDate "@currentTime"^^xsd:dateTimeStamp .
 
-        @for((newObjLang, newObjText) <- newObjects) {
+        @for(newObject <- newObjects) {
 
-            ?property <@predicateToUpdate> """@newObjText"""@@@newObjLang .
+            ?property <@predicateToUpdate> """@{newObject.value}"""@@@{newObject.language.getOrElse(throw SparqlGenerationException("No language code given in object of predicate $predicateToUpdate: $newObject"))} .
 
         }
 
@@ -81,9 +83,9 @@ DELETE {
 
             case Some(linkValuePropertyIri) => {
 
-                @for((newObjLang, newObjText) <- newObjects) {
+                @for(newObject <- newObjects) {
 
-                    <@linkValuePropertyIri> <@predicateToUpdate> """@newObjText"""@@@newObjLang .
+                    <@linkValuePropertyIri> <@predicateToUpdate> """@{newObject.value}"""@@@{newObject.language.getOrElse(throw SparqlGenerationException("No language code given in object of predicate $predicateToUpdate: $newObject"))} .
 
                 }
 

--- a/webapi/src/main/twirl/queries/sparql/v2/createClass.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/createClass.scala.txt
@@ -22,6 +22,7 @@
 @import org.knora.webapi.util.SmartIri
 @import org.knora.webapi.messages.v2.responder.ontologymessages._
 @import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality._
+@import org.knora.webapi.messages.store.triplestoremessages._
 @import java.time.Instant
 
 @*
@@ -58,22 +59,11 @@ DELETE {
 
         @* Insert the class. *@
 
-        @for(predicate <- classDef.predicates.values) {
-
-            @* TODO: In a class definition, all objects that don't have languages must be IRIs. Change this when PredicateInfoV2 knows the types of its objects (#738). *@
-
-            @for(obj <- predicate.objects) {
-
-                <@classDef.classIri> <@predicate.predicateIri> <@obj> .
-
-            }
-
-            @for((lang, text) <- predicate.objectsWithLang) {
-
-                <@classDef.classIri> <@predicate.predicateIri> """@text"""@@@lang .
-
-            }
-
+        @{
+            queries.sparql.v2.txt.generateInsertStatementsForPredicates(
+                entityIri = classDef.classIri,
+                predicates = classDef.predicates.values
+            )
         }
 
         @for(baseClass <- classDef.subClassOf) {

--- a/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForCreateProperty.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForCreateProperty.scala.txt
@@ -31,30 +31,11 @@
 
 @defining(StringFormatter.getGeneralInstance) { stringFormatter =>
 
-    @for(predicate <- propertyDef.predicates.values) {
-
-        @* TODO: change this when PredicateInfoV2 knows the types of its objects (#738). *@
-
-        @for(obj <- predicate.objects) {
-
-            @if(stringFormatter.isIri(obj)) {
-
-                <@propertyDef.propertyIri> <@predicate.predicateIri> <@obj> .
-
-            } else {
-
-                <@propertyDef.propertyIri> <@predicate.predicateIri> """@obj"""^^xsd:string .
-
-            }
-
-        }
-
-        @for((lang, text) <- predicate.objectsWithLang) {
-
-            <@propertyDef.propertyIri> <@predicate.predicateIri> """@text"""@@@lang .
-
-        }
-
+    @{
+        queries.sparql.v2.txt.generateInsertStatementsForPredicates(
+            entityIri = propertyDef.propertyIri,
+            predicates = propertyDef.predicates.values
+        )
     }
 
     @for(superProp <- propertyDef.subPropertyOf) {

--- a/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForPredicates.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForPredicates.scala.txt
@@ -38,9 +38,9 @@
 
         @obj match {
 
-            case IriLiteralV2(iriStr) => {
+            case SmartIriLiteralV2(iri) => {
 
-                <@entityIri> <@predicate.predicateIri> <@iriStr> .
+                <@entityIri> <@predicate.predicateIri> <@iri> .
 
             }
 
@@ -56,36 +56,11 @@
 
             }
 
-            case IntLiteralV2(intVal) => {
-
-                <@entityIri> <@predicate.predicateIri> "@intVal"^^xsd:integer .
-
-            }
-
-            case DecimalLiteralV2(decimalVal) => {
-
-                <@entityIri> <@predicate.predicateIri> "@decimalVal"^^xsd:decimal .
-
-            }
-
             case BooleanLiteralV2(booleanVal) => {
 
                 <@entityIri> <@predicate.predicateIri> "@booleanVal"^^xsd:boolean .
 
             }
-
-            case DateTimeLiteralV2(dateTimeVal) => {
-
-                <@entityIri> <@predicate.predicateIri> "@dateTimeVal"^^xsd:dateTimeStamp .
-
-            }
-
-            case blank: BlankNodeLiteralV2 => {
-
-                @{throw SparqlGenerationException("Blank nodes are not supported as objects in PredicateInfoV2"); ()}
-
-            }
-
         }
 
     }

--- a/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForPredicates.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForPredicates.scala.txt
@@ -1,6 +1,5 @@
 @*
- * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
- * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ * Copyright © 2015-2018 the contributors (see Contributors.md).
  *
  * This file is part of Knora.
  *

--- a/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForPredicates.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForPredicates.scala.txt
@@ -1,0 +1,93 @@
+@*
+ * Copyright © 2015 Lukas Rosenthaler, Benjamin Geer, Ivan Subotic,
+ * Tobias Schweizer, André Kilchenmann, and Sepideh Alassi.
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ *@
+
+@import org.knora.webapi._
+@import org.knora.webapi.util.SmartIri
+@import org.knora.webapi.messages.v2.responder.ontologymessages._
+@import org.knora.webapi.messages.store.triplestoremessages._
+
+@*
+ * Called by other templates to generate INSERT statements for adding predicates to an entity.
+ *
+ * @param entityIri the IRI to which the predicates are to be added.
+ * @param predicates the predicates to be added.
+ *@
+@(entityIri: SmartIri,
+  predicates: Iterable[PredicateInfoV2])
+
+@for(predicate <- predicates) {
+
+    @for(obj <- predicate.objects) {
+
+        @obj match {
+
+            case IriLiteralV2(iriStr) => {
+
+                <@entityIri> <@predicate.predicateIri> <@iriStr> .
+
+            }
+
+            case StringLiteralV2(text, Some(lang)) => {
+
+                <@entityIri> <@predicate.predicateIri> """@text"""@@@lang .
+
+            }
+
+            case StringLiteralV2(text, None) => {
+
+                <@entityIri> <@predicate.predicateIri> """@text""" .
+
+            }
+
+            case IntLiteralV2(intVal) => {
+
+                <@entityIri> <@predicate.predicateIri> "@intVal"^^xsd:integer .
+
+            }
+
+            case DecimalLiteralV2(decimalVal) => {
+
+                <@entityIri> <@predicate.predicateIri> "@decimalVal"^^xsd:decimal .
+
+            }
+
+            case BooleanLiteralV2(booleanVal) => {
+
+                <@entityIri> <@predicate.predicateIri> "@booleanVal"^^xsd:boolean .
+
+            }
+
+            case DateTimeLiteralV2(dateTimeVal) => {
+
+                <@entityIri> <@predicate.predicateIri> "@dateTimeVal"^^xsd:dateTimeStamp .
+
+            }
+
+            case blank: BlankNodeLiteralV2 => {
+
+                @{throw SparqlGenerationException("Blank nodes are not supported as objects in PredicateInfoV2"); ()}
+
+            }
+
+        }
+
+    }
+
+}

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiWithValueObjects.json
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiWithValueObjects.json
@@ -1422,6 +1422,7 @@
         "knora-api:isResourceProperty" : true,
         "knora-api:objectType" : "http://api.knora.org/ontology/knora-api/v2#AudioFileValue",
         "knora-api:subjectType" : "http://api.knora.org/ontology/knora-api/v2#AudioRepresentation",
+        "salsah-gui:guiElement" : "http://api.knora.org/ontology/salsah-gui/v2#Fileupload",
         "rdfs:comment" : "Connects a Representation to an audio file",
         "rdfs:label" : "has audio file",
         "rdfs:subPropertyOf" : "http://api.knora.org/ontology/knora-api/v2#hasFileValue"
@@ -1433,6 +1434,8 @@
         "knora-api:isResourceProperty" : true,
         "knora-api:objectType" : "http://api.knora.org/ontology/knora-api/v2#ColorValue",
         "knora-api:subjectType" : "http://api.knora.org/ontology/knora-api/v2#Region",
+        "salsah-gui:guiAttribute" : "ncolors=8",
+        "salsah-gui:guiElement" : "http://api.knora.org/ontology/salsah-gui/v2#Colorpicker",
         "rdfs:comment" : "Specifies the color of a Region",
         "rdfs:label" : "Color",
         "rdfs:subPropertyOf" : "http://api.knora.org/ontology/knora-api/v2#hasValue"
@@ -1444,6 +1447,7 @@
         "knora-api:isResourceProperty" : true,
         "knora-api:objectType" : "http://api.knora.org/ontology/knora-api/v2#TextValue",
         "knora-api:subjectType" : "http://api.knora.org/ontology/knora-api/v2#Resource",
+        "salsah-gui:guiElement" : "http://api.knora.org/ontology/salsah-gui/v2#Richtext",
         "rdfs:comment" : "Represents a comment on a Resource",
         "rdfs:label" : "Comment",
         "rdfs:subPropertyOf" : "http://api.knora.org/ontology/knora-api/v2#hasValue"
@@ -1455,6 +1459,7 @@
         "knora-api:isResourceProperty" : true,
         "knora-api:objectType" : "http://api.knora.org/ontology/knora-api/v2#DDDFileValue",
         "knora-api:subjectType" : "http://api.knora.org/ontology/knora-api/v2#DDDRepresentation",
+        "salsah-gui:guiElement" : "http://api.knora.org/ontology/salsah-gui/v2#Fileupload",
         "rdfs:comment" : "Connects a Representation to a 3D file",
         "rdfs:label" : "has 3D file",
         "rdfs:subPropertyOf" : "http://api.knora.org/ontology/knora-api/v2#hasFileValue"
@@ -1466,6 +1471,7 @@
         "knora-api:isResourceProperty" : true,
         "knora-api:objectType" : "http://api.knora.org/ontology/knora-api/v2#DocumentFileValue",
         "knora-api:subjectType" : "http://api.knora.org/ontology/knora-api/v2#DocumentRepresentation",
+        "salsah-gui:guiElement" : "http://api.knora.org/ontology/salsah-gui/v2#Fileupload",
         "rdfs:comment" : "Connects a Representation to a document",
         "rdfs:label" : "has document",
         "rdfs:subPropertyOf" : "http://api.knora.org/ontology/knora-api/v2#hasFileValue"
@@ -1476,6 +1482,7 @@
         "knora-api:isResourceProperty" : true,
         "knora-api:objectType" : "http://api.knora.org/ontology/knora-api/v2#FileValue",
         "knora-api:subjectType" : "http://api.knora.org/ontology/knora-api/v2#Representation",
+        "salsah-gui:guiElement" : "http://api.knora.org/ontology/salsah-gui/v2#Fileupload",
         "rdfs:comment" : "Connects a Representation to a file",
         "rdfs:label" : "has file",
         "rdfs:subPropertyOf" : "http://api.knora.org/ontology/knora-api/v2#hasValue"
@@ -1487,6 +1494,8 @@
         "knora-api:isResourceProperty" : true,
         "knora-api:objectType" : "http://api.knora.org/ontology/knora-api/v2#GeomValue",
         "knora-api:subjectType" : "http://api.knora.org/ontology/knora-api/v2#Region",
+        "salsah-gui:guiAttribute" : "width=95%;rows=4;wrap=soft",
+        "salsah-gui:guiElement" : "http://api.knora.org/ontology/salsah-gui/v2#Geometry",
         "rdfs:comment" : "Represents a geometrical shape.",
         "rdfs:label" : "Geometry",
         "rdfs:subPropertyOf" : "http://api.knora.org/ontology/knora-api/v2#hasValue"
@@ -1530,6 +1539,7 @@
         "knora-api:isResourceProperty" : true,
         "knora-api:objectType" : "http://api.knora.org/ontology/knora-api/v2#MovingImageFileValue",
         "knora-api:subjectType" : "http://api.knora.org/ontology/knora-api/v2#MovingImageRepresentation",
+        "salsah-gui:guiElement" : "http://api.knora.org/ontology/salsah-gui/v2#Fileupload",
         "rdfs:comment" : "Connects a Representation to a moving image file",
         "rdfs:label" : "has movie file",
         "rdfs:subPropertyOf" : "http://api.knora.org/ontology/knora-api/v2#hasFileValue"
@@ -1570,6 +1580,7 @@
         "knora-api:isResourceProperty" : true,
         "knora-api:objectType" : "http://api.knora.org/ontology/knora-api/v2#StillImageFileValue",
         "knora-api:subjectType" : "http://api.knora.org/ontology/knora-api/v2#StillImageRepresentation",
+        "salsah-gui:guiElement" : "http://api.knora.org/ontology/salsah-gui/v2#Fileupload",
         "rdfs:comment" : "Connects a Representation to an image file",
         "rdfs:label" : "has image file",
         "rdfs:subPropertyOf" : "http://api.knora.org/ontology/knora-api/v2#hasFileValue"
@@ -1581,6 +1592,7 @@
         "knora-api:isResourceProperty" : true,
         "knora-api:objectType" : "http://api.knora.org/ontology/knora-api/v2#TextFileValue",
         "knora-api:subjectType" : "http://api.knora.org/ontology/knora-api/v2#TextRepresentation",
+        "salsah-gui:guiElement" : "http://api.knora.org/ontology/salsah-gui/v2#Fileupload",
         "rdfs:comment" : "Connects a Representation to a text file",
         "rdfs:label" : "has text file",
         "rdfs:subPropertyOf" : "http://api.knora.org/ontology/knora-api/v2#hasFileValue"

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiWithValueObjectsHasColor.json
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiWithValueObjectsHasColor.json
@@ -10,6 +10,8 @@
         "knora-api:isResourceProperty" : true,
         "knora-api:objectType" : "http://api.knora.org/ontology/knora-api/v2#ColorValue",
         "knora-api:subjectType" : "http://api.knora.org/ontology/knora-api/v2#Region",
+        "salsah-gui:guiAttribute" : "ncolors=8",
+        "salsah-gui:guiElement" : "http://api.knora.org/ontology/salsah-gui/v2#Colorpicker",
         "rdfs:comment" : "Specifies the color of a Region",
         "rdfs:label" : "Color",
         "rdfs:subPropertyOf" : "http://api.knora.org/ontology/knora-api/v2#hasValue"

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
@@ -489,7 +489,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 // Comvert the response to an InputOntologiesV2 and compare the relevant part of it to the request.
                 val responseAsInput: InputOntologiesV2 = InputOntologiesV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
                 assert(responseAsInput.ontologies.size == 1)
-                responseAsInput.ontologies.head.properties.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objectsWithLang should ===(paramsAsInput.ontologies.head.properties.head._2.predicates.head._2.objectsWithLang)
+                responseAsInput.ontologies.head.properties.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects should ===(paramsAsInput.ontologies.head.properties.head._2.predicates.head._2.objects)
 
                 // Check that the ontology's last modification date was updated.
                 val newAnythingLastModDate = responseAsInput.ontologies.head.ontologyMetadata.lastModificationDate.get
@@ -544,7 +544,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 // Comvert the response to an InputOntologiesV2 and compare the relevant part of it to the request.
                 val responseAsInput: InputOntologiesV2 = InputOntologiesV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
                 assert(responseAsInput.ontologies.size == 1)
-                responseAsInput.ontologies.head.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objectsWithLang should ===(paramsAsInput.ontologies.head.properties.head._2.predicates.head._2.objectsWithLang)
+                responseAsInput.ontologies.head.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects should ===(paramsAsInput.ontologies.head.properties.head._2.predicates.head._2.objects)
 
                 // Check that the ontology's last modification date was updated.
                 val newAnythingLastModDate = responseAsInput.ontologies.head.ontologyMetadata.lastModificationDate.get
@@ -577,7 +577,8 @@ class OntologyV2R2RSpec extends R2RSpec {
                    |            {
                    |                "@type": "http://www.w3.org/2002/07/owl#Restriction",
                    |                "owl:maxCardinality": 1,
-                   |                "owl:onProperty": "http://0.0.0.0:3333/ontology/anything/v2#hasName"
+                   |                "owl:onProperty": "http://0.0.0.0:3333/ontology/anything/v2#hasName",
+                   |                "salsah-gui:guiOrder": 1
                    |            }
                    |        ]
                    |      }
@@ -587,6 +588,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                    |  "@context" : {
                    |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
                    |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+                   |    "salsah-gui" : "http://api.knora.org/ontology/salsah-gui/v2#",
                    |    "owl" : "http://www.w3.org/2002/07/owl#",
                    |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
                    |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
@@ -742,7 +744,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 // Comvert the response to an InputOntologiesV2 and compare the relevant part of it to the request.
                 val responseAsInput: InputOntologiesV2 = InputOntologiesV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
                 assert(responseAsInput.ontologies.size == 1)
-                responseAsInput.ontologies.head.classes.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objectsWithLang should ===(paramsAsInput.ontologies.head.classes.head._2.predicates.head._2.objectsWithLang)
+                responseAsInput.ontologies.head.classes.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects should ===(paramsAsInput.ontologies.head.classes.head._2.predicates.head._2.objects)
 
                 // Check that the ontology's last modification date was updated.
                 val newAnythingLastModDate = responseAsInput.ontologies.head.ontologyMetadata.lastModificationDate.get
@@ -766,7 +768,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                    |          "@language" : "en",
                    |          "@value" : "Represents nothing"
                    |        }, {
-                   |          "@language" : "en",
+                   |          "@language" : "fr",
                    |          "@value" : "ne représente rien"
                    |        } ]
                    |      }
@@ -794,7 +796,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 // Comvert the response to an InputOntologiesV2 and compare the relevant part of it to the request.
                 val responseAsInput: InputOntologiesV2 = InputOntologiesV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
                 assert(responseAsInput.ontologies.size == 1)
-                responseAsInput.ontologies.head.classes.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objectsWithLang should ===(paramsAsInput.ontologies.head.classes.head._2.predicates.head._2.objectsWithLang)
+                responseAsInput.ontologies.head.classes.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects should ===(paramsAsInput.ontologies.head.classes.head._2.predicates.head._2.objects)
 
                 // Check that the ontology's last modification date was updated.
                 val newAnythingLastModDate = responseAsInput.ontologies.head.ontologyMetadata.lastModificationDate.get

--- a/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/ontologymessages/InputOntologiesV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/ontologymessages/InputOntologiesV2Spec.scala
@@ -22,7 +22,7 @@ package org.knora.webapi.messages.v2.responder.ontologymessages
 
 import java.time.Instant
 
-import org.knora.webapi.messages.store.triplestoremessages.{IriLiteralV2, StringLiteralV2}
+import org.knora.webapi.messages.store.triplestoremessages.{SmartIriLiteralV2, StringLiteralV2}
 import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality.KnoraCardinalityInfo
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.StringFormatter
@@ -239,26 +239,26 @@ object InputOntologiesV2Spec {
             predicates = Map(
                 "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
-                    objects = Set(IriLiteralV2("http://www.w3.org/2002/07/owl#ObjectProperty")),
+                    objects = Seq(SmartIriLiteralV2("http://www.w3.org/2002/07/owl#ObjectProperty".toSmartIri)),
                 ),
                 "http://api.knora.org/ontology/knora-api/v2#subjectType".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://api.knora.org/ontology/knora-api/v2#subjectType".toSmartIri,
-                    objects = Set(IriLiteralV2("http://0.0.0.0:3333/ontology/anything/v2#Thing")),
+                    objects = Seq(SmartIriLiteralV2("http://0.0.0.0:3333/ontology/anything/v2#Thing".toSmartIri)),
                 ),
                 "http://api.knora.org/ontology/knora-api/v2#objectType".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://api.knora.org/ontology/knora-api/v2#objectType".toSmartIri,
-                    objects = Set(IriLiteralV2("http://api.knora.org/ontology/knora-api/v2#TextValue")),
+                    objects = Seq(SmartIriLiteralV2("http://api.knora.org/ontology/knora-api/v2#TextValue".toSmartIri)),
                 ),
                 "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri,
-                    objects = Set(
+                    objects = Seq(
                         StringLiteralV2("has name", Some("en")),
                         StringLiteralV2("hat Namen", Some("de"))
                     )
                 ),
                 "http://www.w3.org/2000/01/rdf-schema#comment".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://www.w3.org/2000/01/rdf-schema#comment".toSmartIri,
-                    objects = Set(
+                    objects = Seq(
                         StringLiteralV2("The name of a 'Thing'", Some("en")),
                         StringLiteralV2("Der Name eines Dinges", Some("de"))
                     )
@@ -277,15 +277,15 @@ object InputOntologiesV2Spec {
             predicates = Map(
                 "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
-                    objects = Set(IriLiteralV2("http://www.w3.org/2002/07/owl#Class"))
+                    objects = Seq(SmartIriLiteralV2("http://www.w3.org/2002/07/owl#Class".toSmartIri))
                 ),
                 "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri,
-                    objects = Set(StringLiteralV2("wild thing", Some("en")))
+                    objects = Seq(StringLiteralV2("wild thing", Some("en")))
                 ),
                 "http://www.w3.org/2000/01/rdf-schema#comment".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://www.w3.org/2000/01/rdf-schema#comment".toSmartIri,
-                    objects = Set(StringLiteralV2("A thing that is wild", Some("en")))
+                    objects = Seq(StringLiteralV2("A thing that is wild", Some("en")))
                 )
             ),
             classIri = "http://0.0.0.0:3333/ontology/anything/v2#WildThing".toSmartIri,

--- a/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/ontologymessages/InputOntologiesV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/v2/responder/ontologymessages/InputOntologiesV2Spec.scala
@@ -22,6 +22,7 @@ package org.knora.webapi.messages.v2.responder.ontologymessages
 
 import java.time.Instant
 
+import org.knora.webapi.messages.store.triplestoremessages.{IriLiteralV2, StringLiteralV2}
 import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality.KnoraCardinalityInfo
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.StringFormatter
@@ -238,28 +239,28 @@ object InputOntologiesV2Spec {
             predicates = Map(
                 "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
-                    objects = Set("http://www.w3.org/2002/07/owl#ObjectProperty"),
+                    objects = Set(IriLiteralV2("http://www.w3.org/2002/07/owl#ObjectProperty")),
                 ),
                 "http://api.knora.org/ontology/knora-api/v2#subjectType".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://api.knora.org/ontology/knora-api/v2#subjectType".toSmartIri,
-                    objects = Set("http://0.0.0.0:3333/ontology/anything/v2#Thing"),
+                    objects = Set(IriLiteralV2("http://0.0.0.0:3333/ontology/anything/v2#Thing")),
                 ),
                 "http://api.knora.org/ontology/knora-api/v2#objectType".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://api.knora.org/ontology/knora-api/v2#objectType".toSmartIri,
-                    objects = Set("http://api.knora.org/ontology/knora-api/v2#TextValue"),
+                    objects = Set(IriLiteralV2("http://api.knora.org/ontology/knora-api/v2#TextValue")),
                 ),
                 "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri,
-                    objectsWithLang = Map(
-                        "en" -> "has name",
-                        "de" -> "hat Namen"
+                    objects = Set(
+                        StringLiteralV2("has name", Some("en")),
+                        StringLiteralV2("hat Namen", Some("de"))
                     )
                 ),
                 "http://www.w3.org/2000/01/rdf-schema#comment".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://www.w3.org/2000/01/rdf-schema#comment".toSmartIri,
-                    objectsWithLang = Map(
-                        "en" -> "The name of a 'Thing'",
-                        "de" -> "Der Name eines Dinges"
+                    objects = Set(
+                        StringLiteralV2("The name of a 'Thing'", Some("en")),
+                        StringLiteralV2("Der Name eines Dinges", Some("de"))
                     )
                 )
             ),
@@ -276,15 +277,15 @@ object InputOntologiesV2Spec {
             predicates = Map(
                 "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
-                    objects = Set("http://www.w3.org/2002/07/owl#Class")
+                    objects = Set(IriLiteralV2("http://www.w3.org/2002/07/owl#Class"))
                 ),
                 "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri,
-                    objectsWithLang = Map("en" -> "wild thing")
+                    objects = Set(StringLiteralV2("wild thing", Some("en")))
                 ),
                 "http://www.w3.org/2000/01/rdf-schema#comment".toSmartIri -> PredicateInfoV2(
                     predicateIri = "http://www.w3.org/2000/01/rdf-schema#comment".toSmartIri,
-                    objectsWithLang = Map("en" -> "A thing that is wild")
+                    objects = Set(StringLiteralV2("A thing that is wild", Some("en")))
                 )
             ),
             classIri = "http://0.0.0.0:3333/ontology/anything/v2#WildThing".toSmartIri,

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import akka.actor.Props
 import akka.testkit.{ImplicitSender, TestActorRef}
 import org.knora.webapi._
-import org.knora.webapi.messages.store.triplestoremessages.{RdfDataObject, ResetTriplestoreContent, ResetTriplestoreContentACK}
+import org.knora.webapi.messages.store.triplestoremessages.{RdfDataObject, ResetTriplestoreContent, ResetTriplestoreContentACK, StringLiteralV2}
 import org.knora.webapi.messages.v1.responder.ontologymessages.{LoadOntologiesRequest, LoadOntologiesResponse}
 import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality.KnoraCardinalityInfo
 import org.knora.webapi.messages.v2.responder.ontologymessages._
@@ -14,6 +14,7 @@ import org.knora.webapi.responders.{RESPONDER_MANAGER_ACTOR_NAME, ResponderManag
 import org.knora.webapi.store.{STORE_MANAGER_ACTOR_NAME, StoreManager}
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.{MutableTestIri, SmartIri, StringFormatter}
+import org.knora.webapi.messages.store.triplestoremessages.{IriLiteralV2, StringLiteralV2}
 
 import scala.concurrent.duration._
 
@@ -223,28 +224,28 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.TextValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "has name",
-                            "de" -> "hat Namen"
+                        objects = Set(
+                            StringLiteralV2("has name", Some("en")),
+                            StringLiteralV2("hat Namen", Some("de"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "The name of a Thing",
-                            "de" -> "Der Name eines Dinges"
+                        objects = Set(
+                            StringLiteralV2("The name of a Thing", Some("en")),
+                            StringLiteralV2("Der Name eines Dinges", Some("de"))
                         )
                     )
                 ),
@@ -311,26 +312,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "has interesting thing"
+                        objects = Set(
+                            StringLiteralV2("has interesting thing", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "an interesting Thing"
+                        objects = Set(
+                            StringLiteralV2("an interesting Thing", Some("en"))
                         )
                     )
                 ),
@@ -431,22 +432,22 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.TextValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -477,26 +478,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.TextValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -527,26 +528,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.IntValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.IntValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -577,26 +578,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.IntValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.IntValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -627,26 +628,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.TextValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -677,26 +678,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.TextValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -730,26 +731,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("NonexistentClass").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("NonexistentClass").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.TextValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -780,26 +781,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.KnoraApiV2PrefixExpansion + "NonexistentClass")
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.KnoraApiV2PrefixExpansion + "NonexistentClass"))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -830,26 +831,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.Representation)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.Representation))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.TextValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -880,26 +881,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.FileValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.FileValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -930,26 +931,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.LinkValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.LinkValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -980,26 +981,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.LinkValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.LinkValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -1030,26 +1031,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.Xsd.String)
+                        objects = Set(IriLiteralV2(OntologyConstants.Xsd.String))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -1080,26 +1081,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.StillImageFileValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.StillImageFileValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -1130,26 +1131,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -1180,26 +1181,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.TextValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -1230,26 +1231,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.IntValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.IntValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -1281,26 +1282,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -1332,35 +1333,35 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.TextValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     ),
                     OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp.toSmartIri,
-                        objects = Set("http://api.knora.org/ontology/salsah-gui/v2#Textarea")
+                        objects = Set(IriLiteralV2("http://api.knora.org/ontology/salsah-gui/v2#Textarea"))
                     ),
                     OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiAttribute.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiAttribute.toSmartIri,
-                        objects = Set("rows=10", "cols=80.5")
+                        objects = Set(StringLiteralV2("rows=10"), StringLiteralV2("cols=80.5"))
                     )
                 ),
                 subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.HasValue.toSmartIri),
@@ -1390,35 +1391,35 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Thing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.TextValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong property"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid property definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     ),
                     OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp.toSmartIri,
-                        objects = Set("http://api.knora.org/ontology/salsah-gui/v2#Textarea")
+                        objects = Set(IriLiteralV2("http://api.knora.org/ontology/salsah-gui/v2#Textarea"))
                     ),
                     OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiAttribute.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiAttribute.toSmartIri,
-                        objects = Set("rows=10", "cols=80", "wrap=wrong")
+                        objects = Set(StringLiteralV2("rows=10"), StringLiteralV2("cols=80"), StringLiteralV2("wrap=wrong"))
                     )
                 ),
                 subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.HasValue.toSmartIri),
@@ -1442,10 +1443,10 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
         "change the labels of a property" in {
             val propertyIri = AnythingOntologyIri.makeEntityIri("hasName")
 
-            val newObjects = Map(
-                "en" -> "has name",
-                "fr" -> "a nom",
-                "de" -> "hat Namen"
+            val newObjects = Set(
+                StringLiteralV2("has name" , Some("en")),
+                StringLiteralV2("a nom" , Some("fr")),
+                StringLiteralV2("hat Namen" , Some("de"))
             )
 
             actorUnderTest ! ChangePropertyLabelsOrCommentsRequestV2(
@@ -1463,7 +1464,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                     val externalMsg = msg.toOntologySchema(ApiV2WithValueObjects)
                     val ontology = externalMsg.ontologies.head
                     val readPropertyInfo = ontology.properties(propertyIri)
-                    readPropertyInfo.entityInfoContent.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objectsWithLang should ===(newObjects)
+                    readPropertyInfo.entityInfoContent.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects should ===(newObjects)
 
                     val metadata = ontology.ontologyMetadata
                     val newAnythingLastModDate = metadata.lastModificationDate.getOrElse(throw AssertionException(s"${metadata.ontologyIri} has no last modification date"))
@@ -1475,15 +1476,15 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
         "change the comments of a property" in {
             val propertyIri = AnythingOntologyIri.makeEntityIri("hasName")
 
-            val newObjects = Map(
-                "en" -> "The name of a Thing",
-                "fr" -> "Le nom d\\'une chose", // This is SPARQL-escaped as it would be if taken from a JSON-LD request.
-                "de" -> "Der Name eines Dinges"
+            val newObjects = Set(
+                StringLiteralV2("The name of a Thing" , Some("en")),
+                StringLiteralV2("Le nom d\\'une chose" , Some("fr")), // This is SPARQL-escaped as it would be if taken from a JSON-LD request.
+                StringLiteralV2("Der Name eines Dinges" , Some("de"))
             )
 
             // Make an unescaped copy of the new comments, because this is how we will receive them in the API response.
             val newObjectsUnescaped = newObjects.map {
-                case (lang, obj) => lang -> stringFormatter.fromSparqlEncodedString(obj)
+                case StringLiteralV2(text, lang) => StringLiteralV2(stringFormatter.fromSparqlEncodedString(text), lang)
             }
 
             actorUnderTest ! ChangePropertyLabelsOrCommentsRequestV2(
@@ -1501,7 +1502,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                     val externalMsg = msg.toOntologySchema(ApiV2WithValueObjects)
                     val ontology = externalMsg.ontologies.head
                     val readPropertyInfo = ontology.properties(propertyIri)
-                    readPropertyInfo.entityInfoContent.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objectsWithLang should ===(newObjectsUnescaped)
+                    readPropertyInfo.entityInfoContent.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects should ===(newObjectsUnescaped)
 
                     val metadata = ontology.ontologyMetadata
                     val newAnythingLastModDate = metadata.lastModificationDate.getOrElse(throw AssertionException(s"${metadata.ontologyIri} has no last modification date"))
@@ -1518,19 +1519,15 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wild thing"
-                        )
+                        objects = Set(StringLiteralV2("wild thing", Some("en")))
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "A thing that is wild"
-                        )
+                        objects = Set(StringLiteralV2("A thing that is wild", Some("en")))
                     )
                 ),
                 directCardinalities = Map(
@@ -1599,20 +1596,20 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "nothing",
-                            "de" -> "Nichts"
+                        objects = Set(
+                            StringLiteralV2("nothing", Some("en")),
+                            StringLiteralV2("Nichts", Some("de"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "Represents nothing",
-                            "de" -> "Stellt nichts dar"
+                        objects = Set(
+                            StringLiteralV2("Represents nothing", Some("en")),
+                            StringLiteralV2("Stellt nichts dar", Some("de"))
                         )
                     )
                 ),
@@ -1652,9 +1649,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
         "change the labels of a class" in {
             val classIri = AnythingOntologyIri.makeEntityIri("Nothing")
 
-            val newObjects = Map(
-                "en" -> "nothing",
-                "fr" -> "rien"
+            val newObjects = Set(
+                StringLiteralV2("nothing", Some("en")),
+                StringLiteralV2("rien", Some("fr"))
             )
 
             actorUnderTest ! ChangeClassLabelsOrCommentsRequestV2(
@@ -1672,7 +1669,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                     val externalMsg = msg.toOntologySchema(ApiV2WithValueObjects)
                     val ontology = externalMsg.ontologies.head
                     val readClassInfo = ontology.classes(classIri)
-                    readClassInfo.entityInfoContent.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objectsWithLang should ===(newObjects)
+                    readClassInfo.entityInfoContent.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects should ===(newObjects)
 
                     val metadata = ontology.ontologyMetadata
                     val newAnythingLastModDate = metadata.lastModificationDate.getOrElse(throw AssertionException(s"${metadata.ontologyIri} has no last modification date"))
@@ -1684,14 +1681,14 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
         "change the comments of a class" in {
             val classIri = AnythingOntologyIri.makeEntityIri("Nothing")
 
-            val newObjects = Map(
-                "en" -> "Represents nothing",
-                "fr" -> "ne représente rien"
+            val newObjects = Set(
+                StringLiteralV2("Represents nothing", Some("en")),
+                StringLiteralV2("ne représente rien", Some("fr"))
             )
 
             // Make an unescaped copy of the new comments, because this is how we will receive them in the API response.
             val newObjectsUnescaped = newObjects.map {
-                case (lang, obj) => lang -> stringFormatter.fromSparqlEncodedString(obj)
+                case StringLiteralV2(text, lang) => StringLiteralV2(stringFormatter.fromSparqlEncodedString(text), lang)
             }
 
             actorUnderTest ! ChangeClassLabelsOrCommentsRequestV2(
@@ -1709,7 +1706,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                     val externalMsg = msg.toOntologySchema(ApiV2WithValueObjects)
                     val ontology = externalMsg.ontologies.head
                     val readClassInfo = ontology.classes(classIri)
-                    readClassInfo.entityInfoContent.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objectsWithLang should ===(newObjectsUnescaped)
+                    readClassInfo.entityInfoContent.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects should ===(newObjectsUnescaped)
 
                     val metadata = ontology.ontologyMetadata
                     val newAnythingLastModDate = metadata.lastModificationDate.getOrElse(throw AssertionException(s"${metadata.ontologyIri} has no last modification date"))
@@ -1726,18 +1723,18 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong class"
+                        objects = Set(
+                            StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid class definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
                 ),
@@ -1767,18 +1764,18 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong class"
+                        objects = Set(
+                            StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid class definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
                 ),
@@ -1808,18 +1805,18 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong class"
+                        objects = Set(
+                            StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid class definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
                 ),
@@ -1849,18 +1846,18 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong class"
+                        objects = Set(
+                            StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid class definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
                 ),
@@ -1890,18 +1887,18 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong class"
+                        objects = Set(
+                            StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid class definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
                 ),
@@ -1932,18 +1929,18 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong class"
+                        objects = Set(
+                            StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid class definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
                 ),
@@ -1974,18 +1971,18 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "restrictive thing"
+                        objects = Set(
+                            StringLiteralV2("restrictive thing", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "A more restrictive Thing"
+                        objects = Set(
+                            StringLiteralV2("A more restrictive Thing", Some("en"))
                         )
                     )
                 ),
@@ -2026,18 +2023,18 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "wrong class"
+                        objects = Set(
+                            StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "An invalid class definition"
+                        objects = Set(
+                            StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
                 ),
@@ -2068,33 +2065,33 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Nothing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Nothing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "has nothingness",
-                            "de" -> "hat Nichtsein"
+                        objects = Set(
+                            StringLiteralV2("has nothingness", Some("en")),
+                            StringLiteralV2("hat Nichtsein", Some("de"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "Indicates whether a Nothing has nothingness",
-                            "de" -> "Anzeigt, ob ein Nichts Nichtsein hat"
+                        objects = Set(
+                            StringLiteralV2("Indicates whether a Nothing has nothingness", Some("en")),
+                            StringLiteralV2("Anzeigt, ob ein Nichts Nichtsein hat", Some("de"))
                         )
                     ),
                     OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp.toSmartIri,
-                        objects = Set("http://api.knora.org/ontology/salsah-gui/v2#Checkbox")
+                        objects = Set(IriLiteralV2("http://api.knora.org/ontology/salsah-gui/v2#Checkbox"))
                     )
                 ),
                 subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.HasValue.toSmartIri),
@@ -2130,28 +2127,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Nothing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Nothing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "has nothingness",
-                            "de" -> "hat Nichtsein"
+                        objects = Set(
+                            StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "Indicates whether a Nothing has nothingness",
-                            "de" -> "Anzeigt, ob ein Nichts Nichtsein hat"
+                        objects = Set(
+                            StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
                 ),
@@ -2181,20 +2176,18 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "nothing",
-                            "de" -> "Nichts"
+                        objects = Set(
+                            StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "Represents nothing",
-                            "de" -> "Stellt nichts dar"
+                        objects = Set(
+                            StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
                 ),
@@ -2224,19 +2217,15 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "void"
-                        )
+                        objects = Set(StringLiteralV2("void", Some("en")))
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "Represents a void"
-                        )
+                        objects = Set(StringLiteralV2("Represents a void", Some("en")))
                     )
                 ),
                 subClassOf = Set(AnythingOntologyIri.makeEntityIri("Nothing")),
@@ -2274,7 +2263,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     )
                 ),
                 directCardinalities = Map(
@@ -2325,7 +2314,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     )
                 ),
                 directCardinalities = Map(
@@ -2371,7 +2360,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     )
                 ),
                 directCardinalities = Map(
@@ -2402,28 +2391,28 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.ObjectProperty)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(AnythingOntologyIri.makeEntityIri("Nothing").toString)
+                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Nothing").toString))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue)
+                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "has emptiness",
-                            "de" -> "hat Leerheit"
+                        objects = Set(
+                            StringLiteralV2("has emptiness", Some("en")),
+                            StringLiteralV2("hat Leerheit", Some("de"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objectsWithLang = Map(
-                            "en" -> "Indicates whether a Nothing has emptiness",
-                            "de" -> "Anzeigt, ob ein Nichts Leerheit hat"
+                        objects = Set(
+                            StringLiteralV2("Indicates whether a Nothing has emptiness", Some("en")),
+                            StringLiteralV2("Anzeigt, ob ein Nichts Leerheit hat", Some("de"))
                         )
                     )
                 ),
@@ -2460,7 +2449,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     )
                 ),
                 directCardinalities = Map(
@@ -2512,7 +2501,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     )
                 ),
                 directCardinalities = Map(
@@ -2612,7 +2601,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(OntologyConstants.Owl.Class)
+                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
                     )
                 ),
                 ontologySchema = ApiV2WithValueObjects

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -1,3 +1,22 @@
+/*
+ * Copyright © 2015-2018 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package org.knora.webapi.responders.v2
 
 import java.time.Instant

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -14,7 +14,7 @@ import org.knora.webapi.responders.{RESPONDER_MANAGER_ACTOR_NAME, ResponderManag
 import org.knora.webapi.store.{STORE_MANAGER_ACTOR_NAME, StoreManager}
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.{MutableTestIri, SmartIri, StringFormatter}
-import org.knora.webapi.messages.store.triplestoremessages.{IriLiteralV2, StringLiteralV2}
+import org.knora.webapi.messages.store.triplestoremessages.{SmartIriLiteralV2, StringLiteralV2}
 
 import scala.concurrent.duration._
 
@@ -224,26 +224,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("has name", Some("en")),
                             StringLiteralV2("hat Namen", Some("de"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("The name of a Thing", Some("en")),
                             StringLiteralV2("Der Name eines Dinges", Some("de"))
                         )
@@ -312,25 +312,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("has interesting thing", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("an interesting Thing", Some("en"))
                         )
                     )
@@ -432,21 +432,21 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -478,25 +478,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -528,25 +528,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.IntValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.IntValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -578,25 +578,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.IntValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.IntValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -628,25 +628,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -678,25 +678,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -731,25 +731,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("NonexistentClass").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("NonexistentClass")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -781,25 +781,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.KnoraApiV2PrefixExpansion + "NonexistentClass"))
+                        objects = Seq(SmartIriLiteralV2((OntologyConstants.KnoraApiV2WithValueObjects.KnoraApiV2PrefixExpansion + "NonexistentClass").toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -831,25 +831,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.Representation))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.Representation.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -881,25 +881,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.FileValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.FileValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -931,25 +931,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.LinkValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.LinkValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -981,25 +981,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.LinkValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.LinkValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -1031,25 +1031,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Xsd.String))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Xsd.String.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -1081,25 +1081,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.StillImageFileValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.StillImageFileValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -1131,25 +1131,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -1181,25 +1181,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -1231,25 +1231,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.IntValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.IntValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -1282,25 +1282,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -1333,35 +1333,35 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     ),
                     OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp.toSmartIri,
-                        objects = Set(IriLiteralV2("http://api.knora.org/ontology/salsah-gui/v2#Textarea"))
+                        objects = Seq(SmartIriLiteralV2("http://api.knora.org/ontology/salsah-gui/v2#Textarea".toSmartIri))
                     ),
                     OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiAttribute.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiAttribute.toSmartIri,
-                        objects = Set(StringLiteralV2("rows=10"), StringLiteralV2("cols=80.5"))
+                        objects = Seq(StringLiteralV2("rows=10"), StringLiteralV2("cols=80.5"))
                     )
                 ),
                 subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.HasValue.toSmartIri),
@@ -1391,35 +1391,35 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Thing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.TextValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     ),
                     OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp.toSmartIri,
-                        objects = Set(IriLiteralV2("http://api.knora.org/ontology/salsah-gui/v2#Textarea"))
+                        objects = Seq(SmartIriLiteralV2("http://api.knora.org/ontology/salsah-gui/v2#Textarea".toSmartIri))
                     ),
                     OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiAttribute.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiAttribute.toSmartIri,
-                        objects = Set(StringLiteralV2("rows=10"), StringLiteralV2("cols=80"), StringLiteralV2("wrap=wrong"))
+                        objects = Seq(StringLiteralV2("rows=10"), StringLiteralV2("cols=80"), StringLiteralV2("wrap=wrong"))
                     )
                 ),
                 subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.HasValue.toSmartIri),
@@ -1443,7 +1443,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
         "change the labels of a property" in {
             val propertyIri = AnythingOntologyIri.makeEntityIri("hasName")
 
-            val newObjects = Set(
+            val newObjects = Seq(
                 StringLiteralV2("has name" , Some("en")),
                 StringLiteralV2("a nom" , Some("fr")),
                 StringLiteralV2("hat Namen" , Some("de"))
@@ -1476,7 +1476,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
         "change the comments of a property" in {
             val propertyIri = AnythingOntologyIri.makeEntityIri("hasName")
 
-            val newObjects = Set(
+            val newObjects = Seq(
                 StringLiteralV2("The name of a Thing" , Some("en")),
                 StringLiteralV2("Le nom d\\'une chose" , Some("fr")), // This is SPARQL-escaped as it would be if taken from a JSON-LD request.
                 StringLiteralV2("Der Name eines Dinges" , Some("de"))
@@ -1519,15 +1519,15 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(StringLiteralV2("wild thing", Some("en")))
+                        objects = Seq(StringLiteralV2("wild thing", Some("en")))
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(StringLiteralV2("A thing that is wild", Some("en")))
+                        objects = Seq(StringLiteralV2("A thing that is wild", Some("en")))
                     )
                 ),
                 directCardinalities = Map(
@@ -1596,18 +1596,18 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("nothing", Some("en")),
                             StringLiteralV2("Nichts", Some("de"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("Represents nothing", Some("en")),
                             StringLiteralV2("Stellt nichts dar", Some("de"))
                         )
@@ -1649,7 +1649,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
         "change the labels of a class" in {
             val classIri = AnythingOntologyIri.makeEntityIri("Nothing")
 
-            val newObjects = Set(
+            val newObjects = Seq(
                 StringLiteralV2("nothing", Some("en")),
                 StringLiteralV2("rien", Some("fr"))
             )
@@ -1681,7 +1681,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
         "change the comments of a class" in {
             val classIri = AnythingOntologyIri.makeEntityIri("Nothing")
 
-            val newObjects = Set(
+            val newObjects = Seq(
                 StringLiteralV2("Represents nothing", Some("en")),
                 StringLiteralV2("ne représente rien", Some("fr"))
             )
@@ -1723,17 +1723,17 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
@@ -1764,17 +1764,17 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
@@ -1805,17 +1805,17 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
@@ -1846,17 +1846,17 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
@@ -1887,17 +1887,17 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
@@ -1929,17 +1929,17 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
@@ -1971,17 +1971,17 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("restrictive thing", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("A more restrictive Thing", Some("en"))
                         )
                     )
@@ -2023,17 +2023,17 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
@@ -2065,33 +2065,33 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Nothing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Nothing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("has nothingness", Some("en")),
                             StringLiteralV2("hat Nichtsein", Some("de"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("Indicates whether a Nothing has nothingness", Some("en")),
                             StringLiteralV2("Anzeigt, ob ein Nichts Nichtsein hat", Some("de"))
                         )
                     ),
                     OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.SalsahGuiApiV2WithValueObjects.GuiElementProp.toSmartIri,
-                        objects = Set(IriLiteralV2("http://api.knora.org/ontology/salsah-gui/v2#Checkbox"))
+                        objects = Seq(SmartIriLiteralV2("http://api.knora.org/ontology/salsah-gui/v2#Checkbox".toSmartIri))
                     )
                 ),
                 subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.HasValue.toSmartIri),
@@ -2127,25 +2127,25 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Nothing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Nothing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong property", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid property definition", Some("en"))
                         )
                     )
@@ -2176,17 +2176,17 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("wrong class", Some("en"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("An invalid class definition", Some("en"))
                         )
                     )
@@ -2217,15 +2217,15 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(StringLiteralV2("void", Some("en")))
+                        objects = Seq(StringLiteralV2("void", Some("en")))
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(StringLiteralV2("Represents a void", Some("en")))
+                        objects = Seq(StringLiteralV2("Represents a void", Some("en")))
                     )
                 ),
                 subClassOf = Set(AnythingOntologyIri.makeEntityIri("Nothing")),
@@ -2263,7 +2263,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     )
                 ),
                 directCardinalities = Map(
@@ -2314,7 +2314,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     )
                 ),
                 directCardinalities = Map(
@@ -2360,7 +2360,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     )
                 ),
                 directCardinalities = Map(
@@ -2391,26 +2391,26 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.ObjectProperty))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.ObjectProperty.toSmartIri))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.SubjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(AnythingOntologyIri.makeEntityIri("Nothing").toString))
+                        objects = Seq(SmartIriLiteralV2(AnythingOntologyIri.makeEntityIri("Nothing")))
                     ),
                     OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.KnoraApiV2WithValueObjects.ObjectType.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue.toSmartIri))
                     ),
                     OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("has emptiness", Some("en")),
                             StringLiteralV2("hat Leerheit", Some("de"))
                         )
                     ),
                     OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
-                        objects = Set(
+                        objects = Seq(
                             StringLiteralV2("Indicates whether a Nothing has emptiness", Some("en")),
                             StringLiteralV2("Anzeigt, ob ein Nichts Leerheit hat", Some("de"))
                         )
@@ -2449,7 +2449,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     )
                 ),
                 directCardinalities = Map(
@@ -2501,7 +2501,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     )
                 ),
                 directCardinalities = Map(
@@ -2601,7 +2601,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 predicates = Map(
                     OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
                         predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
-                        objects = Set(IriLiteralV2(OntologyConstants.Owl.Class))
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
                     )
                 ),
                 ontologySchema = ApiV2WithValueObjects


### PR DESCRIPTION
The case class `PredicateInfoV2` stores the objects of predicates of ontology entities. Currently, `PredicateInfoV2` stores all its objects as strings. When ontology information is converted from one schema to another, objects that are actually IRIs have to be converted. Since `PredicateInfoV2` doesn't know the types of its objects, something else has to keep track of that. So there are hard-coded sets of predicates that are known to have IRIs as objects, but this is cumbersome. It also means that to convert an IRI, `PredicateInfoV2` needs to convert a string to a `SmartIri` and back again.

This PR takes advantage of the type information that comes with `SparqlExtendedConstructResponse` to enable `PredicateInfoV2` to store store IRIs as `SmartIri` objects instead of strings.

- [x] Add a trait `OntologyLiteralV2`, which is like `LiteralV2` but has just the implementations needed by `PredicateInfoV2`. (`OntologyLiteralV2` shares some of its implementations with `LiteralV2`.)
- [x] Refactor `PredicateInfoV2` to use `OntologyLiteralV2`.
- [x] Use a `Seq` instead of a `Set` for the objects in `PredicateInfoV2`, so a `Seq[StringLiteralV2]` can be accepted as a `Seq[OntologyLiteralV2]` (this doesn't work with `Set`, because `Set` is [not covariant in its type parameter](https://stackoverflow.com/questions/676615/why-is-scalas-immutable-set-not-covariant-in-its-type)).
- [x] Fix bug: when API v2 served `knora-api` (default schema), `salsah-gui:guiElement` and `salsah-gui:guiAttribute` were not shown in properties in that ontology.
- [x] Fix bug: `salsah-gui:guiOrder` was not accepted when creating a property via API v2.

As a result, `PredicateInfoV2.toOntologySchema` becomes nice and simple:

```scala
def toOntologySchema(targetSchema: OntologySchema): PredicateInfoV2 = {
    copy(
        predicateIri = predicateIri.toOntologySchema(targetSchema),
        objects = objects.map {
            case smartIriLiteral: SmartIriLiteralV2 => smartIriLiteral.toOntologySchema(targetSchema)
            case other => other
        }
    )
}
```

Resolves #738.
