### PR TITLE
build (salsah1): add bash to final image

### DIFF
--- a/salsah1/Dockerfile
+++ b/salsah1/Dockerfile
@@ -20,6 +20,9 @@ RUN \
 # starting second stage
 FROM openjdk:8-jre-alpine
 
+## need bash for the webapi start script
+RUN apk add --no-cache bash
+
 COPY --from=build-stage /salsah /salsah
 
 # Expose the salsah default port


### PR DESCRIPTION
### Summary

- add bash package to final alpine linux based image which does not come with bash but we need it and so on and on goes the description of this pr :-)