### PR TITLE
feature (webapi): admin API additions (part 8)

### DIFF
--- a/knora-ontologies/knora-admin.ttl
+++ b/knora-ontologies/knora-admin.ttl
@@ -655,41 +655,6 @@ knora-base:mapEntryValue rdf:type owl:DatatypeProperty ;
 
 
 
-:Map rdf:type owl:Class ;
-
-    rdfs:subClassOf [ rdf:type owl:Restriction ;
-                      owl:onProperty :lastModificationDate ;
-                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
-                    ] ;
-
-    rdfs:comment "Represents a simple map of key-value pairs"@en .
-
-
-
-:MapEntry rdf:type owl:Class ;
-
-    rdfs:subClassOf [ rdf:type owl:Restriction ;
-                      owl:onProperty :isInMap ;
-                      owl:cardinality "1"^^xsd:nonNegativeInteger
-                    ],
-                    [ rdf:type owl:Restriction ;
-                      owl:onProperty :mapEntryKey ;
-                      owl:cardinality "1"^^xsd:nonNegativeInteger
-                    ],
-                    [ rdf:type owl:Restriction ;
-                      owl:onProperty :mapEntryValue ;
-                      owl:cardinality "1"^^xsd:nonNegativeInteger
-                    ],
-                    [ rdf:type owl:Restriction ;
-                      owl:onProperty :lastModificationDate ;
-                      owl:cardinality "1"^^xsd:nonNegativeInteger
-                    ];
-
-    rdfs:comment "Represents a key-value pair in a Map"@en .
-
-
-
-
 #################################################################
 #
 #    Individuals

--- a/knora-ontologies/knora-admin.ttl
+++ b/knora-ontologies/knora-admin.ttl
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU Affero General Public
 # License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
 
-@prefix : <http://www.knora.org/ontology/knora-base#> .
+@prefix : <http://www.knora.org/ontology/knora-admin#> .
+@prefix knora-base <http://www.knora.org/ontology/knora-base#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -23,9 +24,11 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix foaf:<http://xmlns.com/foaf/0.1/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@base <http://www.knora.org/ontology/knora-base> .
+@base <http://www.knora.org/ontology/knora-admin> .
 
-<http://www.knora.org/ontology/knora-base> rdf:type owl:Ontology .
+<http://www.knora.org/ontology/knora-admin> rdf:type owl:Ontology ;
+            rdfs:label "The knora admin ontology" ;
+            knora-base:lastModificationDate "2018-03-19T14:58:00Z"^^xsd:dateTimeStamp .
 
 #################################################################
 #
@@ -35,151 +38,151 @@
 
 
 
-###  http://www.knora.org/ontology/knora-base#attachedToProject
+###  http://www.knora.org/ontology/knora-admin#attachedToProject
 
 :attachedToProject rdf:type owl:ObjectProperty ;
 
-                   rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+                   rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
                    rdfs:comment "Connects a Resource or a ListNode (only the root node) to a project"@en ;
 
-                   :objectClassConstraint :knoraProject .
+                   knora-base:objectClassConstraint :knoraProject .
 
 
 
-###  http://www.knora.org/ontology/knora-base#attachedToUser
+###  http://www.knora.org/ontology/knora-admin#attachedToUser
 
 :attachedToUser rdf:type owl:ObjectProperty ;
 
-                rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+                rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
                 rdfs:comment "Connects a Resource or a Value to a user"@en ;
 
-                :objectClassConstraint :User .
+                knora-base:objectClassConstraint :User .
 
 
 
-###  http://www.knora.org/ontology/knora-base#belongsToInstitution
+###  http://www.knora.org/ontology/knora-admin#belongsToInstitution
 
 :belongsToInstitution rdf:type owl:ObjectProperty ;
 
-               rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+               rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
                rdfs:comment "Indicates which Institution a knoraProject belongs to"@en ;
 
-               :subjectClassConstraint :knoraProject ;
+               knora-base:subjectClassConstraint :knoraProject ;
 
-               :objectClassConstraint :Institution .
+               knora-baseknora-base:objectClassConstraint :Institution .
 
 
 
-###  http://www.knora.org/ontology/knora-base#belongsToProject
+###  http://www.knora.org/ontology/knora-admin#belongsToProject
 
 :belongsToProject rdf:type owl:ObjectProperty ;
 
-                  rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+                  rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
                   rdfs:comment "Indicates which knoraProject a UserGroup belongs to"@en ;
 
-                  :subjectClassConstraint :UserGroup ;
+                  knora-base:subjectClassConstraint :UserGroup ;
 
-                  :objectClassConstraint :knoraProject .
+                  knora-base:objectClassConstraint :knoraProject .
 
 
 
-###  http://www.knora.org/ontology/knora-base#currentproject
+###  http://www.knora.org/ontology/knora-admin#currentproject
 
 :currentproject rdf:type owl:ObjectProperty ;
 
-                rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+                rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
                 rdfs:comment "This property indicates, which is the \"current project\" of a given user. A user can be part of any number of projects, but only one can be the active project."@en ;
 
-                :subjectClassConstraint :User ;
+                knora-base:subjectClassConstraint :User ;
 
-                :objectClassConstraint :knoraProject .
+                knora-base:objectClassConstraint :knoraProject .
 
 
 
-###  http://www.knora.org/ontology/knora-base#isInGroup
+###  http://www.knora.org/ontology/knora-admin#isInGroup
 
 :isInGroup rdf:type owl:ObjectProperty ;
 
-           rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+           rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
            rdfs:comment "The given User is part of the given UserGroup"@en ;
 
            rdfs:subPropertyOf <http://xmlns.com/foaf/0.1/member> ;
 
-           :subjectClassConstraint :User ;
+           knora-base:subjectClassConstraint :User ;
 
-           :objectClassConstraint :UserGroup .
+           knora-base:objectClassConstraint :UserGroup .
 
 
 
-###  http://www.knora.org/ontology/knora-base#isInProject
+###  http://www.knora.org/ontology/knora-admin#isInProject
 
 :isInProject rdf:type owl:ObjectProperty ;
 
-             rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+             rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
              rdfs:comment "The given User is part of the given knoraProject"@en ;
 
              rdfs:subPropertyOf <http://xmlns.com/foaf/0.1/member> ;
 
-             :subjectClassConstraint :User ;
+             knora-base:subjectClassConstraint :User ;
 
-             :objectClassConstraint :knoraProject .
+             knora-base:objectClassConstraint :knoraProject .
 
 
 
-###  http://www.knora.org/ontology/knora-base#isAdminForProject
+###  http://www.knora.org/ontology/knora-admin#isAdminForProject
 
 :isInProjectAdminGroup rdf:type owl:ObjectProperty ;
 
-                       rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+                       rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
                        rdfs:comment "The given User is part of the given Project's ProjectAdmin group"@en ;
 
                        rdfs:subPropertyOf <http://xmlns.com/foaf/0.1/member> ;
 
-                       :subjectClassConstraint :User ;
+                       knora-base:subjectClassConstraint :User ;
 
-                       :objectClassConstraint :knoraProject .
+                       knora-base:objectClassConstraint :knoraProject .
 
 
 
-:isInMap rdf:type owl:ObjectProperty ;
+knora-base:isInMap rdf:type owl:ObjectProperty ;
 
-    rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+    rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
-    :subjectClassConstraint :MapEntry;
+    knora-base:subjectClassConstraint knora-base:MapEntry;
 
-    :objectClassConstraint :Map ;
+    knora-base:objectClassConstraint knora-base:Map ;
 
     rdfs:comment "Associates a MapEntry with a Map"@en .
 
 
 
-:mapEntryKey rdf:type owl:DatatypeProperty ;
+knora-base:mapEntryKey rdf:type owl:DatatypeProperty ;
 
-    rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+    rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
-    :subjectClassConstraint :MapEntry;
+    knora-base:subjectClassConstraint knora-base:MapEntry;
 
-    :objectDatatypeConstraint xsd:string ;
+    knora-base:objectDatatypeConstraint xsd:string ;
 
     rdfs:comment "Represents the key of a MapEntry"@en .
 
 
 
-:mapEntryValue rdf:type owl:DatatypeProperty ;
+knora-base:mapEntryValue rdf:type owl:DatatypeProperty ;
 
-    rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+    rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
-    :subjectClassConstraint :MapEntry;
+    knora-base:subjectClassConstraint knora-base:MapEntry;
 
-    :objectDatatypeConstraint xsd:string ;
+    knora-base:objectDatatypeConstraint xsd:string ;
 
     rdfs:comment "Represents the value of a MapEntry"@en .
 
@@ -194,15 +197,15 @@
 
 
 
-###  http://www.knora.org/ontology/knora-base#groupName
+###  http://www.knora.org/ontology/knora-admin#groupName
 
 :groupName rdf:type owl:DatatypeProperty ;
 
-             rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+             rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
              rdfs:comment "The group's name"@en ;
 
-             :subjectClassConstraint :UserGroup ;
+             knora-base:subjectClassConstraint :UserGroup ;
 
              :objectDatatypeConstraint xsd:string ;
 
@@ -210,131 +213,131 @@
 
 
 
-###  http://www.knora.org/ontology/knora-base#groupDescription
+###  http://www.knora.org/ontology/knora-admin#groupDescription
 
 :groupDescription rdf:type owl:DatatypeProperty ;
 
-             rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+             rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
              rdfs:comment "A description of a user group"@en ;
 
              rdfs:subPropertyOf :description ;
 
-             :subjectClassConstraint :UserGroup ;
+             knora-base:subjectClassConstraint :UserGroup ;
 
              :objectDatatypeConstraint xsd:string .
 
 
 
-###  http://www.knora.org/ontology/knora-base#hasSelfJoinEnabled
+###  http://www.knora.org/ontology/knora-admin#hasSelfJoinEnabled
 
 :hasSelfJoinEnabled rdf:type owl:DatatypeProperty ;
 
-            rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+            rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
             rdfs:comment "Exists and is true if users can add themselves to the project or group"@en ;
 
-            # No :subjectClassConstraint, because this can be used with :knoraProject or :UserGroup.
+            # No knora-base:subjectClassConstraint, because this can be used with :knoraProject or :UserGroup.
 
             :objectDatatypeConstraint xsd:boolean .
 
 
 
-###  http://www.knora.org/ontology/knora-base#institutionName
+###  http://www.knora.org/ontology/knora-admin#institutionName
 
 :institutionName rdf:type owl:DatatypeProperty ;
 
-             rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+             rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
              rdfs:comment "The institutions's name"@en ;
 
              rdfs:subPropertyOf <http://xmlns.com/foaf/0.1/name> ;
 
-             :subjectClassConstraint :Institution ;
+             knora-base:subjectClassConstraint :Institution ;
 
              :objectDatatypeConstraint xsd:string .
 
 
 
-###  http://www.knora.org/ontology/knora-base#institutionDescription
+###  http://www.knora.org/ontology/knora-admin#institutionDescription
 
 :institutionDescription rdf:type owl:DatatypeProperty ;
 
-            rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+            rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
             rdfs:comment "A description of a user group"@en ;
 
             rdfs:subPropertyOf :description ;
 
-            :subjectClassConstraint :Institution ;
+            knora-base:subjectClassConstraint :Institution ;
 
             :objectDatatypeConstraint xsd:string .
 
 
 
-###  http://www.knora.org/ontology/knora-base#institutionWebsite
+###  http://www.knora.org/ontology/knora-admin#institutionWebsite
 
 :institutionWebsite rdf:type owl:DatatypeProperty ;
 
-            rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+            rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
             rdfs:comment "The URL of a web site"@en ;
 
-            :subjectClassConstraint :Institution ;
+            knora-base:subjectClassConstraint :Institution ;
 
             :objectDatatypeConstraint xsd:anyURI .
 
 
 
-###  http://www.knora.org/ontology/knora-base#isActiveUser
+###  http://www.knora.org/ontology/knora-admin#isActiveUser
 
 :isInSystemAdminGroup rdf:type owl:DatatypeProperty ;
 
-          rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+          rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
           rdfs:comment "Exists and is true if the user is a member of the SystemAdmin group."@en ;
 
-          :subjectClassConstraint :User ;
+          knora-base:subjectClassConstraint :User ;
 
           :objectDatatypeConstraint xsd:boolean .
 
 
 
-###  http://www.knora.org/ontology/knora-base#givenName
+###  http://www.knora.org/ontology/knora-admin#givenName
 
 :givenName rdf:type owl:DatatypeProperty ;
 
-      rdfs:subPropertyOf foaf:givenName, :objectCannotBeMarkedAsDeleted .
+      rdfs:subPropertyOf foaf:givenName, knora-base:objectCannotBeMarkedAsDeleted .
 
 
 
-###  http://www.knora.org/ontology/knora-base#familyName
+###  http://www.knora.org/ontology/knora-admin#familyName
 
 :familyName rdf:type owl:DatatypeProperty ;
 
-      rdfs:subPropertyOf foaf:familyName, :objectCannotBeMarkedAsDeleted .
+      rdfs:subPropertyOf foaf:familyName, knora-base:objectCannotBeMarkedAsDeleted .
 
 
 
-###  http://www.knora.org/ontology/knora-base#password
+###  http://www.knora.org/ontology/knora-admin#password
 
 :password rdf:type owl:DatatypeProperty ;
 
-          rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+          rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
           rdfs:comment "An encrypted credential for access"@en ;
 
-          :subjectClassConstraint foaf:Person ;
+          knora-base:subjectClassConstraint foaf:Person ;
 
           :objectDatatypeConstraint xsd:string .
 
 
 
-###  http://www.knora.org/ontology/knora-base#phone
+###  http://www.knora.org/ontology/knora-admin#phone
 
 :phone rdf:type owl:DatatypeProperty ;
 
-       rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+       rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
        rdfs:comment "Phone number of a person, institution, etc."@en ;
 
@@ -342,11 +345,11 @@
 
 
 
-###  http://www.knora.org/ontology/knora-base#preferredLanguage
+###  http://www.knora.org/ontology/knora-admin#preferredLanguage
 
 :preferredLanguage rdf:type owl:DatatypeProperty ;
 
-                   rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+                   rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
                    rdfs:comment "Language (\"en\", \"de\", \"fr\", \"it\", \"gr\", etc.)"@en ;
 
@@ -354,132 +357,132 @@
 
 
 
-###  http://www.knora.org/ontology/knora-base#projectDescription
+###  http://www.knora.org/ontology/knora-admin#projectDescription
 
 :projectDescription rdf:type owl:DatatypeProperty ;
 
-            rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+            rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
             rdfs:comment "A description of a Knora project"@en ;
 
             rdfs:subPropertyOf :description ;
 
-            :subjectClassConstraint :knoraProject ;
+            knora-base:subjectClassConstraint :knoraProject ;
 
             :objectDatatypeConstraint xsd:string .
 
 
 
-###  http://www.knora.org/ontology/knora-base#projectKeyword
+###  http://www.knora.org/ontology/knora-admin#projectKeyword
 
 :projectKeyword rdf:type owl:DatatypeProperty ;
 
-             rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+             rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
              rdfs:comment "A keyword describing a project"@en ;
 
-             :subjectClassConstraint :knoraProject ;
+             knora-base:subjectClassConstraint :knoraProject ;
 
              :objectDatatypeConstraint xsd:string .
 
 
 
-###  http://www.knora.org/ontology/knora-base#projectLongname
+###  http://www.knora.org/ontology/knora-admin#projectLongname
 
 :projectLongname rdf:type owl:DatatypeProperty ;
 
-             rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+             rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
              rdfs:comment "The longname of a Knora project"@en ;
 
              rdfs:subPropertyOf <http://xmlns.com/foaf/0.1/name> ;
 
-             :subjectClassConstraint :knoraProject ;
+             knora-base:subjectClassConstraint :knoraProject ;
 
              :objectDatatypeConstraint xsd:string .
 
 
 
-###  http://www.knora.org/ontology/knora-base#projectLogo
+###  http://www.knora.org/ontology/knora-admin#projectLogo
 
 :projectLogo rdf:type owl:DatatypeProperty ;
 
-             rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+             rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
              rdfs:comment "Path to the projects logo"@en ;
 
-             :subjectClassConstraint :knoraProject ;
+             knora-base:subjectClassConstraint :knoraProject ;
 
              :objectDatatypeConstraint xsd:string .
 
 
 
-###  http://www.knora.org/ontology/knora-base#projectOntology
+###  http://www.knora.org/ontology/knora-admin#projectOntology
 
 :projectOntology rdf:type owl:DatatypeProperty ;
 
-            rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+            rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
             rdfs:comment "The IRI of the project specific ontology"@en ;
 
-            :subjectClassConstraint :knoraProject ;
+            knora-base:subjectClassConstraint :knoraProject ;
 
             :objectDatatypeConstraint xsd:anyURI .
 
 
 
-###  http://www.knora.org/ontology/knora-base#projectShortname
+###  http://www.knora.org/ontology/knora-admin#projectShortname
 
 :projectShortname rdf:type owl:DatatypeProperty ;
 
-             rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+             rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
              rdfs:comment "The unique shortname of a Knora project."@en ;
 
              rdfs:subPropertyOf <http://xmlns.com/foaf/0.1/name> ;
 
-             :subjectClassConstraint :knoraProject ;
+             knora-base:subjectClassConstraint :knoraProject ;
 
              :objectDatatypeConstraint xsd:string .
 
 
 
-###  http://www.knora.org/ontology/knora-base#projectShortcode
+###  http://www.knora.org/ontology/knora-admin#projectShortcode
 
 :projectShortcode rdf:type owl:DatatypeProperty ;
 
-             rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+             rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
              rdfs:comment "The unique short code of a Knora project."@en ;
 
              rdfs:subPropertyOf <http://xmlns.com/foaf/0.1/name> ;
 
-             :subjectClassConstraint :knoraProject ;
+             knora-base:subjectClassConstraint :knoraProject ;
 
              :objectDatatypeConstraint xsd:string .
 
 
 
 
-###  http://www.knora.org/ontology/knora-base#email
+###  http://www.knora.org/ontology/knora-admin#email
 
 :email rdf:type owl:DatatypeProperty ;
 
-        rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+        rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
         rdfs:comment "The email address and login name of a user of Knora"@en ;
 
-        :subjectClassConstraint :User ;
+        knora-base:subjectClassConstraint :User ;
 
         :objectDatatypeConstraint xsd:string .
 
 
 
-###  http://www.knora.org/ontology/knora-base#status
+###  http://www.knora.org/ontology/knora-admin#status
 
 :status rdf:type owl:DatatypeProperty ;
 
-          rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+          rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
 
           rdfs:comment "The status of the user / group / project. It is false if the entity has been deactivated (deleted)"@en ;
 
@@ -495,7 +498,7 @@
 
 
 
-###  http://www.knora.org/ontology/knora-base#Institution
+###  http://www.knora.org/ontology/knora-admin#Institution
 
 :Institution rdf:type owl:Class ;
 
@@ -529,7 +532,7 @@
 
 
 
-###  http://www.knora.org/ontology/knora-base#User
+###  http://www.knora.org/ontology/knora-admin#User
 
 :User rdf:type owl:Class ;
 
@@ -575,7 +578,7 @@
 
 
 
-###  http://www.knora.org/ontology/knora-base#UserGroup
+###  http://www.knora.org/ontology/knora-admin#UserGroup
 
 :UserGroup rdf:type owl:Class ;
 
@@ -602,7 +605,7 @@
 
 
 
-###  http://www.knora.org/ontology/knora-base#knoraProject
+###  http://www.knora.org/ontology/knora-admin#knoraProject
 
 :knoraProject rdf:type owl:Class ;
 
@@ -613,7 +616,7 @@
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty :projectShortcode ;
-                                owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                owl:cardinality "1"^^xsd:nonNegativeInteger
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty :projectLongname ;
@@ -693,39 +696,39 @@
 #
 #################################################################
 
-###  http://www.knora.org/ontology/knora-base#UnknownUser
+###  http://www.knora.org/ontology/knora-admin#UnknownUser
 :UnknownUser rdf:type :UserGroup ;
              :groupName "UnknownUser" ;
              :status "true"^^xsd:boolean .
 
-###  http://www.knora.org/ontology/knora-base#KnownUser
+###  http://www.knora.org/ontology/knora-admin#KnownUser
 :KnownUser rdf:type :UserGroup ;
            :groupName "KnownUser" ;
            :status "true"^^xsd:boolean .
 
-###  http://www.knora.org/ontology/knora-base#Creator
+###  http://www.knora.org/ontology/knora-admin#Creator
 :Creator rdf:type :UserGroup ;
          :groupName  "Creator" ;
          :status "true"^^xsd:boolean .
 
-###  http://www.knora.org/ontology/knora-base#ProjectMember
+###  http://www.knora.org/ontology/knora-admin#ProjectMember
 :ProjectMember rdf:type :UserGroup ;
                :groupName "ProjectMember" ;
                :status "true"^^xsd:boolean .
 
-###  http://www.knora.org/ontology/knora-base#ProjectAdmin
+###  http://www.knora.org/ontology/knora-admin#ProjectAdmin
 :ProjectAdmin rdf:type :UserGroup ;
               :groupName "ProjectAdmin" ;
               :status "true"^^xsd:boolean .
 
-###  http://www.knora.org/ontology/knora-base#SystemAdmin
+###  http://www.knora.org/ontology/knora-admin#SystemAdmin
 :SystemAdmin rdf:type :UserGroup ;
              :groupName "SystemAdmin" ;
-             :belongsToProject <http://www.knora.org/ontology/knora-base#SystemProject> ;
+             :belongsToProject <http://www.knora.org/ontology/knora-admin#SystemProject> ;
              :status "true"^^xsd:boolean ;
              :hasSelfJoinEnabled "false"^^xsd:boolean .
 
-###  http://www.knora.org/ontology/knora-base#SystemUser
+###  http://www.knora.org/ontology/knora-admin#SystemUser
 :SystemUser rdf:type :User ;
             rdfs:comment "A built-in system user."@en ;
             :email "system@localhost" ;
@@ -736,7 +739,7 @@
             :preferredLanguage "en" ;
             :isInSystemAdminGroup "false"^^xsd:boolean .
 
-###  http://www.knora.org/ontology/knora-base#AnonymousUser
+###  http://www.knora.org/ontology/knora-admin#AnonymousUser
 :AnonymousUser rdf:type :User ;
             rdfs:comment "A built-in anonymous user."@en ;
             :email "anonymous@localhost" ;
@@ -747,7 +750,7 @@
             :preferredLanguage "en" ;
             :isInSystemAdminGroup "false"^^xsd:boolean .
 
-### http://www.knora.org/ontology/knora-base#SystemProject
+### http://www.knora.org/ontology/knora-admin#SystemProject
 :SystemProject rdf:type :knoraProject ;
             rdfs:comment "A built-in project representing the Knora System."@en ;
             :projectShortname "SystemProject" ;
@@ -763,32 +766,32 @@
 ### Permission Class Properties
 ##
 #
-### http://www.knora.org/ontology/knora-base#forProject
+### http://www.knora.org/ontology/knora-admin#forProject
 
 :forProject rdf:type rdf:Property ;
-            rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+            rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
             rdfs:comment "Permission property pointing to a knoraProject."@en ;
-            :subjectClassConstraint :Permission ;
-            :objectClassConstraint :knoraProject .
+            knora-base:subjectClassConstraint :Permission ;
+            knora-base:objectClassConstraint :knoraProject .
 
-### http://www.knora.org/ontology/knora-base#forGroup
+### http://www.knora.org/ontology/knora-admin#forGroup
 :forGroup rdf:type rdf:Property ;
-            rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+            rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
             rdfs:comment "Permission property pointing to a UserGroup."@en ;
-            :subjectClassConstraint :Permission ;
-            :objectClassConstraint :UserGroup .
+            knora-base:subjectClassConstraint :Permission ;
+            knora-base:objectClassConstraint :UserGroup .
 
-### http://www.knora.org/ontology/knora-base#forResourceClass
+### http://www.knora.org/ontology/knora-admin#forResourceClass
 :forResourceClass rdf:type rdf:Property ;
-            rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+            rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
             rdfs:comment "Permission property pointing to a resource class."@en ;
-            :subjectClassConstraint :Permission .
+            knora-base:subjectClassConstraint :Permission .
 
-### http://www.knora.org/ontology/knora-base#forProperty
+### http://www.knora.org/ontology/knora-admin#forProperty
 :forProperty rdf:type rdf:property ;
-            rdfs:subPropertyOf :objectCannotBeMarkedAsDeleted ;
+            rdfs:subPropertyOf knora-base:objectCannotBeMarkedAsDeleted ;
             rdfs:comment "Permission property pointing to a resource property."@en ;
-            :subjectClassConstraint :Permission .
+            knora-base:subjectClassConstraint :Permission .
 
 
 #
@@ -796,17 +799,17 @@
 ### Permission Class and Sub-Classes
 ##
 #
-### http://www.knora.org/ontology/knora-base#Permission
+### http://www.knora.org/ontology/knora-admin#Permission
 :Permission rdf:type owl:Class ;
             rdfs:comment "Base Permission class."@en.
 
 
-### http://www.knora.org/ontology/knora-base#AdministrativePermission
+### http://www.knora.org/ontology/knora-admin#AdministrativePermission
 :AdministrativePermission rdf:type owl:Class ;
             rdfs:comment "Administrative Permission class used to create instances for storing administrative permissions on groups."@en ;
             rdfs:subClassOf :Permission .
 
-### http://www.knora.org/ontology/knora-base#DefaultObjectAccessPermission
+### http://www.knora.org/ontology/knora-admin#DefaultObjectAccessPermission
 :DefaultObjectAccessPermission rdf:type owl:Class ;
             rdfs:comment "Default Object Access Permission class used to create instances for storing default object access permission for a project and either groups, resource classes, or properties."@en ;
             rdfs:subClassOf :Permission .

--- a/knora-ontologies/knora-base.ttl
+++ b/knora-ontologies/knora-base.ttl
@@ -1510,6 +1510,40 @@
                 :objectDatatypeConstraint xsd:string .
 
 
+### issue 524
+
+:Map rdf:type owl:Class ;
+
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                      owl:onProperty :lastModificationDate ;
+                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                    ] ;
+
+    rdfs:comment "Represents a simple map of key-value pairs"@en .
+
+
+
+:MapEntry rdf:type owl:Class ;
+
+    rdfs:subClassOf [ rdf:type owl:Restriction ;
+                      owl:onProperty :isInMap ;
+                      owl:cardinality "1"^^xsd:nonNegativeInteger
+                    ],
+                    [ rdf:type owl:Restriction ;
+                      owl:onProperty :mapEntryKey ;
+                      owl:cardinality "1"^^xsd:nonNegativeInteger
+                    ],
+                    [ rdf:type owl:Restriction ;
+                      owl:onProperty :mapEntryValue ;
+                      owl:cardinality "1"^^xsd:nonNegativeInteger
+                    ],
+                    [ rdf:type owl:Restriction ;
+                      owl:onProperty :lastModificationDate ;
+                      owl:cardinality "1"^^xsd:nonNegativeInteger
+                    ];
+
+    rdfs:comment "Represents a key-value pair in a Map"@en .
+
 
 #################################################################
 #

--- a/webapi/src/main/scala/org/knora/webapi/KnoraSystemInstances.scala
+++ b/webapi/src/main/scala/org/knora/webapi/KnoraSystemInstances.scala
@@ -37,7 +37,7 @@ object KnoraSystemInstances {
           * Represents the anonymous user.
           */
         val AnonymousUser = UserADM(
-            id = OntologyConstants.KnoraBase.AnonymousUser,
+            id = OntologyConstants.KnoraAdmin.AnonymousUser,
             email = "anonymous@localhost",
             password = None,
             token = None,
@@ -55,7 +55,7 @@ object KnoraSystemInstances {
           * Represents the system user used internally.
           */
         val SystemUser = UserADM(
-            id = OntologyConstants.KnoraBase.SystemUser,
+            id = OntologyConstants.KnoraAdmin.SystemUser,
             email = "system@localhost",
             password = None,
             token  = None,
@@ -76,7 +76,7 @@ object KnoraSystemInstances {
           * Represents the system project.
           */
         val SystemProject = ProjectADM(
-            id = OntologyConstants.KnoraBase.SystemProject,
+            id = OntologyConstants.KnoraAdmin.SystemProject,
             shortname = "SystemProject",
             shortcode = Some("FFFF"),
             longname = Some("Knora System Project"),

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -19,6 +19,8 @@
 
 package org.knora.webapi
 
+import org.knora.webapi.OntologyConstants.KnoraBase.KnoraBasePrefixExpansion
+
 /**
   * Contains string constants for IRIs from ontologies used by the application.
   */
@@ -286,13 +288,7 @@ object OntologyConstants {
             TextFileValue
         )
 
-        val ListNode: IRI = KnoraBasePrefixExpansion + "ListNode"
-        val ListNodeName: IRI = KnoraBasePrefixExpansion + "listNodeName"
-        val IsRootNode: IRI = KnoraBasePrefixExpansion + "isRootNode"
-        val HasRootNode: IRI = KnoraBasePrefixExpansion + "hasRootNode"
-        val HasSubListNode: IRI = KnoraBasePrefixExpansion + "hasSubListNode"
-        val ListNodePosition: IRI = KnoraBasePrefixExpansion + "listNodePosition"
-
+        /* General deleted flag used in knora-base and knora-admin */
         val IsDeleted: IRI = KnoraBasePrefixExpansion + "isDeleted"
 
         /* Resource creator */
@@ -301,51 +297,99 @@ object OntologyConstants {
         /* Resource's and list's project */
         val AttachedToProject: IRI = KnoraBasePrefixExpansion + "attachedToProject"
 
+        /* Standoff */
+
+        val StandoffTag: IRI = KnoraBasePrefixExpansion + "StandoffTag"
+        val StandoffTagHasStart: IRI = KnoraBasePrefixExpansion + "standoffTagHasStart"
+        val StandoffTagHasEnd: IRI = KnoraBasePrefixExpansion + "standoffTagHasEnd"
+        val StandoffTagHasStartIndex: IRI = KnoraBasePrefixExpansion + "standoffTagHasStartIndex"
+        val StandoffTagHasEndIndex: IRI = KnoraBasePrefixExpansion + "standoffTagHasEndIndex"
+        val StandoffTagHasStartParent: IRI = KnoraBasePrefixExpansion + "standoffTagHasStartParent"
+        val StandoffTagHasEndParent: IRI = KnoraBasePrefixExpansion + "standoffTagHasEndParent"
+        val StandoffTagHasUUID: IRI = KnoraBasePrefixExpansion + "standoffTagHasUUID"
+        val StandoffTagHasOriginalXMLID: IRI = KnoraBasePrefixExpansion + "standoffTagHasOriginalXMLID"
+        val StandoffTagHasInternalReference: IRI = KnoraBasePrefixExpansion + "standoffTagHasInternalReference"
+
+        val StandoffTagHasLink: IRI = KnoraBasePrefixExpansion + "standoffTagHasLink"
+        val HasStandoffLinkTo: IRI = KnoraBasePrefixExpansion + "hasStandoffLinkTo"
+        val HasStandoffLinkToValue: IRI = KnoraBasePrefixExpansion + "hasStandoffLinkToValue"
+
+        val StandoffDateTag: IRI = KnoraBasePrefixExpansion + "StandoffDateTag"
+        val StandoffColorTag: IRI = KnoraBasePrefixExpansion + "StandoffColorTag"
+        val StandoffIntegerTag: IRI = KnoraBasePrefixExpansion + "StandoffIntegerTag"
+        val StandoffDecimalTag: IRI = KnoraBasePrefixExpansion + "StandoffDecimalTag"
+        val StandoffIntervalTag: IRI = KnoraBasePrefixExpansion + "StandoffIntervalTag"
+        val StandoffBooleanTag: IRI = KnoraBasePrefixExpansion + "StandoffBooleanTag"
+        val StandoffLinkTag: IRI = KnoraBasePrefixExpansion + "StandoffLinkTag"
+        val StandoffUriTag: IRI = KnoraBasePrefixExpansion + "StandoffUriTag"
+        val StandoffInternalReferenceTag: IRI = KnoraBasePrefixExpansion + "StandoffInternalReferenceTag"
+
+        val StandardMapping: IRI = "http://rdfh.ch/standoff/mappings/StandardMapping"
+
+        val CreationDate: IRI = KnoraBasePrefixExpansion + "creationDate"
+        val ValueCreationDate: IRI = KnoraBasePrefixExpansion + "valueCreationDate"
+
+        val Map: IRI = KnoraBasePrefixExpansion + "Map"
+        val MapEntry: IRI = KnoraBasePrefixExpansion + "MapEntry"
+        val MapEntryKey: IRI = KnoraBasePrefixExpansion + "mapEntryKey"
+        val MapEntryValue: IRI = KnoraBasePrefixExpansion + "mapEntryValue"
+
+        val LastModificationDate: IRI = KnoraBasePrefixExpansion + "lastModificationDate"
+    }
+
+    object KnoraAdmin {
+
+        val KnoraAdminOntologyLabel: String = "knora-admin"
+        val KnoraAdminOntologyIri: IRI = KnoraInternal.InternalOntologyStart + KnoraAdminOntologyLabel
+
+        val KnoraAdminPrefix: String = KnoraAdminOntologyLabel + ":"
+        val KnoraAdminPrefixExpansion: IRI = KnoraAdminOntologyIri + "#"
+
         /* User */
-        val User: IRI = KnoraBasePrefixExpansion + "User"
-        val Email: IRI = KnoraBasePrefixExpansion + "email"
-        val GivenName: IRI = KnoraBasePrefixExpansion + "givenName"
-        val FamilyName: IRI = KnoraBasePrefixExpansion + "familyName"
-        val Password: IRI = KnoraBasePrefixExpansion + "password"
-        val UsersActiveProject: IRI = KnoraBasePrefixExpansion + "currentproject"
-        val Status: IRI = KnoraBasePrefixExpansion + "status"
-        val PreferredLanguage: IRI = KnoraBasePrefixExpansion + "preferredLanguage"
-        val IsInProject: IRI = KnoraBasePrefixExpansion + "isInProject"
-        val IsInProjectAdminGroup: IRI = KnoraBasePrefixExpansion + "isInProjectAdminGroup"
-        val IsInGroup: IRI = KnoraBasePrefixExpansion + "isInGroup"
-        val IsInSystemAdminGroup: IRI = KnoraBasePrefixExpansion + "isInSystemAdminGroup"
+        val User: IRI = KnoraAdminPrefixExpansion + "User"
+        val Email: IRI = KnoraAdminPrefixExpansion + "email"
+        val GivenName: IRI = KnoraAdminPrefixExpansion + "givenName"
+        val FamilyName: IRI = KnoraAdminPrefixExpansion + "familyName"
+        val Password: IRI = KnoraAdminPrefixExpansion + "password"
+        val UsersActiveProject: IRI = KnoraAdminPrefixExpansion + "currentproject"
+        val Status: IRI = KnoraAdminPrefixExpansion + "status"
+        val PreferredLanguage: IRI = KnoraAdminPrefixExpansion + "preferredLanguage"
+        val IsInProject: IRI = KnoraAdminPrefixExpansion + "isInProject"
+        val IsInProjectAdminGroup: IRI = KnoraAdminPrefixExpansion + "isInProjectAdminGroup"
+        val IsInGroup: IRI = KnoraAdminPrefixExpansion + "isInGroup"
+        val IsInSystemAdminGroup: IRI = KnoraAdminPrefixExpansion + "isInSystemAdminGroup"
 
         /* Project */
-        val KnoraProject: IRI = KnoraBasePrefixExpansion + "knoraProject"
-        val ProjectShortname: IRI = KnoraBasePrefixExpansion + "projectShortname"
-        val ProjectShortcode: IRI = KnoraBasePrefixExpansion + "projectShortcode"
-        val ProjectLongname: IRI = KnoraBasePrefixExpansion + "projectLongname"
-        val ProjectDescription: IRI = KnoraBasePrefixExpansion + "projectDescription"
-        val ProjectKeyword: IRI = KnoraBasePrefixExpansion + "projectKeyword"
-        val ProjectLogo: IRI = KnoraBasePrefixExpansion + "projectLogo"
-        val BelongsToInstitution: IRI = KnoraBasePrefixExpansion + "belongsToInstitution"
-        val ProjectOntology: IRI = KnoraBasePrefixExpansion + "projectOntology"
-        val HasSelfJoinEnabled: IRI = KnoraBasePrefixExpansion + "hasSelfJoinEnabled"
+        val KnoraProject: IRI = KnoraAdminPrefixExpansion + "knoraProject"
+        val ProjectShortname: IRI = KnoraAdminPrefixExpansion + "projectShortname"
+        val ProjectShortcode: IRI = KnoraAdminPrefixExpansion + "projectShortcode"
+        val ProjectLongname: IRI = KnoraAdminPrefixExpansion + "projectLongname"
+        val ProjectDescription: IRI = KnoraAdminPrefixExpansion + "projectDescription"
+        val ProjectKeyword: IRI = KnoraAdminPrefixExpansion + "projectKeyword"
+        val ProjectLogo: IRI = KnoraAdminPrefixExpansion + "projectLogo"
+        val BelongsToInstitution: IRI = KnoraAdminPrefixExpansion + "belongsToInstitution"
+        val ProjectOntology: IRI = KnoraAdminPrefixExpansion + "projectOntology"
+        val HasSelfJoinEnabled: IRI = KnoraAdminPrefixExpansion + "hasSelfJoinEnabled"
 
         /* Group */
-        val UserGroup: IRI = KnoraBasePrefixExpansion + "UserGroup"
-        val GroupName: IRI = KnoraBasePrefixExpansion + "groupName"
-        val GroupDescription: IRI = KnoraBasePrefixExpansion + "groupDescription"
-        val BelongsToProject: IRI = KnoraBasePrefixExpansion + "belongsToProject"
+        val UserGroup: IRI = KnoraAdminPrefixExpansion + "UserGroup"
+        val GroupName: IRI = KnoraAdminPrefixExpansion + "groupName"
+        val GroupDescription: IRI = KnoraAdminPrefixExpansion + "groupDescription"
+        val BelongsToProject: IRI = KnoraAdminPrefixExpansion + "belongsToProject"
 
         /* Built-In Groups */
-        val UnknownUser: IRI = KnoraBasePrefixExpansion + "UnknownUser"
-        val KnownUser: IRI = KnoraBasePrefixExpansion + "KnownUser"
-        val ProjectMember: IRI = KnoraBasePrefixExpansion + "ProjectMember"
-        val Creator: IRI = KnoraBasePrefixExpansion + "Creator"
-        val SystemAdmin: IRI = KnoraBasePrefixExpansion + "SystemAdmin"
-        val ProjectAdmin: IRI = KnoraBasePrefixExpansion + "ProjectAdmin"
+        val UnknownUser: IRI = KnoraAdminPrefixExpansion + "UnknownUser"
+        val KnownUser: IRI = KnoraAdminPrefixExpansion + "KnownUser"
+        val ProjectMember: IRI = KnoraAdminPrefixExpansion + "ProjectMember"
+        val Creator: IRI = KnoraAdminPrefixExpansion + "Creator"
+        val SystemAdmin: IRI = KnoraAdminPrefixExpansion + "SystemAdmin"
+        val ProjectAdmin: IRI = KnoraAdminPrefixExpansion + "ProjectAdmin"
 
         /* Institution */
-        val Institution: IRI = KnoraBasePrefixExpansion + "Institution"
+        val Institution: IRI = KnoraAdminPrefixExpansion + "Institution"
 
         /* Permissions */
-        val HasPermissions: IRI = KnoraBasePrefixExpansion + "hasPermissions"
+        val HasPermissions: IRI = KnoraAdminPrefixExpansion + "hasPermissions"
 
         val PermissionListDelimiter: Char = '|'
         val GroupListDelimiter: Char = ','
@@ -383,11 +427,11 @@ object OntologyConstants {
             ProjectAdminOntologyAllPermission
         )
 
-        val HasDefaultRestrictedViewPermission: IRI = KnoraBasePrefixExpansion + "hasDefaultRestrictedViewPermission"
-        val HasDefaultViewPermission: IRI = KnoraBasePrefixExpansion + "hasDefaultViewPermission"
-        val HasDefaultModifyPermission: IRI = KnoraBasePrefixExpansion + "hasDefaultModifyPermission"
-        val HasDefaultDeletePermission: IRI = KnoraBasePrefixExpansion + "hasDefaultDeletePermission"
-        val HasDefaultChangeRightsPermission: IRI = KnoraBasePrefixExpansion + "hasDefaultChangeRightsPermission"
+        val HasDefaultRestrictedViewPermission: IRI = KnoraAdminPrefixExpansion + "hasDefaultRestrictedViewPermission"
+        val HasDefaultViewPermission: IRI = KnoraAdminPrefixExpansion + "hasDefaultViewPermission"
+        val HasDefaultModifyPermission: IRI = KnoraAdminPrefixExpansion + "hasDefaultModifyPermission"
+        val HasDefaultDeletePermission: IRI = KnoraAdminPrefixExpansion + "hasDefaultDeletePermission"
+        val HasDefaultChangeRightsPermission: IRI = KnoraAdminPrefixExpansion + "hasDefaultChangeRightsPermission"
 
         val DefaultPermissionProperties: Set[IRI] = Set(
             HasDefaultRestrictedViewPermission,
@@ -397,64 +441,38 @@ object OntologyConstants {
             HasDefaultChangeRightsPermission
         )
 
-        /* Standoff */
+        val AdministrativePermission: IRI = KnoraAdminPrefixExpansion + "AdministrativePermission"
+        val DefaultObjectAccessPermission: IRI = KnoraAdminPrefixExpansion + "DefaultObjectAccessPermission"
+        val ForProject: IRI = KnoraAdminPrefixExpansion + "forProject"
+        val ForGroup: IRI = KnoraAdminPrefixExpansion + "forGroup"
+        val ForResourceClass: IRI = KnoraAdminPrefixExpansion + "forResourceClass"
+        val ForProperty: IRI = KnoraAdminPrefixExpansion + "forProperty"
 
-        val StandoffTag: IRI = KnoraBasePrefixExpansion + "StandoffTag"
-        val StandoffTagHasStart: IRI = KnoraBasePrefixExpansion + "standoffTagHasStart"
-        val StandoffTagHasEnd: IRI = KnoraBasePrefixExpansion + "standoffTagHasEnd"
-        val StandoffTagHasStartIndex: IRI = KnoraBasePrefixExpansion + "standoffTagHasStartIndex"
-        val StandoffTagHasEndIndex: IRI = KnoraBasePrefixExpansion + "standoffTagHasEndIndex"
-        val StandoffTagHasStartParent: IRI = KnoraBasePrefixExpansion + "standoffTagHasStartParent"
-        val StandoffTagHasEndParent: IRI = KnoraBasePrefixExpansion + "standoffTagHasEndParent"
-        val StandoffTagHasUUID: IRI = KnoraBasePrefixExpansion + "standoffTagHasUUID"
-        val StandoffTagHasOriginalXMLID: IRI = KnoraBasePrefixExpansion + "standoffTagHasOriginalXMLID"
-        val StandoffTagHasInternalReference: IRI = KnoraBasePrefixExpansion + "standoffTagHasInternalReference"
+        /* Lists */
 
-        val StandoffTagHasLink: IRI = KnoraBasePrefixExpansion + "standoffTagHasLink"
-        val HasStandoffLinkTo: IRI = KnoraBasePrefixExpansion + "hasStandoffLinkTo"
-        val HasStandoffLinkToValue: IRI = KnoraBasePrefixExpansion + "hasStandoffLinkToValue"
+        val ListNode: IRI = KnoraAdminPrefixExpansion + "ListNode"
+        val ListNodeName: IRI = KnoraAdminPrefixExpansion + "listNodeName"
+        val IsRootNode: IRI = KnoraAdminPrefixExpansion + "isRootNode"
+        val HasRootNode: IRI = KnoraAdminPrefixExpansion + "hasRootNode"
+        val HasSubListNode: IRI = KnoraAdminPrefixExpansion + "hasSubListNode"
+        val ListNodePosition: IRI = KnoraAdminPrefixExpansion + "listNodePosition"
 
-        val StandoffDateTag: IRI = KnoraBasePrefixExpansion + "StandoffDateTag"
-        val StandoffColorTag: IRI = KnoraBasePrefixExpansion + "StandoffColorTag"
-        val StandoffIntegerTag: IRI = KnoraBasePrefixExpansion + "StandoffIntegerTag"
-        val StandoffDecimalTag: IRI = KnoraBasePrefixExpansion + "StandoffDecimalTag"
-        val StandoffIntervalTag: IRI = KnoraBasePrefixExpansion + "StandoffIntervalTag"
-        val StandoffBooleanTag: IRI = KnoraBasePrefixExpansion + "StandoffBooleanTag"
-        val StandoffLinkTag: IRI = KnoraBasePrefixExpansion + "StandoffLinkTag"
-        val StandoffUriTag: IRI = KnoraBasePrefixExpansion + "StandoffUriTag"
-        val StandoffInternalReferenceTag: IRI = KnoraBasePrefixExpansion + "StandoffInternalReferenceTag"
 
-        val StandardMapping: IRI = "http://rdfh.ch/standoff/mappings/StandardMapping"
 
-        val AdministrativePermission: IRI = KnoraBasePrefixExpansion + "AdministrativePermission"
-        val DefaultObjectAccessPermission: IRI = KnoraBasePrefixExpansion + "DefaultObjectAccessPermission"
-        val ForProject: IRI = KnoraBasePrefixExpansion + "forProject"
-        val ForGroup: IRI = KnoraBasePrefixExpansion + "forGroup"
-        val ForResourceClass: IRI = KnoraBasePrefixExpansion + "forResourceClass"
-        val ForProperty: IRI = KnoraBasePrefixExpansion + "forProperty"
+        /* Admin Instances */
 
-        val SystemProject: IRI = KnoraBasePrefixExpansion + "SystemProject"
+        val SystemProject: IRI = KnoraAdminPrefixExpansion + "SystemProject"
 
         /**
           * The system user is the owner of objects that are created by the system, rather than directly by the user,
           * such as link values for standoff resource references.
           */
-        val SystemUser: IRI = KnoraBasePrefixExpansion + "SystemUser"
+        val SystemUser: IRI = KnoraAdminPrefixExpansion + "SystemUser"
 
         /**
           * Every user not logged-in is per default an anonymous user.
           */
-        val AnonymousUser: IRI = KnoraBasePrefixExpansion + "AnonymousUser"
-
-        val CreationDate: IRI = KnoraBasePrefixExpansion + "creationDate"
-        val ValueCreationDate: IRI = KnoraBasePrefixExpansion + "valueCreationDate"
-
-        val Map: IRI = KnoraBasePrefixExpansion + "Map"
-        val MapEntry: IRI = KnoraBasePrefixExpansion + "MapEntry"
-        val MapEntryKey: IRI = KnoraBasePrefixExpansion + "mapEntryKey"
-        val MapEntryValue: IRI = KnoraBasePrefixExpansion + "mapEntryValue"
-
-        val LastModificationDate: IRI = KnoraBasePrefixExpansion + "lastModificationDate"
+        val AnonymousUser: IRI = KnoraAdminPrefixExpansion + "AnonymousUser"
     }
 
     object Standoff {

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
@@ -69,26 +69,17 @@ case class CreateListApiRequestADM(projectIri: IRI,
 
 /**
   * Represents an API request payload that asks the Knora API server to update an existing list's basic information.
+  * Sending an empty sequence means removing all data for the corresponding property. At least one label is required.
   *
-  * @param listIri    the IRI of the list to change.
   * @param projectIri the IRI of the project the list belongs to.
   * @param labels     the labels.
   * @param comments   the comments.
   */
-case class ChangeListInfoApiRequestADM(listIri: IRI,
-                                       projectIri: IRI,
+case class ChangeListInfoApiRequestADM(projectIri: IRI,
                                        labels: Seq[StringLiteralV2],
                                        comments: Seq[StringLiteralV2]) extends ListADMJsonProtocol {
 
     private val stringFormatter = StringFormatter.getInstanceForConstantOntologies
-
-    if (listIri.isEmpty) {
-        throw BadRequestException(LIST_IRI_MISSING_ERROR)
-    }
-
-    if (!stringFormatter.isKnoraListIriStr(listIri)) {
-        throw BadRequestException(LIST_IRI_INVALID_ERROR)
-    }
 
     if (projectIri.isEmpty) {
         throw BadRequestException(PROJECT_IRI_MISSING_ERROR)
@@ -98,8 +89,8 @@ case class ChangeListInfoApiRequestADM(listIri: IRI,
         throw BadRequestException(PROJECT_IRI_INVALID_ERROR)
     }
 
-    if (labels.isEmpty && comments.isEmpty) {
-        throw BadRequestException(REQUEST_NOT_CHANGING_DATA_ERROR)
+    if (labels.isEmpty) {
+        throw BadRequestException(REQUEST_REMOVING_ALL_LABELS_ERROR)
     }
 
     def toJsValue: JsValue = changeListInfoApiRequestADMFormat.write(this)
@@ -554,7 +545,7 @@ trait ListADMJsonProtocol extends SprayJsonSupport with DefaultJsonProtocol with
 
 
     implicit val createListApiRequestADMFormat: RootJsonFormat[CreateListApiRequestADM] = jsonFormat(CreateListApiRequestADM, "projectIri", "labels", "comments")
-    implicit val changeListInfoApiRequestADMFormat: RootJsonFormat[ChangeListInfoApiRequestADM] = jsonFormat(ChangeListInfoApiRequestADM, "listIri", "projectIri", "labels", "comments")
+    implicit val changeListInfoApiRequestADMFormat: RootJsonFormat[ChangeListInfoApiRequestADM] = jsonFormat(ChangeListInfoApiRequestADM, "projectIri", "labels", "comments")
     implicit val nodePathGetResponseADMFormat: RootJsonFormat[NodePathGetResponseADM] = jsonFormat(NodePathGetResponseADM, "nodelist")
     implicit val listsGetResponseADMFormat: RootJsonFormat[ListsGetResponseADM] = jsonFormat(ListsGetResponseADM, "lists")
     implicit val listGetResponseADMFormat: RootJsonFormat[ListGetResponseADM] = jsonFormat(ListGetResponseADM, "list")

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -393,12 +393,12 @@ case class PermissionsDataADM(groupsPerProject: Map[IRI, Seq[IRI]] = Map.empty[I
 
     /* Is the user a member of the SystemAdmin group */
     def isSystemAdmin: Boolean = {
-        groupsPerProject.getOrElse(OntologyConstants.KnoraBase.SystemProject, List.empty[IRI]).contains(OntologyConstants.KnoraBase.SystemAdmin)
+        groupsPerProject.getOrElse(OntologyConstants.KnoraAdmin.SystemProject, List.empty[IRI]).contains(OntologyConstants.KnoraAdmin.SystemAdmin)
     }
 
     /* Is the user a member of the ProjectAdmin group */
     def isProjectAdmin(projectIri: IRI): Boolean = {
-        groupsPerProject.getOrElse(projectIri, List.empty[IRI]).contains(OntologyConstants.KnoraBase.ProjectAdmin)
+        groupsPerProject.getOrElse(projectIri, List.empty[IRI]).contains(OntologyConstants.KnoraAdmin.ProjectAdmin)
     }
 
     /* Does the user have the 'ProjectAdminAllPermission' permission for the project */
@@ -590,7 +590,7 @@ object PermissionADM {
 
     val ProjectResourceCreateAllPermission: PermissionADM = {
         PermissionADM(
-            name = OntologyConstants.KnoraBase.ProjectResourceCreateAllPermission,
+            name = OntologyConstants.KnoraAdmin.ProjectResourceCreateAllPermission,
             additionalInformation = None,
             v1Code = None
         )
@@ -598,7 +598,7 @@ object PermissionADM {
 
     def projectResourceCreateRestrictedPermission(restriction: IRI): PermissionADM = {
         PermissionADM(
-            name = OntologyConstants.KnoraBase.ProjectResourceCreateRestrictedPermission,
+            name = OntologyConstants.KnoraAdmin.ProjectResourceCreateRestrictedPermission,
             additionalInformation = Some(restriction),
             v1Code = None
         )
@@ -606,7 +606,7 @@ object PermissionADM {
 
     val ProjectAdminAllPermission: PermissionADM = {
         PermissionADM(
-            name = OntologyConstants.KnoraBase.ProjectAdminAllPermission,
+            name = OntologyConstants.KnoraAdmin.ProjectAdminAllPermission,
             additionalInformation = None,
             v1Code = None
         )
@@ -614,7 +614,7 @@ object PermissionADM {
 
     val ProjectAdminGroupAllPermission: PermissionADM = {
         PermissionADM(
-            name = OntologyConstants.KnoraBase.ProjectAdminGroupAllPermission,
+            name = OntologyConstants.KnoraAdmin.ProjectAdminGroupAllPermission,
             additionalInformation = None,
             v1Code = None
         )
@@ -622,7 +622,7 @@ object PermissionADM {
 
     def projectAdminGroupRestrictedPermission(restriction: IRI): PermissionADM = {
         PermissionADM(
-            name = OntologyConstants.KnoraBase.ProjectAdminGroupRestrictedPermission,
+            name = OntologyConstants.KnoraAdmin.ProjectAdminGroupRestrictedPermission,
             additionalInformation = Some(restriction),
             v1Code = None
         )
@@ -630,7 +630,7 @@ object PermissionADM {
 
     val ProjectAdminRightsAllPermission: PermissionADM = {
         PermissionADM(
-            name = OntologyConstants.KnoraBase.ProjectAdminRightsAllPermission,
+            name = OntologyConstants.KnoraAdmin.ProjectAdminRightsAllPermission,
             additionalInformation = None,
             v1Code = None
         )
@@ -638,7 +638,7 @@ object PermissionADM {
 
     val ProjectAdminOntologyAllPermission: PermissionADM = {
         PermissionADM(
-            name = OntologyConstants.KnoraBase.ProjectAdminOntologyAllPermission,
+            name = OntologyConstants.KnoraAdmin.ProjectAdminOntologyAllPermission,
             additionalInformation = None,
             v1Code = None
         )
@@ -650,7 +650,7 @@ object PermissionADM {
 
     def changeRightsPermission(restriction: IRI): PermissionADM = {
         PermissionADM(
-            name = OntologyConstants.KnoraBase.ChangeRightsPermission,
+            name = OntologyConstants.KnoraAdmin.ChangeRightsPermission,
             additionalInformation = Some(restriction),
             v1Code = Some(8)
         )
@@ -658,7 +658,7 @@ object PermissionADM {
 
     def deletePermission(restriction: IRI): PermissionADM = {
         PermissionADM(
-            name = OntologyConstants.KnoraBase.DeletePermission,
+            name = OntologyConstants.KnoraAdmin.DeletePermission,
             additionalInformation = Some(restriction),
             v1Code = Some(7)
         )
@@ -666,7 +666,7 @@ object PermissionADM {
 
     def modifyPermission(restriction: IRI): PermissionADM = {
         PermissionADM(
-            name = OntologyConstants.KnoraBase.ModifyPermission,
+            name = OntologyConstants.KnoraAdmin.ModifyPermission,
             additionalInformation = Some(restriction),
             v1Code = Some(6)
         )
@@ -674,7 +674,7 @@ object PermissionADM {
 
     def viewPermission(restriction: IRI): PermissionADM = {
         PermissionADM(
-            name = OntologyConstants.KnoraBase.ViewPermission,
+            name = OntologyConstants.KnoraAdmin.ViewPermission,
             additionalInformation = Some(restriction),
             v1Code = Some(2)
         )
@@ -682,7 +682,7 @@ object PermissionADM {
 
     def restrictedViewPermission(restriction: IRI): PermissionADM = {
         PermissionADM(
-            name = OntologyConstants.KnoraBase.RestrictedViewPermission,
+            name = OntologyConstants.KnoraAdmin.RestrictedViewPermission,
             additionalInformation = Some(restriction),
             v1Code = Some(1)
         )

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/usersmessages/UsersMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/usersmessages/UsersMessagesADM.scala
@@ -546,12 +546,12 @@ case class UserADM(id: IRI,
 
     /* Is the user a member of the SystemAdmin group */
     def isSystemAdmin: Boolean = {
-        permissions.groupsPerProject.getOrElse(OntologyConstants.KnoraBase.SystemProject, List.empty[IRI]).contains(OntologyConstants.KnoraBase.SystemAdmin)
+        permissions.groupsPerProject.getOrElse(OntologyConstants.KnoraAdmin.SystemProject, List.empty[IRI]).contains(OntologyConstants.KnoraAdmin.SystemAdmin)
     }
 
-    def isSystemUser: Boolean = id.equalsIgnoreCase(OntologyConstants.KnoraBase.SystemUser)
+    def isSystemUser: Boolean = id.equalsIgnoreCase(OntologyConstants.KnoraAdmin.SystemUser)
 
-    def isAnonymousUser: Boolean = id.equalsIgnoreCase(OntologyConstants.KnoraBase.AnonymousUser)
+    def isAnonymousUser: Boolean = id.equalsIgnoreCase(OntologyConstants.KnoraAdmin.AnonymousUser)
 
     def fullname: String = givenName + " " + familyName
 
@@ -596,7 +596,7 @@ case class UserADM(id: IRI,
 
             val v1Groups: Seq[IRI] = groups.map(_.id)
 
-            val projectesWithoutSystemProject = projects.filter(_.id != OntologyConstants.KnoraBase.SystemProject)
+            val projectesWithoutSystemProject = projects.filter(_.id != OntologyConstants.KnoraAdmin.SystemProject)
             val projectInfosV1 = projectesWithoutSystemProject.map(_.asProjectInfoV1)
             val projects_info_v1: Map[IRI, ProjectInfoV1] = projectInfosV1.map(_.id).zip(projectInfosV1).toMap[IRI, ProjectInfoV1]
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
@@ -86,7 +86,7 @@ class GroupsResponderADM extends Responder with GroupsADMJsonProtocol {
             groups: Seq[Future[GroupADM]] = statements.map {
                 case (groupIri: SubjectV2, propsMap: Map[IRI, Seq[LiteralV2]]) =>
 
-                    val projectIri: IRI = propsMap.getOrElse(OntologyConstants.KnoraBase.BelongsToProject, throw InconsistentTriplestoreDataException(s"Group $groupIri has no project attached")).head.asInstanceOf[IriLiteralV2].value
+                    val projectIri: IRI = propsMap.getOrElse(OntologyConstants.KnoraAdmin.BelongsToProject, throw InconsistentTriplestoreDataException(s"Group $groupIri has no project attached")).head.asInstanceOf[IriLiteralV2].value
 
                     for {
                         maybeProjectADM: Option[ProjectADM] <- (responderManager ? ProjectGetADM(maybeIri = Some(projectIri), maybeShortname = None, maybeShortcode = None, requestingUser = KnoraSystemInstances.Users.SystemUser)).mapTo[Option[ProjectADM]]
@@ -97,11 +97,11 @@ class GroupsResponderADM extends Responder with GroupsADMJsonProtocol {
 
                         group = GroupADM(
                             id = groupIri.toString,
-                            name = propsMap.getOrElse(OntologyConstants.KnoraBase.GroupName, throw InconsistentTriplestoreDataException(s"Group $groupIri has no name attached")).head.asInstanceOf[StringLiteralV2].value,
-                            description = propsMap.getOrElse(OntologyConstants.KnoraBase.GroupDescription, throw InconsistentTriplestoreDataException(s"Group $groupIri has no description attached")).head.asInstanceOf[StringLiteralV2].value,
+                            name = propsMap.getOrElse(OntologyConstants.KnoraAdmin.GroupName, throw InconsistentTriplestoreDataException(s"Group $groupIri has no name attached")).head.asInstanceOf[StringLiteralV2].value,
+                            description = propsMap.getOrElse(OntologyConstants.KnoraAdmin.GroupDescription, throw InconsistentTriplestoreDataException(s"Group $groupIri has no description attached")).head.asInstanceOf[StringLiteralV2].value,
                             project = projectADM,
-                            status = propsMap.getOrElse(OntologyConstants.KnoraBase.Status, throw InconsistentTriplestoreDataException(s"Group $groupIri has no status attached")).head.asInstanceOf[BooleanLiteralV2].value,
-                            selfjoin = propsMap.getOrElse(OntologyConstants.KnoraBase.HasSelfJoinEnabled, throw InconsistentTriplestoreDataException(s"Group $groupIri has no status attached")).head.asInstanceOf[BooleanLiteralV2].value
+                            status = propsMap.getOrElse(OntologyConstants.KnoraAdmin.Status, throw InconsistentTriplestoreDataException(s"Group $groupIri has no status attached")).head.asInstanceOf[BooleanLiteralV2].value,
+                            selfjoin = propsMap.getOrElse(OntologyConstants.KnoraAdmin.HasSelfJoinEnabled, throw InconsistentTriplestoreDataException(s"Group $groupIri has no status attached")).head.asInstanceOf[BooleanLiteralV2].value
                         )
 
                     } yield group
@@ -265,7 +265,7 @@ class GroupsResponderADM extends Responder with GroupsADMJsonProtocol {
                 adminNamedGraphIri = OntologyConstants.NamedGraphs.AdminNamedGraph,
                 triplestore = settings.triplestoreType,
                 groupIri = groupIri,
-                groupClassIri = OntologyConstants.KnoraBase.UserGroup,
+                groupClassIri = OntologyConstants.KnoraAdmin.UserGroup,
                 name = createRequest.name,
                 maybeDescription = createRequest.description,
                 projectIri = createRequest.project,
@@ -454,7 +454,7 @@ class GroupsResponderADM extends Responder with GroupsADMJsonProtocol {
 
         log.debug("statements2GroupADM - groupIri: {}", groupIri)
 
-        val maybeProjectIri = propsMap.get(OntologyConstants.KnoraBase.BelongsToProject)
+        val maybeProjectIri = propsMap.get(OntologyConstants.KnoraAdmin.BelongsToProject)
         val projectIriFuture: Future[IRI] = maybeProjectIri match {
             case Some(iri) => FastFuture.successful(iri.head.asInstanceOf[IriLiteralV2].value)
             case None => FastFuture.failed(throw InconsistentTriplestoreDataException(s"Group $groupIri has no project attached"))
@@ -468,11 +468,11 @@ class GroupsResponderADM extends Responder with GroupsADMJsonProtocol {
 
                 groupADM: GroupADM = GroupADM(
                     id = groupIri,
-                    name = propsMap.getOrElse(OntologyConstants.KnoraBase.GroupName, throw InconsistentTriplestoreDataException(s"Group $groupIri has no groupName attached")).head.asInstanceOf[StringLiteralV2].value,
-                    description = propsMap.getOrElse(OntologyConstants.KnoraBase.GroupDescription, throw InconsistentTriplestoreDataException(s"Group $groupIri has no description attached")).head.asInstanceOf[StringLiteralV2].value,
+                    name = propsMap.getOrElse(OntologyConstants.KnoraAdmin.GroupName, throw InconsistentTriplestoreDataException(s"Group $groupIri has no groupName attached")).head.asInstanceOf[StringLiteralV2].value,
+                    description = propsMap.getOrElse(OntologyConstants.KnoraAdmin.GroupDescription, throw InconsistentTriplestoreDataException(s"Group $groupIri has no description attached")).head.asInstanceOf[StringLiteralV2].value,
                     project = project,
-                    status = propsMap.getOrElse(OntologyConstants.KnoraBase.Status, throw InconsistentTriplestoreDataException(s"Group $groupIri has no status attached")).head.asInstanceOf[BooleanLiteralV2].value,
-                    selfjoin = propsMap.getOrElse(OntologyConstants.KnoraBase.HasSelfJoinEnabled, throw InconsistentTriplestoreDataException(s"Group $groupIri has no selfJoin attached")).head.asInstanceOf[BooleanLiteralV2].value
+                    status = propsMap.getOrElse(OntologyConstants.KnoraAdmin.Status, throw InconsistentTriplestoreDataException(s"Group $groupIri has no status attached")).head.asInstanceOf[BooleanLiteralV2].value,
+                    selfjoin = propsMap.getOrElse(OntologyConstants.KnoraAdmin.HasSelfJoinEnabled, throw InconsistentTriplestoreDataException(s"Group $groupIri has no selfJoin attached")).head.asInstanceOf[BooleanLiteralV2].value
                 )
             } yield Some(groupADM)
         } else {

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
@@ -121,7 +121,7 @@ class PermissionsResponderADM extends Responder {
             projectMembers: Seq[(IRI, IRI)] = if (projectIris.nonEmpty) {
                 for {
                     projectIri <- projectIris.toVector
-                    res = (projectIri, OntologyConstants.KnoraBase.ProjectMember)
+                    res = (projectIri, OntologyConstants.KnoraAdmin.ProjectMember)
                 } yield res
             } else {
                 Seq.empty[(IRI, IRI)]
@@ -133,7 +133,7 @@ class PermissionsResponderADM extends Responder {
             projectAdmins: Seq[(IRI, IRI)] = if (projectIris.nonEmpty) {
                 for {
                     projectAdminForGroup <- isInProjectAdminGroups.toSeq
-                    res = (projectAdminForGroup, OntologyConstants.KnoraBase.ProjectAdmin)
+                    res = (projectAdminForGroup, OntologyConstants.KnoraAdmin.ProjectAdmin)
                 } yield res
             } else {
                 Seq.empty[(IRI, IRI)]
@@ -142,7 +142,7 @@ class PermissionsResponderADM extends Responder {
 
             /* materialize implicit membership in 'http://www.knora.org/ontology/knora-base#SystemAdmin' group */
             systemAdmin: Seq[(IRI, IRI)] = if (isInSystemAdminGroup) {
-                Seq((OntologyConstants.KnoraBase.SystemProject, OntologyConstants.KnoraBase.SystemAdmin))
+                Seq((OntologyConstants.KnoraAdmin.SystemProject, OntologyConstants.KnoraAdmin.SystemAdmin))
             } else {
                 Seq.empty[(IRI, IRI)]
             }
@@ -195,9 +195,9 @@ class PermissionsResponderADM extends Responder {
 
             for {
                 /* Get administrative permissions for the knora-base:ProjectAdmin group */
-                administrativePermissionsOnProjectAdminGroup: Set[PermissionADM] <- administrativePermissionForGroupsGeADM(projectIri, List(OntologyConstants.KnoraBase.ProjectAdmin))
+                administrativePermissionsOnProjectAdminGroup: Set[PermissionADM] <- administrativePermissionForGroupsGeADM(projectIri, List(OntologyConstants.KnoraAdmin.ProjectAdmin))
                 _ = if (administrativePermissionsOnProjectAdminGroup.nonEmpty) {
-                    if (extendedUserGroups.contains(OntologyConstants.KnoraBase.ProjectAdmin)) {
+                    if (extendedUserGroups.contains(OntologyConstants.KnoraAdmin.ProjectAdmin)) {
                         permissionsListBuffer += (("ProjectAdmin", administrativePermissionsOnProjectAdminGroup))
                     }
                 }
@@ -206,7 +206,7 @@ class PermissionsResponderADM extends Responder {
 
                 /* Get administrative permissions for custom groups (all groups other than the built-in groups) */
                 administrativePermissionsOnCustomGroups: Set[PermissionADM] <- {
-                    val customGroups = extendedUserGroups diff List(OntologyConstants.KnoraBase.KnownUser, OntologyConstants.KnoraBase.ProjectMember, OntologyConstants.KnoraBase.ProjectAdmin)
+                    val customGroups = extendedUserGroups diff List(OntologyConstants.KnoraAdmin.KnownUser, OntologyConstants.KnoraAdmin.ProjectMember, OntologyConstants.KnoraAdmin.ProjectAdmin)
                     if (customGroups.nonEmpty) {
                         administrativePermissionForGroupsGeADM(projectIri, customGroups)
                     } else {
@@ -222,10 +222,10 @@ class PermissionsResponderADM extends Responder {
 
 
                 /* Get administrative permissions for the knora-base:ProjectMember group */
-                administrativePermissionsOnProjectMemberGroup: Set[PermissionADM] <- administrativePermissionForGroupsGeADM(projectIri, List(OntologyConstants.KnoraBase.ProjectMember))
+                administrativePermissionsOnProjectMemberGroup: Set[PermissionADM] <- administrativePermissionForGroupsGeADM(projectIri, List(OntologyConstants.KnoraAdmin.ProjectMember))
                 _ = if (administrativePermissionsOnProjectMemberGroup.nonEmpty) {
                     if (permissionsListBuffer.isEmpty) {
-                        if (extendedUserGroups.contains(OntologyConstants.KnoraBase.ProjectMember)) {
+                        if (extendedUserGroups.contains(OntologyConstants.KnoraAdmin.ProjectMember)) {
                             permissionsListBuffer += (("ProjectMember", administrativePermissionsOnProjectMemberGroup))
                         }
                     }
@@ -234,10 +234,10 @@ class PermissionsResponderADM extends Responder {
 
 
                 /* Get administrative permissions for the knora-base:KnownUser group */
-                administrativePermissionsOnKnownUserGroup: Set[PermissionADM] <- administrativePermissionForGroupsGeADM(projectIri, List(OntologyConstants.KnoraBase.KnownUser))
+                administrativePermissionsOnKnownUserGroup: Set[PermissionADM] <- administrativePermissionForGroupsGeADM(projectIri, List(OntologyConstants.KnoraAdmin.KnownUser))
                 _ = if (administrativePermissionsOnKnownUserGroup.nonEmpty) {
                     if (permissionsListBuffer.isEmpty) {
-                        if (extendedUserGroups.contains(OntologyConstants.KnoraBase.KnownUser)) {
+                        if (extendedUserGroups.contains(OntologyConstants.KnoraAdmin.KnownUser)) {
                             permissionsListBuffer += (("KnownUser", administrativePermissionsOnKnownUserGroup))
                         }
                     }
@@ -261,7 +261,7 @@ class PermissionsResponderADM extends Responder {
             (projectIri, groups) <- groupsPerProject
 
             /* Explicitly add 'KnownUser' group */
-            extendedUserGroups = OntologyConstants.KnoraBase.KnownUser ++ groups
+            extendedUserGroups = OntologyConstants.KnoraAdmin.KnownUser ++ groups
 
             result = calculatePermission(projectIri, groups)
 
@@ -353,10 +353,10 @@ class PermissionsResponderADM extends Responder {
                 case (permissionIri: IRI, propsMap: Map[String, String]) =>
 
                     /* parse permissions */
-                    val hasPermissions: Set[PermissionADM] = PermissionUtilADM.parsePermissionsWithType(propsMap.get(OntologyConstants.KnoraBase.HasPermissions), PermissionType.AP)
+                    val hasPermissions: Set[PermissionADM] = PermissionUtilADM.parsePermissionsWithType(propsMap.get(OntologyConstants.KnoraAdmin.HasPermissions), PermissionType.AP)
 
                     /* construct permission object */
-                    AdministrativePermissionADM(iri = permissionIri, forProject = propsMap.getOrElse(OntologyConstants.KnoraBase.ForProject, throw InconsistentTriplestoreDataException(s"Administrative Permission $permissionIri has no project attached.")), forGroup = propsMap.getOrElse(OntologyConstants.KnoraBase.ForGroup, throw InconsistentTriplestoreDataException(s"Administrative Permission $permissionIri has no group attached.")), hasPermissions = hasPermissions)
+                    AdministrativePermissionADM(iri = permissionIri, forProject = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ForProject, throw InconsistentTriplestoreDataException(s"Administrative Permission $permissionIri has no project attached.")), forGroup = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ForGroup, throw InconsistentTriplestoreDataException(s"Administrative Permission $permissionIri has no group attached.")), hasPermissions = hasPermissions)
             }.toSeq
 
             /* construct response object */
@@ -399,11 +399,11 @@ class PermissionsResponderADM extends Responder {
             _ = if (groupedPermissionsQueryResponse.isEmpty) throw NotFoundException(s"Administrative permission $administrativePermissionIri could not be found.")
 
             /* extract the permission */
-            hasPermissions = PermissionUtilADM.parsePermissionsWithType(groupedPermissionsQueryResponse.get(OntologyConstants.KnoraBase.HasPermissions).map(_.head), PermissionType.AP)
+            hasPermissions = PermissionUtilADM.parsePermissionsWithType(groupedPermissionsQueryResponse.get(OntologyConstants.KnoraAdmin.HasPermissions).map(_.head), PermissionType.AP)
             //_ = log.debug(s"administrativePermissionForIriGetRequestV1 - hasPermissions: ${MessageUtil.toSource(hasPermissions)}")
 
             /* construct the permission object */
-            permission = permissionsmessages.AdministrativePermissionADM(iri = administrativePermissionIri, forProject = groupedPermissionsQueryResponse.getOrElse(OntologyConstants.KnoraBase.ForProject, throw InconsistentTriplestoreDataException(s"Permission $administrativePermissionIri has no project attached")).head, forGroup = groupedPermissionsQueryResponse.getOrElse(OntologyConstants.KnoraBase.ForGroup, throw InconsistentTriplestoreDataException(s"Permission $administrativePermissionIri has no group attached")).head, hasPermissions = hasPermissions)
+            permission = permissionsmessages.AdministrativePermissionADM(iri = administrativePermissionIri, forProject = groupedPermissionsQueryResponse.getOrElse(OntologyConstants.KnoraAdmin.ForProject, throw InconsistentTriplestoreDataException(s"Permission $administrativePermissionIri has no project attached")).head, forGroup = groupedPermissionsQueryResponse.getOrElse(OntologyConstants.KnoraAdmin.ForGroup, throw InconsistentTriplestoreDataException(s"Permission $administrativePermissionIri has no group attached")).head, hasPermissions = hasPermissions)
 
             /* construct the response object */
             response = AdministrativePermissionForIriGetResponseADM(permission)
@@ -448,7 +448,7 @@ class PermissionsResponderADM extends Responder {
                 val groupedPermissionsQueryResponse: Map[String, Seq[String]] = permissionQueryResponseRows.groupBy(_.rowMap("p")).map {
                     case (predicate, rows) => predicate -> rows.map(_.rowMap("o"))
                 }
-                val hasPermissions = PermissionUtilADM.parsePermissionsWithType(groupedPermissionsQueryResponse.get(OntologyConstants.KnoraBase.HasPermissions).map(_.head), PermissionType.AP)
+                val hasPermissions = PermissionUtilADM.parsePermissionsWithType(groupedPermissionsQueryResponse.get(OntologyConstants.KnoraAdmin.HasPermissions).map(_.head), PermissionType.AP)
                 Some(
                     permissionsmessages.AdministrativePermissionADM(iri = returnedPermissionIri, forProject = projectIri, forGroup = groupIri, hasPermissions = hasPermissions)
                 )
@@ -547,7 +547,7 @@ class PermissionsResponderADM extends Responder {
                 val groupedPermissionsQueryResponse: Map[String, Seq[String]] = permissionQueryResponseRows.groupBy(_.rowMap("p")).map {
                     case (predicate, rows) => predicate -> rows.map(_.rowMap("o"))
                 }
-                val hasPermissions: Set[PermissionADM] = PermissionUtilADM.parsePermissionsWithType(groupedPermissionsQueryResponse.get(OntologyConstants.KnoraBase.HasPermissions).map(_.head), PermissionType.OAP)
+                val hasPermissions: Set[PermissionADM] = PermissionUtilADM.parsePermissionsWithType(groupedPermissionsQueryResponse.get(OntologyConstants.KnoraAdmin.HasPermissions).map(_.head), PermissionType.OAP)
                 Some(
                     ObjectAccessPermissionADM(forResource = Some(resourceIri), forValue = None, hasPermissions = hasPermissions)
                 )
@@ -584,7 +584,7 @@ class PermissionsResponderADM extends Responder {
                 val groupedPermissionsQueryResponse: Map[String, Seq[String]] = permissionQueryResponseRows.groupBy(_.rowMap("p")).map {
                     case (predicate, rows) => predicate -> rows.map(_.rowMap("o"))
                 }
-                val hasPermissions: Set[PermissionADM] = PermissionUtilADM.parsePermissionsWithType(groupedPermissionsQueryResponse.get(OntologyConstants.KnoraBase.HasPermissions).map(_.head), PermissionType.OAP)
+                val hasPermissions: Set[PermissionADM] = PermissionUtilADM.parsePermissionsWithType(groupedPermissionsQueryResponse.get(OntologyConstants.KnoraAdmin.HasPermissions).map(_.head), PermissionType.OAP)
                 Some(
                     ObjectAccessPermissionADM(forResource = None, forValue = Some(valueIri), hasPermissions = hasPermissions)
                 )
@@ -633,10 +633,10 @@ class PermissionsResponderADM extends Responder {
                 case (permissionIri: IRI, propsMap: Map[String, String]) =>
 
                     /* parse permissions */
-                    val hasPermissions: Set[PermissionADM] = PermissionUtilADM.parsePermissionsWithType(propsMap.get(OntologyConstants.KnoraBase.HasPermissions), PermissionType.OAP)
+                    val hasPermissions: Set[PermissionADM] = PermissionUtilADM.parsePermissionsWithType(propsMap.get(OntologyConstants.KnoraAdmin.HasPermissions), PermissionType.OAP)
 
                     /* construct permission object */
-                    DefaultObjectAccessPermissionADM(iri = permissionIri, forProject = propsMap.getOrElse(OntologyConstants.KnoraBase.ForProject, throw InconsistentTriplestoreDataException(s"Permission $permissionIri has no project.")), forGroup = propsMap.get(OntologyConstants.KnoraBase.ForGroup), forResourceClass = propsMap.get(OntologyConstants.KnoraBase.ForResourceClass), forProperty = propsMap.get(OntologyConstants.KnoraBase.ForProperty), hasPermissions = hasPermissions)
+                    DefaultObjectAccessPermissionADM(iri = permissionIri, forProject = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ForProject, throw InconsistentTriplestoreDataException(s"Permission $permissionIri has no project.")), forGroup = propsMap.get(OntologyConstants.KnoraAdmin.ForGroup), forResourceClass = propsMap.get(OntologyConstants.KnoraAdmin.ForResourceClass), forProperty = propsMap.get(OntologyConstants.KnoraAdmin.ForProperty), hasPermissions = hasPermissions)
             }.toSeq
 
             /* construct response object */
@@ -677,9 +677,9 @@ class PermissionsResponderADM extends Responder {
             }
             //_ = log.debug(s"defaultObjectAccessPermissionForIriGetRequestADM - groupedResult: ${MessageUtil.toSource(groupedPermissionsQueryResponse)}")
 
-            hasPermissions = PermissionUtilADM.parsePermissionsWithType(groupedPermissionsQueryResponse.get(OntologyConstants.KnoraBase.HasPermissions).map(_.head), PermissionType.OAP)
+            hasPermissions = PermissionUtilADM.parsePermissionsWithType(groupedPermissionsQueryResponse.get(OntologyConstants.KnoraAdmin.HasPermissions).map(_.head), PermissionType.OAP)
 
-            defaultObjectAccessPermission = permissionsmessages.DefaultObjectAccessPermissionADM(iri = permissionIri, forProject = groupedPermissionsQueryResponse.getOrElse(OntologyConstants.KnoraBase.ForProject, throw InconsistentTriplestoreDataException(s"Permission $permissionIri has no project.")).head, forGroup = groupedPermissionsQueryResponse.get(OntologyConstants.KnoraBase.ForGroup).map(_.head), forResourceClass = groupedPermissionsQueryResponse.get(OntologyConstants.KnoraBase.ForResourceClass).map(_.head), forProperty = groupedPermissionsQueryResponse.get(OntologyConstants.KnoraBase.ForProperty).map(_.head), hasPermissions = hasPermissions)
+            defaultObjectAccessPermission = permissionsmessages.DefaultObjectAccessPermissionADM(iri = permissionIri, forProject = groupedPermissionsQueryResponse.getOrElse(OntologyConstants.KnoraAdmin.ForProject, throw InconsistentTriplestoreDataException(s"Permission $permissionIri has no project.")).head, forGroup = groupedPermissionsQueryResponse.get(OntologyConstants.KnoraAdmin.ForGroup).map(_.head), forResourceClass = groupedPermissionsQueryResponse.get(OntologyConstants.KnoraAdmin.ForResourceClass).map(_.head), forProperty = groupedPermissionsQueryResponse.get(OntologyConstants.KnoraAdmin.ForProperty).map(_.head), hasPermissions = hasPermissions)
 
             result = DefaultObjectAccessPermissionForIriGetResponseADM(defaultObjectAccessPermission)
 
@@ -734,9 +734,9 @@ class PermissionsResponderADM extends Responder {
                 val groupedPermissionsQueryResponse: Map[String, Seq[String]] = permissionQueryResponseRows.groupBy(_.rowMap("p")).map {
                     case (predicate, rows) => predicate -> rows.map(_.rowMap("o"))
                 }
-                val hasPermissions: Set[PermissionADM] = PermissionUtilADM.parsePermissionsWithType(groupedPermissionsQueryResponse.get(OntologyConstants.KnoraBase.HasPermissions).map(_.head), PermissionType.OAP)
+                val hasPermissions: Set[PermissionADM] = PermissionUtilADM.parsePermissionsWithType(groupedPermissionsQueryResponse.get(OntologyConstants.KnoraAdmin.HasPermissions).map(_.head), PermissionType.OAP)
                 Some(
-                    DefaultObjectAccessPermissionADM(iri = permissionIri, forProject = groupedPermissionsQueryResponse.getOrElse(OntologyConstants.KnoraBase.ForProject, throw InconsistentTriplestoreDataException(s"Permission has no project.")).head, forGroup = groupedPermissionsQueryResponse.get(OntologyConstants.KnoraBase.ForGroup).map(_.head), forResourceClass = groupedPermissionsQueryResponse.get(OntologyConstants.KnoraBase.ForResourceClass).map(_.head), forProperty = groupedPermissionsQueryResponse.get(OntologyConstants.KnoraBase.ForProperty).map(_.head), hasPermissions = hasPermissions)
+                    DefaultObjectAccessPermissionADM(iri = permissionIri, forProject = groupedPermissionsQueryResponse.getOrElse(OntologyConstants.KnoraAdmin.ForProject, throw InconsistentTriplestoreDataException(s"Permission has no project.")).head, forGroup = groupedPermissionsQueryResponse.get(OntologyConstants.KnoraAdmin.ForGroup).map(_.head), forResourceClass = groupedPermissionsQueryResponse.get(OntologyConstants.KnoraAdmin.ForResourceClass).map(_.head), forProperty = groupedPermissionsQueryResponse.get(OntologyConstants.KnoraAdmin.ForProperty).map(_.head), hasPermissions = hasPermissions)
                 )
             } else {
                 None
@@ -769,7 +769,7 @@ class PermissionsResponderADM extends Responder {
                 case None => {
                     /* if the query was for a property, then we need to additionally check if it is a system property */
                     if (propertyIri.isDefined) {
-                        val systemProject = OntologyConstants.KnoraBase.SystemProject
+                        val systemProject = OntologyConstants.KnoraAdmin.SystemProject
                         val doapF = defaultObjectAccessPermissionGetADM(systemProject, groupIri, resourceClassIri, propertyIri)
                         doapF.mapTo[Option[DefaultObjectAccessPermissionADM]].map {
                             case Some(systemDoap) => DefaultObjectAccessPermissionGetResponseADM(systemDoap)
@@ -909,9 +909,9 @@ class PermissionsResponderADM extends Responder {
 
             /* Explicitly add 'SystemAdmin' and 'KnownUser' groups. */
             extendedUserGroups: List[IRI] = if (targetUser.permissionData.isSystemAdmin) {
-                OntologyConstants.KnoraBase.SystemAdmin :: OntologyConstants.KnoraBase.KnownUser :: userGroups.toList
+                OntologyConstants.KnoraAdmin.SystemAdmin :: OntologyConstants.KnoraAdmin.KnownUser :: userGroups.toList
             } else {
-                OntologyConstants.KnoraBase.KnownUser :: userGroups.toList
+                OntologyConstants.KnoraAdmin.KnownUser :: userGroups.toList
             }
 
             // _ = log.debug("defaultObjectAccessPermissionsStringForEntityGetV1 - extendedUserGroups: {}", extendedUserGroups)
@@ -924,9 +924,9 @@ class PermissionsResponderADM extends Responder {
 
 
             /* Get the default object access permissions for the knora-base:ProjectAdmin group */
-            defaultPermissionsOnProjectAdminGroup: Set[PermissionADM] <- defaultObjectAccessPermissionsForGroupsGetADM(projectIri, List(OntologyConstants.KnoraBase.ProjectAdmin))
+            defaultPermissionsOnProjectAdminGroup: Set[PermissionADM] <- defaultObjectAccessPermissionsForGroupsGetADM(projectIri, List(OntologyConstants.KnoraAdmin.ProjectAdmin))
             _ = if (defaultPermissionsOnProjectAdminGroup.nonEmpty) {
-                if (extendedUserGroups.contains(OntologyConstants.KnoraBase.ProjectAdmin) || extendedUserGroups.contains(OntologyConstants.KnoraBase.SystemAdmin)) {
+                if (extendedUserGroups.contains(OntologyConstants.KnoraAdmin.ProjectAdmin) || extendedUserGroups.contains(OntologyConstants.KnoraAdmin.SystemAdmin)) {
                     permissionsListBuffer += (("ProjectAdmin", defaultPermissionsOnProjectAdminGroup))
                     // log.debug(s"defaultObjectAccessPermissionsStringForEntityGetV1 - defaultPermissionsOnProjectAdminGroup: $defaultPermissionsOnProjectAdminGroup")
                 }
@@ -951,7 +951,7 @@ class PermissionsResponderADM extends Responder {
             /* system resource class / property combination */
             defaultPermissionsOnSystemResourceClassProperty: Set[PermissionADM] <- {
                 if (entityType == PROPERTY_ENTITY_TYPE && permissionsListBuffer.isEmpty) {
-                    val systemProject = OntologyConstants.KnoraBase.SystemProject
+                    val systemProject = OntologyConstants.KnoraAdmin.SystemProject
                     defaultObjectAccessPermissionsForResourceClassPropertyGetADM(projectIri = systemProject, resourceClassIri = resourceClassIri, propertyIri = propertyIri.getOrElse(throw BadRequestException("PropertyIri needs to be supplied.")))
                 } else {
                     Future(Set.empty[PermissionADM])
@@ -981,7 +981,7 @@ class PermissionsResponderADM extends Responder {
             /* Get the default object access permissions defined on the resource class inside the SystemProject */
             defaultPermissionsOnSystemResourceClass: Set[PermissionADM] <- {
                 if (entityType == RESOURCE_ENTITY_TYPE && permissionsListBuffer.isEmpty) {
-                    val systemProject = OntologyConstants.KnoraBase.SystemProject
+                    val systemProject = OntologyConstants.KnoraAdmin.SystemProject
                     defaultObjectAccessPermissionsForResourceClassGetADM(projectIri = systemProject, resourceClassIri = resourceClassIri)
                 } else {
                     Future(Set.empty[PermissionADM])
@@ -1011,7 +1011,7 @@ class PermissionsResponderADM extends Responder {
             /* system property */
             defaultPermissionsOnSystemProperty: Set[PermissionADM] <- {
                 if (entityType == PROPERTY_ENTITY_TYPE && permissionsListBuffer.isEmpty) {
-                    val systemProject = OntologyConstants.KnoraBase.SystemProject
+                    val systemProject = OntologyConstants.KnoraAdmin.SystemProject
                     defaultObjectAccessPermissionsForPropertyGetADM(projectIri = systemProject, propertyIri = propertyIri.getOrElse(throw BadRequestException("PropertyIri needs to be supplied.")))
                 } else {
                     Future(Set.empty[PermissionADM])
@@ -1028,7 +1028,7 @@ class PermissionsResponderADM extends Responder {
             /* Get the default object access permissions for custom groups (all groups other than the built-in groups) */
             defaultPermissionsOnCustomGroups: Set[PermissionADM] <- {
                 if (extendedUserGroups.nonEmpty && permissionsListBuffer.isEmpty) {
-                    val customGroups: List[IRI] = extendedUserGroups.toList diff List(OntologyConstants.KnoraBase.KnownUser, OntologyConstants.KnoraBase.ProjectMember, OntologyConstants.KnoraBase.ProjectAdmin, OntologyConstants.KnoraBase.SystemAdmin)
+                    val customGroups: List[IRI] = extendedUserGroups.toList diff List(OntologyConstants.KnoraAdmin.KnownUser, OntologyConstants.KnoraAdmin.ProjectMember, OntologyConstants.KnoraAdmin.ProjectAdmin, OntologyConstants.KnoraAdmin.SystemAdmin)
                     if (customGroups.nonEmpty) {
                         defaultObjectAccessPermissionsForGroupsGetADM(projectIri, customGroups)
                     } else {
@@ -1050,13 +1050,13 @@ class PermissionsResponderADM extends Responder {
             /* Get the default object access permissions for the knora-base:ProjectMember group */
             defaultPermissionsOnProjectMemberGroup: Set[PermissionADM] <- {
                 if (permissionsListBuffer.isEmpty) {
-                    defaultObjectAccessPermissionsForGroupsGetADM(projectIri, List(OntologyConstants.KnoraBase.ProjectMember))
+                    defaultObjectAccessPermissionsForGroupsGetADM(projectIri, List(OntologyConstants.KnoraAdmin.ProjectMember))
                 } else {
                     Future(Set.empty[PermissionADM])
                 }
             }
             _ = if (defaultPermissionsOnProjectMemberGroup.nonEmpty) {
-                if (extendedUserGroups.contains(OntologyConstants.KnoraBase.ProjectMember) || extendedUserGroups.contains(OntologyConstants.KnoraBase.SystemAdmin)) {
+                if (extendedUserGroups.contains(OntologyConstants.KnoraAdmin.ProjectMember) || extendedUserGroups.contains(OntologyConstants.KnoraAdmin.SystemAdmin)) {
                     permissionsListBuffer += (("ProjectMember", defaultPermissionsOnProjectMemberGroup))
                 }
                 // log.debug(s"defaultObjectAccessPermissionsStringForEntityGetV1 - defaultPermissionsOnProjectMemberGroup: $defaultPermissionsOnProjectMemberGroup")
@@ -1068,13 +1068,13 @@ class PermissionsResponderADM extends Responder {
             /* Get the default object access permissions for the knora-base:KnownUser group */
             defaultPermissionsOnKnownUserGroup: Set[PermissionADM] <- {
                 if (permissionsListBuffer.isEmpty) {
-                    defaultObjectAccessPermissionsForGroupsGetADM(projectIri, List(OntologyConstants.KnoraBase.KnownUser))
+                    defaultObjectAccessPermissionsForGroupsGetADM(projectIri, List(OntologyConstants.KnoraAdmin.KnownUser))
                 } else {
                     Future(Set.empty[PermissionADM])
                 }
             }
             _ = if (defaultPermissionsOnKnownUserGroup.nonEmpty) {
-                if (extendedUserGroups.contains(OntologyConstants.KnoraBase.KnownUser)) {
+                if (extendedUserGroups.contains(OntologyConstants.KnoraAdmin.KnownUser)) {
                     permissionsListBuffer += (("KnownUser", defaultPermissionsOnKnownUserGroup))
                     // log.debug(s"defaultObjectAccessPermissionsStringForEntityGetV1 - defaultPermissionsOnKnownUserGroup: $defaultPermissionsOnKnownUserGroup")
                 }
@@ -1085,7 +1085,7 @@ class PermissionsResponderADM extends Responder {
             ///////////////////////
             /* Set 'CR knora-base:Creator' as the fallback permission */
             _ = if (permissionsListBuffer.isEmpty) {
-                    val defaultFallbackPermission = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraBase.Creator))
+                    val defaultFallbackPermission = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator))
                     permissionsListBuffer += (("Fallback", defaultFallbackPermission))
                     // log.debug(s"defaultObjectAccessPermissionsStringForEntityGetV1 - defaultFallbackPermission: $defaultFallbackPermission")
                 } else {

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
@@ -94,7 +94,7 @@ class ProjectsResponderADM extends Responder {
             projects: Seq[ProjectADM] = statements.map {
                 case (projectIri: SubjectV2, propsMap: Map[IRI, Seq[LiteralV2]]) =>
 
-                    val ontologyIris = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectOntology, Seq.empty[IRI]).map(_.asInstanceOf[IriLiteralV2].value)
+                    val ontologyIris = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectOntology, Seq.empty[IRI]).map(_.asInstanceOf[IriLiteralV2].value)
 
                     val ontologyInfos: Seq[OntologyInfoShortADM] = ontologyIris.map { ontologyIri =>
                         OntologyInfoShortADM(
@@ -105,15 +105,15 @@ class ProjectsResponderADM extends Responder {
 
                     ProjectADM(
                         id = projectIri.toString,
-                        shortname = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectShortname, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no shortname defined.")).head.asInstanceOf[StringLiteralV2].value,
-                        shortcode = propsMap.get(OntologyConstants.KnoraBase.ProjectShortcode).map(_.head.asInstanceOf[StringLiteralV2].value),
-                        longname = propsMap.get(OntologyConstants.KnoraBase.ProjectLongname).map(_.head.asInstanceOf[StringLiteralV2].value),
-                        description = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectDescription, Seq.empty[StringLiteralV2]).map(_.asInstanceOf[StringLiteralV2]),
-                        keywords = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectKeyword, Seq.empty[String]).map(_.asInstanceOf[StringLiteralV2].value).sorted,
-                        logo = propsMap.get(OntologyConstants.KnoraBase.ProjectLogo).map(_.head.asInstanceOf[StringLiteralV2].value),
+                        shortname = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectShortname, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no shortname defined.")).head.asInstanceOf[StringLiteralV2].value,
+                        shortcode = propsMap.get(OntologyConstants.KnoraAdmin.ProjectShortcode).map(_.head.asInstanceOf[StringLiteralV2].value),
+                        longname = propsMap.get(OntologyConstants.KnoraAdmin.ProjectLongname).map(_.head.asInstanceOf[StringLiteralV2].value),
+                        description = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectDescription, Seq.empty[StringLiteralV2]).map(_.asInstanceOf[StringLiteralV2]),
+                        keywords = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectKeyword, Seq.empty[String]).map(_.asInstanceOf[StringLiteralV2].value).sorted,
+                        logo = propsMap.get(OntologyConstants.KnoraAdmin.ProjectLogo).map(_.head.asInstanceOf[StringLiteralV2].value),
                         ontologies = ontologyInfos,
-                        status = propsMap.getOrElse(OntologyConstants.KnoraBase.Status, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no status defined.")).head.asInstanceOf[BooleanLiteralV2].value,
-                        selfjoin = propsMap.getOrElse(OntologyConstants.KnoraBase.HasSelfJoinEnabled, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no hasSelfJoinEnabled defined.")).head.asInstanceOf[BooleanLiteralV2].value
+                        status = propsMap.getOrElse(OntologyConstants.KnoraAdmin.Status, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no status defined.")).head.asInstanceOf[BooleanLiteralV2].value,
+                        selfjoin = propsMap.getOrElse(OntologyConstants.KnoraAdmin.HasSelfJoinEnabled, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no hasSelfJoinEnabled defined.")).head.asInstanceOf[BooleanLiteralV2].value
                     )
             }
 
@@ -401,7 +401,7 @@ class ProjectsResponderADM extends Responder {
                 adminNamedGraphIri = OntologyConstants.NamedGraphs.AdminNamedGraph,
                 triplestore = settings.triplestoreType,
                 projectIri = newProjectIRI,
-                projectClassIri = OntologyConstants.KnoraBase.KnoraProject,
+                projectClassIri = OntologyConstants.KnoraAdmin.KnoraProject,
                 shortname = createRequest.shortname,
                 shortcode = createRequest.shortcode,
                 maybeLongname = createRequest.longname,
@@ -708,7 +708,7 @@ class ProjectsResponderADM extends Responder {
         val projectIri: IRI = statements._1.toString
         val propsMap: Map[IRI, Seq[LiteralV2]] = statements._2
 
-        val ontologyIris = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectOntology, Seq.empty[IRI]).map(_.asInstanceOf[IriLiteralV2].value)
+        val ontologyIris = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectOntology, Seq.empty[IRI]).map(_.asInstanceOf[IriLiteralV2].value)
 
         val ontologyInfos: Seq[OntologyInfoShortADM] = ontologyIris.map { ontologyIri =>
             OntologyInfoShortADM(
@@ -719,15 +719,15 @@ class ProjectsResponderADM extends Responder {
 
         ProjectADM(
             id = projectIri,
-            shortname = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectShortname, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no shortname defined.")).head.asInstanceOf[StringLiteralV2].value,
-            shortcode = propsMap.get(OntologyConstants.KnoraBase.ProjectShortcode).map(_.head.asInstanceOf[StringLiteralV2].value),
-            longname = propsMap.get(OntologyConstants.KnoraBase.ProjectLongname).map(_.head.asInstanceOf[StringLiteralV2].value),
-            description = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectDescription, Seq.empty[StringLiteralV2]).map(_.asInstanceOf[StringLiteralV2]),
-            keywords = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectKeyword, Seq.empty[String]).map(_.asInstanceOf[StringLiteralV2].value).sorted,
-            logo = propsMap.get(OntologyConstants.KnoraBase.ProjectLogo).map(_.head.asInstanceOf[StringLiteralV2].value),
+            shortname = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectShortname, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no shortname defined.")).head.asInstanceOf[StringLiteralV2].value,
+            shortcode = propsMap.get(OntologyConstants.KnoraAdmin.ProjectShortcode).map(_.head.asInstanceOf[StringLiteralV2].value),
+            longname = propsMap.get(OntologyConstants.KnoraAdmin.ProjectLongname).map(_.head.asInstanceOf[StringLiteralV2].value),
+            description = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectDescription, Seq.empty[StringLiteralV2]).map(_.asInstanceOf[StringLiteralV2]),
+            keywords = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectKeyword, Seq.empty[String]).map(_.asInstanceOf[StringLiteralV2].value).sorted,
+            logo = propsMap.get(OntologyConstants.KnoraAdmin.ProjectLogo).map(_.head.asInstanceOf[StringLiteralV2].value),
             ontologies = ontologyInfos,
-            status = propsMap.getOrElse(OntologyConstants.KnoraBase.Status, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no status defined.")).head.asInstanceOf[BooleanLiteralV2].value,
-            selfjoin = propsMap.getOrElse(OntologyConstants.KnoraBase.HasSelfJoinEnabled, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no hasSelfJoinEnabled defined.")).head.asInstanceOf[BooleanLiteralV2].value
+            status = propsMap.getOrElse(OntologyConstants.KnoraAdmin.Status, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no status defined.")).head.asInstanceOf[BooleanLiteralV2].value,
+            selfjoin = propsMap.getOrElse(OntologyConstants.KnoraAdmin.HasSelfJoinEnabled, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no hasSelfJoinEnabled defined.")).head.asInstanceOf[BooleanLiteralV2].value
         )
     }
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
@@ -110,11 +110,11 @@ class UsersResponderADM extends Responder {
 
                     UserADM(
                         id = userIri.toString,
-                        email = propsMap.getOrElse(OntologyConstants.KnoraBase.Email, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'email' defined.")).head.asInstanceOf[StringLiteralV2].value,
-                        givenName = propsMap.getOrElse(OntologyConstants.KnoraBase.GivenName, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'givenName' defined.")).head.asInstanceOf[StringLiteralV2].value,
-                        familyName = propsMap.getOrElse(OntologyConstants.KnoraBase.FamilyName, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'familyName' defined.")).head.asInstanceOf[StringLiteralV2].value,
-                        status = propsMap.getOrElse(OntologyConstants.KnoraBase.Status, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'status' defined.")).head.asInstanceOf[BooleanLiteralV2].value,
-                        lang = propsMap.getOrElse(OntologyConstants.KnoraBase.PreferredLanguage, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'preferedLanguage' defined.")).head.asInstanceOf[StringLiteralV2].value
+                        email = propsMap.getOrElse(OntologyConstants.KnoraAdmin.Email, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'email' defined.")).head.asInstanceOf[StringLiteralV2].value,
+                        givenName = propsMap.getOrElse(OntologyConstants.KnoraAdmin.GivenName, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'givenName' defined.")).head.asInstanceOf[StringLiteralV2].value,
+                        familyName = propsMap.getOrElse(OntologyConstants.KnoraAdmin.FamilyName, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'familyName' defined.")).head.asInstanceOf[StringLiteralV2].value,
+                        status = propsMap.getOrElse(OntologyConstants.KnoraAdmin.Status, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'status' defined.")).head.asInstanceOf[BooleanLiteralV2].value,
+                        lang = propsMap.getOrElse(OntologyConstants.KnoraAdmin.PreferredLanguage, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'preferedLanguage' defined.")).head.asInstanceOf[StringLiteralV2].value
                     )
             }
 
@@ -265,7 +265,7 @@ class UsersResponderADM extends Responder {
                 adminNamedGraphIri = OntologyConstants.NamedGraphs.AdminNamedGraph,
                 triplestore = settings.triplestoreType,
                 userIri = userIri,
-                userClassIri = OntologyConstants.KnoraBase.User,
+                userClassIri = OntologyConstants.KnoraAdmin.User,
                 email = createRequest.email,
                 password = hashedPassword,
                 givenName = createRequest.givenName,
@@ -739,7 +739,7 @@ class UsersResponderADM extends Responder {
             }
 
             /* the projects the user is member of */
-            projectIris: Seq[IRI] = groupedUserData.get(OntologyConstants.KnoraBase.IsInProjectAdminGroup) match {
+            projectIris: Seq[IRI] = groupedUserData.get(OntologyConstants.KnoraAdmin.IsInProjectAdminGroup) match {
                 case Some(projects) => projects
                 case None => Seq.empty[IRI]
             }
@@ -1219,18 +1219,18 @@ class UsersResponderADM extends Responder {
             // _ = log.debug(s"userDataQueryResponse2UserProfile - groupedUserData: ${MessageUtil.toSource(groupedUserData)}")
 
             val userDataV1 = UserDataV1(
-                lang = groupedUserData.get(OntologyConstants.KnoraBase.PreferredLanguage) match {
+                lang = groupedUserData.get(OntologyConstants.KnoraAdmin.PreferredLanguage) match {
                     case Some(langList) => langList.head
                     case None => settings.fallbackLanguage
                 },
                 user_id = Some(returnedUserIri),
-                email = groupedUserData.get(OntologyConstants.KnoraBase.Email).map(_.head),
-                firstname = groupedUserData.get(OntologyConstants.KnoraBase.GivenName).map(_.head),
-                lastname = groupedUserData.get(OntologyConstants.KnoraBase.FamilyName).map(_.head),
+                email = groupedUserData.get(OntologyConstants.KnoraAdmin.Email).map(_.head),
+                firstname = groupedUserData.get(OntologyConstants.KnoraAdmin.GivenName).map(_.head),
+                lastname = groupedUserData.get(OntologyConstants.KnoraAdmin.FamilyName).map(_.head),
                 password = if (!short) {
-                    groupedUserData.get(OntologyConstants.KnoraBase.Password).map(_.head)
+                    groupedUserData.get(OntologyConstants.KnoraAdmin.Password).map(_.head)
                 } else None,
-                status = groupedUserData.get(OntologyConstants.KnoraBase.Status).map(_.head.toBoolean)
+                status = groupedUserData.get(OntologyConstants.KnoraAdmin.Status).map(_.head.toBoolean)
             )
             // _ = log.debug(s"userDataQueryResponse - userDataV1: {}", MessageUtil.toSource(userDataV1)")
             FastFuture.successful(Some(userDataV1))
@@ -1257,7 +1257,7 @@ class UsersResponderADM extends Responder {
         if (propsMap.nonEmpty) {
 
             /* the groups the user is member of (only explicit groups) */
-            val groupIris: Seq[IRI] = propsMap.get(OntologyConstants.KnoraBase.IsInGroup) match {
+            val groupIris: Seq[IRI] = propsMap.get(OntologyConstants.KnoraAdmin.IsInGroup) match {
                 case Some(groups) => groups.map(_.asInstanceOf[IriLiteralV2].value)
                 case None => Seq.empty[IRI]
             }
@@ -1265,7 +1265,7 @@ class UsersResponderADM extends Responder {
             // log.debug(s"statements2UserADM - groupIris: {}", MessageUtil.toSource(groupIris))
 
             /* the projects the user is member of (only explicit projects) */
-            val projectIris: Seq[IRI] = propsMap.get(OntologyConstants.KnoraBase.IsInProject) match {
+            val projectIris: Seq[IRI] = propsMap.get(OntologyConstants.KnoraAdmin.IsInProject) match {
                 case Some(projects) => projects.map(_.asInstanceOf[IriLiteralV2].value)
                 case None => Seq.empty[IRI]
             }
@@ -1273,10 +1273,10 @@ class UsersResponderADM extends Responder {
             // log.debug(s"statements2UserADM - projectIris: {}", MessageUtil.toSource(projectIris))
 
             /* the projects for which the user is implicitly considered a member of the 'http://www.knora.org/ontology/knora-base#ProjectAdmin' group */
-            val isInProjectAdminGroups: Seq[IRI] = propsMap.getOrElse(OntologyConstants.KnoraBase.IsInProjectAdminGroup, Vector.empty[IRI]).map(_.asInstanceOf[IriLiteralV2].value)
+            val isInProjectAdminGroups: Seq[IRI] = propsMap.getOrElse(OntologyConstants.KnoraAdmin.IsInProjectAdminGroup, Vector.empty[IRI]).map(_.asInstanceOf[IriLiteralV2].value)
 
             /* is the user implicitly considered a member of the 'http://www.knora.org/ontology/knora-base#SystemAdmin' group */
-            val isInSystemAdminGroup = propsMap.get(OntologyConstants.KnoraBase.IsInSystemAdminGroup).exists(p => p.head.asInstanceOf[BooleanLiteralV2].value)
+            val isInSystemAdminGroup = propsMap.get(OntologyConstants.KnoraAdmin.IsInSystemAdminGroup).exists(p => p.head.asInstanceOf[BooleanLiteralV2].value)
 
             for {
                 /* get the user's permission profile from the permissions responder */
@@ -1306,13 +1306,13 @@ class UsersResponderADM extends Responder {
                 /* construct the user profile from the different parts */
                 user = UserADM(
                     id = userIri,
-                    email = propsMap.getOrElse(OntologyConstants.KnoraBase.Email, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'email' defined.")).head.asInstanceOf[StringLiteralV2].value,
-                    password = propsMap.get(OntologyConstants.KnoraBase.Password).map(_.head.asInstanceOf[StringLiteralV2].value),
+                    email = propsMap.getOrElse(OntologyConstants.KnoraAdmin.Email, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'email' defined.")).head.asInstanceOf[StringLiteralV2].value,
+                    password = propsMap.get(OntologyConstants.KnoraAdmin.Password).map(_.head.asInstanceOf[StringLiteralV2].value),
                     token = None,
-                    givenName = propsMap.getOrElse(OntologyConstants.KnoraBase.GivenName, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'givenName' defined.")).head.asInstanceOf[StringLiteralV2].value,
-                    familyName = propsMap.getOrElse(OntologyConstants.KnoraBase.FamilyName, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'familyName' defined.")).head.asInstanceOf[StringLiteralV2].value,
-                    status = propsMap.getOrElse(OntologyConstants.KnoraBase.Status, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'status' defined.")).head.asInstanceOf[BooleanLiteralV2].value,
-                    lang = propsMap.getOrElse(OntologyConstants.KnoraBase.PreferredLanguage, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'preferredLanguage' defined.")).head.asInstanceOf[StringLiteralV2].value,
+                    givenName = propsMap.getOrElse(OntologyConstants.KnoraAdmin.GivenName, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'givenName' defined.")).head.asInstanceOf[StringLiteralV2].value,
+                    familyName = propsMap.getOrElse(OntologyConstants.KnoraAdmin.FamilyName, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'familyName' defined.")).head.asInstanceOf[StringLiteralV2].value,
+                    status = propsMap.getOrElse(OntologyConstants.KnoraAdmin.Status, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'status' defined.")).head.asInstanceOf[BooleanLiteralV2].value,
+                    lang = propsMap.getOrElse(OntologyConstants.KnoraAdmin.PreferredLanguage, throw InconsistentTriplestoreDataException(s"User: $userIri has no 'preferredLanguage' defined.")).head.asInstanceOf[StringLiteralV2].value,
                     groups = groups,
                     projects = projects,
                     sessionId = None,

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ProjectsResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ProjectsResponderV1.scala
@@ -117,7 +117,7 @@ class ProjectsResponderV1 extends Responder {
             projects = projectsWithProperties.map {
                 case (projectIri: String, propsMap: Map[String, Seq[String]]) =>
 
-                    val keywordsSeq: Seq[String] = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectKeyword, Seq.empty[String]).sorted
+                    val keywordsSeq: Seq[String] = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectKeyword, Seq.empty[String]).sorted
 
                     val maybeKeywords: Option[String] = if (keywordsSeq.nonEmpty) {
                         Some(keywordsSeq.mkString(", "))
@@ -127,16 +127,16 @@ class ProjectsResponderV1 extends Responder {
 
                     ProjectInfoV1(
                         id = projectIri,
-                        shortname = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectShortname, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no shortname defined.")).head,
-                        shortcode = propsMap.get(OntologyConstants.KnoraBase.ProjectShortcode).map(_.head),
-                        longname = propsMap.get(OntologyConstants.KnoraBase.ProjectLongname).map(_.head),
-                        description = propsMap.get(OntologyConstants.KnoraBase.ProjectDescription).map(_.head),
+                        shortname = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectShortname, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no shortname defined.")).head,
+                        shortcode = propsMap.get(OntologyConstants.KnoraAdmin.ProjectShortcode).map(_.head),
+                        longname = propsMap.get(OntologyConstants.KnoraAdmin.ProjectLongname).map(_.head),
+                        description = propsMap.get(OntologyConstants.KnoraAdmin.ProjectDescription).map(_.head),
                         keywords = maybeKeywords,
-                        logo = propsMap.get(OntologyConstants.KnoraBase.ProjectLogo).map(_.head),
-                        institution = propsMap.get(OntologyConstants.KnoraBase.BelongsToInstitution).map(_.head),
-                        ontologies = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectOntology, Seq.empty[IRI]),
-                        status = propsMap.getOrElse(OntologyConstants.KnoraBase.Status, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no status defined.")).head.toBoolean,
-                        selfjoin = propsMap.getOrElse(OntologyConstants.KnoraBase.HasSelfJoinEnabled, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no hasSelfJoinEnabled defined.")).head.toBoolean
+                        logo = propsMap.get(OntologyConstants.KnoraAdmin.ProjectLogo).map(_.head),
+                        institution = propsMap.get(OntologyConstants.KnoraAdmin.BelongsToInstitution).map(_.head),
+                        ontologies = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectOntology, Seq.empty[IRI]),
+                        status = propsMap.getOrElse(OntologyConstants.KnoraAdmin.Status, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no status defined.")).head.toBoolean,
+                        selfjoin = propsMap.getOrElse(OntologyConstants.KnoraAdmin.HasSelfJoinEnabled, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no hasSelfJoinEnabled defined.")).head.toBoolean
                     )
             }.toSeq
 
@@ -173,17 +173,17 @@ class ProjectsResponderV1 extends Responder {
             namedGraphs: Seq[NamedGraphV1] = projectsWithProperties.flatMap {
                 case (projectIri: String, propsMap: Map[String, Seq[String]]) =>
 
-                    val maybeOntologies = propsMap.get(OntologyConstants.KnoraBase.ProjectOntology)
+                    val maybeOntologies = propsMap.get(OntologyConstants.KnoraAdmin.ProjectOntology)
                     maybeOntologies match {
                         case Some(ontologies) => ontologies.map(ontologyIri =>
                             NamedGraphV1(
                                 id = ontologyIri,
-                                shortname = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectShortname, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no basepath defined.")).head,
-                                longname = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectLongname, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no longname defined.")).head,
-                                description = propsMap.getOrElse(OntologyConstants.KnoraBase.ProjectDescription, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no description defined.")).head,
+                                shortname = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectShortname, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no basepath defined.")).head,
+                                longname = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectLongname, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no longname defined.")).head,
+                                description = propsMap.getOrElse(OntologyConstants.KnoraAdmin.ProjectDescription, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no description defined.")).head,
                                 project_id = projectIri,
                                 uri = ontologyIri,
-                                active = propsMap.getOrElse(OntologyConstants.KnoraBase.Status, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no status defined.")).head.toBoolean
+                                active = propsMap.getOrElse(OntologyConstants.KnoraAdmin.Status, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no status defined.")).head.toBoolean
                             )
                         )
                         case None => Seq.empty[NamedGraphV1]
@@ -504,7 +504,7 @@ class ProjectsResponderV1 extends Responder {
                 case (predicate, rows) => predicate -> rows.map(_.rowMap("o"))
             }
 
-            val keywordsSeq: Seq[String] = projectProperties.getOrElse(OntologyConstants.KnoraBase.ProjectKeyword, Seq.empty[String]).sorted
+            val keywordsSeq: Seq[String] = projectProperties.getOrElse(OntologyConstants.KnoraAdmin.ProjectKeyword, Seq.empty[String]).sorted
 
             val maybeKeywords: Option[String] = if (keywordsSeq.nonEmpty) {
                 Some(keywordsSeq.mkString(", "))
@@ -517,16 +517,16 @@ class ProjectsResponderV1 extends Responder {
             /* create and return the project info */
             ProjectInfoV1(
                 id = projectIri,
-                shortname = projectProperties.getOrElse(OntologyConstants.KnoraBase.ProjectShortname, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no shortname defined.")).head,
-                shortcode = projectProperties.get(OntologyConstants.KnoraBase.ProjectShortcode).map(_.head),
-                longname = projectProperties.get(OntologyConstants.KnoraBase.ProjectLongname).map(_.head),
-                description = projectProperties.get(OntologyConstants.KnoraBase.ProjectDescription).map(_.head),
+                shortname = projectProperties.getOrElse(OntologyConstants.KnoraAdmin.ProjectShortname, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no shortname defined.")).head,
+                shortcode = projectProperties.get(OntologyConstants.KnoraAdmin.ProjectShortcode).map(_.head),
+                longname = projectProperties.get(OntologyConstants.KnoraAdmin.ProjectLongname).map(_.head),
+                description = projectProperties.get(OntologyConstants.KnoraAdmin.ProjectDescription).map(_.head),
                 keywords = maybeKeywords,
-                logo = projectProperties.get(OntologyConstants.KnoraBase.ProjectLogo).map(_.head),
-                institution = projectProperties.get(OntologyConstants.KnoraBase.BelongsToInstitution).map(_.head),
-                ontologies = projectProperties.getOrElse(OntologyConstants.KnoraBase.ProjectOntology, Seq.empty[IRI]),
-                status = projectProperties.getOrElse(OntologyConstants.KnoraBase.Status, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no status defined.")).head.toBoolean,
-                selfjoin = projectProperties.getOrElse(OntologyConstants.KnoraBase.HasSelfJoinEnabled, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no hasSelfJoinEnabled defined.")).head.toBoolean
+                logo = projectProperties.get(OntologyConstants.KnoraAdmin.ProjectLogo).map(_.head),
+                institution = projectProperties.get(OntologyConstants.KnoraAdmin.BelongsToInstitution).map(_.head),
+                ontologies = projectProperties.getOrElse(OntologyConstants.KnoraAdmin.ProjectOntology, Seq.empty[IRI]),
+                status = projectProperties.getOrElse(OntologyConstants.KnoraAdmin.Status, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no status defined.")).head.toBoolean,
+                selfjoin = projectProperties.getOrElse(OntologyConstants.KnoraAdmin.HasSelfJoinEnabled, throw InconsistentTriplestoreDataException(s"Project: $projectIri has no hasSelfJoinEnabled defined.")).head.toBoolean
             )
 
         } else {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
@@ -328,7 +328,7 @@ class ResourcesResponderV1 extends Responder {
                 subjectPermissionLiteral = startNode.nodePermissions,
                 userProfile = graphDataGetRequest.userProfile
             ).isEmpty) {
-                val userID = graphDataGetRequest.userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraBase.UnknownUser)
+                val userID = graphDataGetRequest.userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraAdmin.UnknownUser)
                 throw ForbiddenException(s"User $userID does not have permission to view resource ${graphDataGetRequest.resourceIri}")
             }
 
@@ -417,7 +417,7 @@ class ResourcesResponderV1 extends Responder {
                     rights = userPermissions
                 )
             case None =>
-                val userID = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraBase.UnknownUser)
+                val userID = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraAdmin.UnknownUser)
                 throw ForbiddenException(s"User $userID does not have permission to view resource $resourceIri")
         }
     }
@@ -721,7 +721,7 @@ class ResourcesResponderV1 extends Responder {
                     access = "OK"
                 )
             } else {
-                val userID = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraBase.UnknownUser)
+                val userID = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraAdmin.UnknownUser)
                 throw ForbiddenException(s"User $userID does not have permission to query resource $resourceIri")
             }
         } yield resFullResponse
@@ -828,7 +828,7 @@ class ResourcesResponderV1 extends Responder {
             )
         }
 
-        val userIri = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraBase.UnknownUser)
+        val userIri = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraAdmin.UnknownUser)
 
         for {
             // Get the resource info even if the user didn't ask for it, so we can check its permissions.
@@ -1895,7 +1895,7 @@ class ResourcesResponderV1 extends Responder {
                 // Check that the user has permission to delete the resource.
                 (permissionCode, resourceInfo) <- getResourceInfoV1(resourceIri = resourceDeleteRequest.resourceIri, userProfile = resourceDeleteRequest.userProfile, queryOntology = false)
 
-                _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = permissionCode, userNeedsPermission = OntologyConstants.KnoraBase.DeletePermission)) {
+                _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = permissionCode, userNeedsPermission = OntologyConstants.KnoraAdmin.DeletePermission)) {
                     throw ForbiddenException(s"User $userIri does not have permission to mark resource ${resourceDeleteRequest.resourceIri} as deleted")
                 }
 
@@ -1970,8 +1970,8 @@ class ResourcesResponderV1 extends Responder {
             // Check that the user has permission to view the resource.
             (permissionCode, resourceInfo) <- getResourceInfoV1(resourceIri = resourceIri, userProfile = userProfile, queryOntology = false)
 
-            _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = permissionCode, userNeedsPermission = OntologyConstants.KnoraBase.RestrictedViewPermission)) {
-                val userIri = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraBase.UnknownUser)
+            _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = permissionCode, userNeedsPermission = OntologyConstants.KnoraAdmin.RestrictedViewPermission)) {
+                val userIri = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraAdmin.UnknownUser)
                 throw ForbiddenException(s"User $userIri does not have permission to view resource $resourceIri")
             }
 
@@ -2004,7 +2004,7 @@ class ResourcesResponderV1 extends Responder {
                 (permissionCode, resourceInfo) <- getResourceInfoV1(resourceIri = resourceIri, userProfile = userProfile, queryOntology = false)
 
                 // check if the given user may change its label
-                _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = permissionCode, userNeedsPermission = OntologyConstants.KnoraBase.ModifyPermission)) {
+                _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = permissionCode, userNeedsPermission = OntologyConstants.KnoraAdmin.ModifyPermission)) {
                     throw ForbiddenException(s"User $userIri does not have permission to change the label of resource $resourceIri")
                 }
 
@@ -2225,7 +2225,7 @@ class ResourcesResponderV1 extends Responder {
                             subjectProject = Some(resourceProject),
                             userProfile = userProfile
                         )
-                        PermissionUtilADM.impliesV1(userHasPermissionCode = permissionCode, userNeedsPermission = OntologyConstants.KnoraBase.RestrictedViewPermission)
+                        PermissionUtilADM.impliesV1(userHasPermissionCode = permissionCode, userNeedsPermission = OntologyConstants.KnoraAdmin.RestrictedViewPermission)
                 }
 
                 // Convert the ValueProps objects into FileValueV1 objects

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/UsersResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/UsersResponderV1.scala
@@ -95,15 +95,15 @@ class UsersResponderV1 extends Responder {
                 case (userIri: IRI, propsMap: Map[String, String]) =>
 
                     UserDataV1(
-                        lang = propsMap.get(OntologyConstants.KnoraBase.PreferredLanguage) match {
+                        lang = propsMap.get(OntologyConstants.KnoraAdmin.PreferredLanguage) match {
                             case Some(langList) => langList
                             case None => settings.fallbackLanguage
                         },
                         user_id = Some(userIri),
-                        email = propsMap.get(OntologyConstants.KnoraBase.Email),
-                        firstname = propsMap.get(OntologyConstants.KnoraBase.GivenName),
-                        lastname = propsMap.get(OntologyConstants.KnoraBase.FamilyName),
-                        status = propsMap.get(OntologyConstants.KnoraBase.Status).map(_.toBoolean)
+                        email = propsMap.get(OntologyConstants.KnoraAdmin.Email),
+                        firstname = propsMap.get(OntologyConstants.KnoraAdmin.GivenName),
+                        lastname = propsMap.get(OntologyConstants.KnoraAdmin.FamilyName),
+                        status = propsMap.get(OntologyConstants.KnoraAdmin.Status).map(_.toBoolean)
                     )
             }.toSeq
 
@@ -299,7 +299,7 @@ class UsersResponderV1 extends Responder {
             }
 
             /* the projects the user is member of */
-            projectIris: Seq[IRI] = groupedUserData.get(OntologyConstants.KnoraBase.IsInProject) match {
+            projectIris: Seq[IRI] = groupedUserData.get(OntologyConstants.KnoraAdmin.IsInProject) match {
                 case Some(projects) => projects
                 case None => Seq.empty[IRI]
             }
@@ -333,7 +333,7 @@ class UsersResponderV1 extends Responder {
             }
 
             /* the projects the user is member of */
-            projectIris: Seq[IRI] = groupedUserData.get(OntologyConstants.KnoraBase.IsInProjectAdminGroup) match {
+            projectIris: Seq[IRI] = groupedUserData.get(OntologyConstants.KnoraAdmin.IsInProjectAdminGroup) match {
                 case Some(projects) => projects
                 case None => Seq.empty[IRI]
             }
@@ -367,7 +367,7 @@ class UsersResponderV1 extends Responder {
             }
 
             /* the groups the user is member of */
-            groupIris: Seq[IRI] = groupedUserData.get(OntologyConstants.KnoraBase.IsInGroup) match {
+            groupIris: Seq[IRI] = groupedUserData.get(OntologyConstants.KnoraAdmin.IsInGroup) match {
                 case Some(projects) => projects
                 case None => Seq.empty[IRI]
             }
@@ -402,18 +402,18 @@ class UsersResponderV1 extends Responder {
             // _ = log.debug(s"userDataQueryResponse2UserProfileV1 - groupedUserData: ${MessageUtil.toSource(groupedUserData)}")
 
             val userDataV1 = UserDataV1(
-                lang = groupedUserData.get(OntologyConstants.KnoraBase.PreferredLanguage) match {
+                lang = groupedUserData.get(OntologyConstants.KnoraAdmin.PreferredLanguage) match {
                     case Some(langList) => langList.head
                     case None => settings.fallbackLanguage
                 },
                 user_id = Some(returnedUserIri),
-                email = groupedUserData.get(OntologyConstants.KnoraBase.Email).map(_.head),
-                firstname = groupedUserData.get(OntologyConstants.KnoraBase.GivenName).map(_.head),
-                lastname = groupedUserData.get(OntologyConstants.KnoraBase.FamilyName).map(_.head),
+                email = groupedUserData.get(OntologyConstants.KnoraAdmin.Email).map(_.head),
+                firstname = groupedUserData.get(OntologyConstants.KnoraAdmin.GivenName).map(_.head),
+                lastname = groupedUserData.get(OntologyConstants.KnoraAdmin.FamilyName).map(_.head),
                 password = if (!short) {
-                    groupedUserData.get(OntologyConstants.KnoraBase.Password).map(_.head)
+                    groupedUserData.get(OntologyConstants.KnoraAdmin.Password).map(_.head)
                 } else None,
-                status = groupedUserData.get(OntologyConstants.KnoraBase.Status).map(_.head.toBoolean)
+                status = groupedUserData.get(OntologyConstants.KnoraAdmin.Status).map(_.head.toBoolean)
             )
             // _ = log.debug(s"userDataQueryResponse - userDataV1: {}", MessageUtil.toSource(userDataV1)")
             FastFuture.successful(Some(userDataV1))
@@ -442,23 +442,23 @@ class UsersResponderV1 extends Responder {
             // log.debug("userDataQueryResponse2UserProfileV1 - groupedUserData: {}", MessageUtil.toSource(groupedUserData))
 
             val userDataV1 = UserDataV1(
-                lang = groupedUserData.get(OntologyConstants.KnoraBase.PreferredLanguage) match {
+                lang = groupedUserData.get(OntologyConstants.KnoraAdmin.PreferredLanguage) match {
                     case Some(langList) => langList.head
                     case None => settings.fallbackLanguage
                 },
                 user_id = Some(returnedUserIri),
-                email = groupedUserData.get(OntologyConstants.KnoraBase.Email).map(_.head),
-                firstname = groupedUserData.get(OntologyConstants.KnoraBase.GivenName).map(_.head),
-                lastname = groupedUserData.get(OntologyConstants.KnoraBase.FamilyName).map(_.head),
-                password = groupedUserData.get(OntologyConstants.KnoraBase.Password).map(_.head),
-                status = groupedUserData.get(OntologyConstants.KnoraBase.Status).map(_.head.toBoolean)
+                email = groupedUserData.get(OntologyConstants.KnoraAdmin.Email).map(_.head),
+                firstname = groupedUserData.get(OntologyConstants.KnoraAdmin.GivenName).map(_.head),
+                lastname = groupedUserData.get(OntologyConstants.KnoraAdmin.FamilyName).map(_.head),
+                password = groupedUserData.get(OntologyConstants.KnoraAdmin.Password).map(_.head),
+                status = groupedUserData.get(OntologyConstants.KnoraAdmin.Status).map(_.head.toBoolean)
             )
 
             // log.debug("userDataQueryResponse2UserProfileV1 - userDataV1: {}", MessageUtil.toSource(userDataV1))
 
 
             /* the projects the user is member of */
-            val projectIris: Seq[IRI] = groupedUserData.get(OntologyConstants.KnoraBase.IsInProject) match {
+            val projectIris: Seq[IRI] = groupedUserData.get(OntologyConstants.KnoraAdmin.IsInProject) match {
                 case Some(projects) => projects
                 case None => Seq.empty[IRI]
             }
@@ -466,7 +466,7 @@ class UsersResponderV1 extends Responder {
             // log.debug(s"userDataQueryResponse2UserProfileV1 - projectIris: ${MessageUtil.toSource(projectIris)}")
 
             /* the groups the user is member of (only explicit groups) */
-            val groupIris = groupedUserData.get(OntologyConstants.KnoraBase.IsInGroup) match {
+            val groupIris = groupedUserData.get(OntologyConstants.KnoraAdmin.IsInGroup) match {
                 case Some(groups) => groups
                 case None => Seq.empty[IRI]
             }
@@ -474,10 +474,10 @@ class UsersResponderV1 extends Responder {
             // log.debug(s"userDataQueryResponse2UserProfileV1 - groupIris: ${MessageUtil.toSource(groupIris)}")
 
             /* the projects for which the user is implicitly considered a member of the 'http://www.knora.org/ontology/knora-base#ProjectAdmin' group */
-            val isInProjectAdminGroups = groupedUserData.getOrElse(OntologyConstants.KnoraBase.IsInProjectAdminGroup, Vector.empty[IRI])
+            val isInProjectAdminGroups = groupedUserData.getOrElse(OntologyConstants.KnoraAdmin.IsInProjectAdminGroup, Vector.empty[IRI])
 
             /* is the user implicitly considered a member of the 'http://www.knora.org/ontology/knora-base#SystemAdmin' group */
-            val isInSystemAdminGroup = groupedUserData.get(OntologyConstants.KnoraBase.IsInSystemAdminGroup).exists(p => p.head.toBoolean)
+            val isInSystemAdminGroup = groupedUserData.get(OntologyConstants.KnoraAdmin.IsInSystemAdminGroup).exists(p => p.head.toBoolean)
 
             for {
                 /* get the user's permission profile from the permissions responder */

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
@@ -157,7 +157,7 @@ class ValuesResponderV1 extends Responder {
 
             resourcePermissionCode: Option[Int] = resourceFullResponse.resdata.flatMap(resdata => resdata.rights)
 
-            _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = resourcePermissionCode, userNeedsPermission = OntologyConstants.KnoraBase.ModifyPermission)) {
+            _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = resourcePermissionCode, userNeedsPermission = OntologyConstants.KnoraAdmin.ModifyPermission)) {
                 throw ForbiddenException(s"User $userIri does not have permission to modify resource ${createValueRequest.resourceIri}")
             }
 
@@ -376,7 +376,7 @@ class ValuesResponderV1 extends Responder {
                             linkTargetIri = realTargetIri,
                             currentReferenceCount = 0,
                             newReferenceCount = initialReferenceCount,
-                            newLinkValueCreator = OntologyConstants.KnoraBase.SystemUser,
+                            newLinkValueCreator = OntologyConstants.KnoraAdmin.SystemUser,
                             newLinkValuePermissions = standoffLinkValuePermissions
                         )
                 }
@@ -800,7 +800,7 @@ class ValuesResponderV1 extends Responder {
 
                 currentValueQueryResult = maybeCurrentValueQueryResult.getOrElse(throw NotFoundException(s"Value ${changeValueRequest.valueIri} not found (it may have been deleted)"))
 
-                _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = Some(currentValueQueryResult.permissionCode), userNeedsPermission = OntologyConstants.KnoraBase.ModifyPermission)) {
+                _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = Some(currentValueQueryResult.permissionCode), userNeedsPermission = OntologyConstants.KnoraAdmin.ModifyPermission)) {
                     throw ForbiddenException(s"User $userIri does not have permission to add a new version to value ${changeValueRequest.valueIri}")
                 }
 
@@ -898,7 +898,7 @@ class ValuesResponderV1 extends Responder {
                         // We're updating a link. This means deleting an existing link and creating a new one, so
                         // check that the user has permission to modify the resource.
                         val resourcePermissionCode = resourceFullResponse.resdata.flatMap(resdata => resdata.rights)
-                        if (!PermissionUtilADM.impliesV1(userHasPermissionCode = resourcePermissionCode, userNeedsPermission = OntologyConstants.KnoraBase.ModifyPermission)) {
+                        if (!PermissionUtilADM.impliesV1(userHasPermissionCode = resourcePermissionCode, userNeedsPermission = OntologyConstants.KnoraAdmin.ModifyPermission)) {
                             throw ForbiddenException(s"User $userIri does not have permission to modify resource ${findResourceWithValueResult.resourceIri}")
                         }
 
@@ -922,7 +922,7 @@ class ValuesResponderV1 extends Responder {
                         // Give the new version the same permissions as the previous version.
 
                         val valuePermissions = currentValueQueryResult.permissionRelevantAssertions.find {
-                            case (p, o) => p == OntologyConstants.KnoraBase.HasPermissions
+                            case (p, o) => p == OntologyConstants.KnoraAdmin.HasPermissions
                         }.map(_._2).getOrElse(throw InconsistentTriplestoreDataException(s"Value ${changeValueRequest.valueIri} has no permissions"))
 
                         changeOrdinaryValueV1AfterChecks(projectIri = currentValueQueryResult.projectIri,
@@ -975,7 +975,7 @@ class ValuesResponderV1 extends Responder {
 
                 currentValueQueryResult = maybeCurrentValueQueryResult.getOrElse(throw NotFoundException(s"Value ${changeCommentRequest.valueIri} not found (it may have been deleted)"))
 
-                _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = Some(currentValueQueryResult.permissionCode), userNeedsPermission = OntologyConstants.KnoraBase.ModifyPermission)) {
+                _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = Some(currentValueQueryResult.permissionCode), userNeedsPermission = OntologyConstants.KnoraAdmin.ModifyPermission)) {
                     throw ForbiddenException(s"User $userIri does not have permission to add a new version to value ${changeCommentRequest.valueIri}")
                 }
 
@@ -1074,7 +1074,7 @@ class ValuesResponderV1 extends Responder {
             maybeCurrentValueQueryResult <- findValue(deleteValueRequest.valueIri, deleteValueRequest.userProfile)
             currentValueQueryResult = maybeCurrentValueQueryResult.getOrElse(throw NotFoundException(s"Value ${deleteValueRequest.valueIri} not found (it may have been deleted)"))
 
-            _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = Some(currentValueQueryResult.permissionCode), userNeedsPermission = OntologyConstants.KnoraBase.DeletePermission)) {
+            _ = if (!PermissionUtilADM.impliesV1(userHasPermissionCode = Some(currentValueQueryResult.permissionCode), userNeedsPermission = OntologyConstants.KnoraAdmin.DeletePermission)) {
                 throw ForbiddenException(s"User $userIri does not have permission to delete value ${deleteValueRequest.valueIri}")
             }
 
@@ -1091,7 +1091,7 @@ class ValuesResponderV1 extends Responder {
                     // Give the new version the same permissions as the previous version.
 
                     val valuePermissions: String = currentValueQueryResult.permissionRelevantAssertions.find {
-                        case (p, o) => p == OntologyConstants.KnoraBase.HasPermissions
+                        case (p, o) => p == OntologyConstants.KnoraAdmin.HasPermissions
                     }.map(_._2).getOrElse(throw InconsistentTriplestoreDataException(s"Value ${deleteValueRequest.valueIri} has no permissions"))
 
                     val linkPropertyIri = knoraIdUtil.linkValuePropertyIri2LinkPropertyIri(findResourceWithValueResult.propertyIri)
@@ -1142,7 +1142,7 @@ class ValuesResponderV1 extends Responder {
                                         sourceResourceIri = findResourceWithValueResult.resourceIri,
                                         linkPropertyIri = OntologyConstants.KnoraBase.HasStandoffLinkTo,
                                         targetResourceIri = targetResourceIri,
-                                        valueCreator = OntologyConstants.KnoraBase.SystemUser,
+                                        valueCreator = OntologyConstants.KnoraAdmin.SystemUser,
                                         valuePermissions = standoffLinkValuePermissions,
                                         userProfile = deleteValueRequest.userProfile
                                     )
@@ -1488,7 +1488,7 @@ class ValuesResponderV1 extends Responder {
             }
 
             rowMap = rows.head.rowMap
-            userIri = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraBase.UnknownUser)
+            userIri = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraAdmin.UnknownUser)
 
             maybeSourcePermissionCode = PermissionUtilADM.getUserPermissionV1(
                 subjectIri = rowMap("source"),
@@ -1643,7 +1643,7 @@ class ValuesResponderV1 extends Responder {
                 }
 
                 permissionCode = maybePermissionCode.getOrElse {
-                    val userIri = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraBase.UnknownUser)
+                    val userIri = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraAdmin.UnknownUser)
                     throw ForbiddenException(s"User $userIri does not have permission to see value $valueIri")
                 }
 
@@ -1708,7 +1708,7 @@ class ValuesResponderV1 extends Responder {
                     subjectProject = None, // no need to specify this here, because it's in valueProps
                     userProfile = userProfile
                 ).getOrElse {
-                    val userIri = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraBase.UnknownUser)
+                    val userIri = userProfile.userData.user_id.getOrElse(OntologyConstants.KnoraAdmin.UnknownUser)
                     throw ForbiddenException(s"User $userIri does not have permission to see value $linkValueIri")
                 }
 
@@ -2064,7 +2064,7 @@ class ValuesResponderV1 extends Responder {
                                     sourceResourceIri = resourceIri,
                                     linkPropertyIri = OntologyConstants.KnoraBase.HasStandoffLinkTo,
                                     targetResourceIri = targetResourceIri,
-                                    valueCreator = OntologyConstants.KnoraBase.SystemUser,
+                                    valueCreator = OntologyConstants.KnoraAdmin.SystemUser,
                                     valuePermissions = standoffLinkValuePermissions,
                                     userProfile = userProfile
                                 )
@@ -2273,7 +2273,7 @@ class ValuesResponderV1 extends Responder {
                                 sourceResourceIri = resourceIri,
                                 linkPropertyIri = OntologyConstants.KnoraBase.HasStandoffLinkTo,
                                 targetResourceIri = targetResourceIri,
-                                valueCreator = OntologyConstants.KnoraBase.SystemUser,
+                                valueCreator = OntologyConstants.KnoraAdmin.SystemUser,
                                 valuePermissions = standoffLinkValuePermissions,
                                 userProfile = userProfile
                             )
@@ -2286,7 +2286,7 @@ class ValuesResponderV1 extends Responder {
                                 sourceResourceIri = resourceIri,
                                 linkPropertyIri = OntologyConstants.KnoraBase.HasStandoffLinkTo,
                                 targetResourceIri = removedTargetResource,
-                                valueCreator = OntologyConstants.KnoraBase.SystemUser,
+                                valueCreator = OntologyConstants.KnoraAdmin.SystemUser,
                                 valuePermissions = standoffLinkValuePermissions,
                                 userProfile = userProfile
                             )
@@ -2617,8 +2617,8 @@ class ValuesResponderV1 extends Responder {
       */
     lazy val standoffLinkValuePermissions: String = {
         val permissionMap = Map(
-            OntologyConstants.KnoraBase.ChangeRightsPermission -> Set(OntologyConstants.KnoraBase.SystemUser),
-            OntologyConstants.KnoraBase.ViewPermission -> Set(OntologyConstants.KnoraBase.UnknownUser)
+            OntologyConstants.KnoraAdmin.ChangeRightsPermission -> Set(OntologyConstants.KnoraAdmin.SystemUser),
+            OntologyConstants.KnoraAdmin.ViewPermission -> Set(OntologyConstants.KnoraAdmin.UnknownUser)
         )
 
         PermissionUtilADM.formatPermissions(permissionMap)

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ListsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ListsRouteADM.scala
@@ -27,6 +27,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.util.Timeout
 import org.knora.webapi.messages.admin.responder.listsmessages._
+import org.knora.webapi.responders.admin.ListsResponderADM.{LIST_IRI_INVALID_ERROR, LIST_IRI_MISSING_ERROR}
 import org.knora.webapi.routing.{Authenticator, RouteUtilADM}
 import org.knora.webapi.util.StringFormatter
 import org.knora.webapi.{BadRequestException, IRI, NotImplementedException, SettingsImpl}
@@ -137,6 +138,15 @@ object ListsRouteADM extends Authenticator with ListADMJsonProtocol {
                 entity(as[ChangeListInfoApiRequestADM]) { apiRequest =>
                     requestContext =>
                         val requestingUser = getUserADM(requestContext)
+
+                        if (iri.isEmpty) {
+                            throw BadRequestException(LIST_IRI_MISSING_ERROR)
+                        }
+
+                        if (!stringFormatter.isKnoraListIriStr(iri)) {
+                            throw BadRequestException(LIST_IRI_INVALID_ERROR)
+                        }
+
                         val listIri = stringFormatter.validateAndEscapeIri(iri, throw BadRequestException(s"Invalid param list IRI: $iri"))
 
                         val requestMessage = ListInfoChangeRequestADM(

--- a/webapi/src/main/scala/org/knora/webapi/util/PermissionUtilADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/PermissionUtilADM.scala
@@ -40,17 +40,17 @@ object PermissionUtilADM {
       * A [[Map]] of Knora permission abbreviations to their API v1 codes.
       */
     val permissionsToV1PermissionCodes = new ErrorHandlingMap(Map(
-        OntologyConstants.KnoraBase.RestrictedViewPermission -> 1,
-        OntologyConstants.KnoraBase.ViewPermission -> 2,
-        OntologyConstants.KnoraBase.ModifyPermission -> 6,
-        OntologyConstants.KnoraBase.DeletePermission -> 7,
-        OntologyConstants.KnoraBase.ChangeRightsPermission -> 8
+        OntologyConstants.KnoraAdmin.RestrictedViewPermission -> 1,
+        OntologyConstants.KnoraAdmin.ViewPermission -> 2,
+        OntologyConstants.KnoraAdmin.ModifyPermission -> 6,
+        OntologyConstants.KnoraAdmin.DeletePermission -> 7,
+        OntologyConstants.KnoraAdmin.ChangeRightsPermission -> 8
     ), { key: IRI => s"Unknown permission: $key" })
 
     /**
       * The API v1 code of the highest permission.
       */
-    private val MaxPermissionCode = permissionsToV1PermissionCodes(OntologyConstants.KnoraBase.MaxPermission)
+    private val MaxPermissionCode = permissionsToV1PermissionCodes(OntologyConstants.KnoraAdmin.MaxPermission)
 
     /**
       * A [[Map]] of API v1 permission codes to Knora permission abbreviations. Used for debugging.
@@ -63,18 +63,18 @@ object PermissionUtilADM {
     private val permissionRelevantAssertions = Set(
         OntologyConstants.KnoraBase.AttachedToUser,
         OntologyConstants.KnoraBase.AttachedToProject,
-        OntologyConstants.KnoraBase.HasPermissions
+        OntologyConstants.KnoraAdmin.HasPermissions
     )
 
     /**
       * A map of IRIs for default permissions to the corresponding permission abbreviations.
       */
     private val defaultPermissions2Permissions: Map[IRI, IRI] = Map(
-        OntologyConstants.KnoraBase.HasDefaultRestrictedViewPermission -> OntologyConstants.KnoraBase.RestrictedViewPermission,
-        OntologyConstants.KnoraBase.HasDefaultViewPermission -> OntologyConstants.KnoraBase.ViewPermission,
-        OntologyConstants.KnoraBase.HasDefaultModifyPermission -> OntologyConstants.KnoraBase.ModifyPermission,
-        OntologyConstants.KnoraBase.HasDefaultDeletePermission -> OntologyConstants.KnoraBase.DeletePermission,
-        OntologyConstants.KnoraBase.HasDefaultChangeRightsPermission -> OntologyConstants.KnoraBase.ChangeRightsPermission
+        OntologyConstants.KnoraAdmin.HasDefaultRestrictedViewPermission -> OntologyConstants.KnoraAdmin.RestrictedViewPermission,
+        OntologyConstants.KnoraAdmin.HasDefaultViewPermission -> OntologyConstants.KnoraAdmin.ViewPermission,
+        OntologyConstants.KnoraAdmin.HasDefaultModifyPermission -> OntologyConstants.KnoraAdmin.ModifyPermission,
+        OntologyConstants.KnoraAdmin.HasDefaultDeletePermission -> OntologyConstants.KnoraAdmin.DeletePermission,
+        OntologyConstants.KnoraAdmin.HasDefaultChangeRightsPermission -> OntologyConstants.KnoraAdmin.ChangeRightsPermission
     )
 
     /**
@@ -100,7 +100,7 @@ object PermissionUtilADM {
       *                       pertaining to the value, grouped by predicate. The predicates must include
       *                       [[org.knora.webapi.OntologyConstants.KnoraBase.AttachedToUser]], and should include
       *                       [[org.knora.webapi.OntologyConstants.KnoraBase.AttachedToProject]]
-      *                       and [[org.knora.webapi.OntologyConstants.KnoraBase.HasPermissions]]. Other predicates may be
+      *                       and [[org.knora.webapi.OntologyConstants.KnoraAdmin.HasPermissions]]. Other predicates may be
       *                       included, but they will be ignored, so there is no need to filter them before passing them to
       *                       this function.
       * @param subjectProject if provided, the `knora-base:attachedToProject` of the resource containing the value. Otherwise,
@@ -141,7 +141,7 @@ object PermissionUtilADM {
       * Given the IRI of an RDF property, returns `true` if the property is relevant to calculating permissions. This
       * is the case if the property is [[org.knora.webapi.OntologyConstants.KnoraBase.AttachedToUser]],
       * [[org.knora.webapi.OntologyConstants.KnoraBase.AttachedToProject]], or
-      * or [[org.knora.webapi.OntologyConstants.KnoraBase.HasPermissions]].
+      * or [[org.knora.webapi.OntologyConstants.KnoraAdmin.HasPermissions]].
       *
       * @param p the IRI of the property.
       * @return `true` if the property is relevant to calculating permissions.
@@ -239,13 +239,13 @@ object PermissionUtilADM {
                 // The user is a known user.
                 // If the user is the creator of the subject, put the user in the "creator" built-in group.
                 val creatorOption = if (userIri == subjectCreator) {
-                    Some(OntologyConstants.KnoraBase.Creator)
+                    Some(OntologyConstants.KnoraAdmin.Creator)
                 } else {
                     None
                 }
 
                 val systemAdminOption = if (userProfile.permissionData.isSystemAdmin) {
-                    Some(OntologyConstants.KnoraBase.SystemAdmin)
+                    Some(OntologyConstants.KnoraAdmin.SystemAdmin)
                 } else {
                     None
                 }
@@ -257,10 +257,10 @@ object PermissionUtilADM {
 
                 // Make the complete list of the user's groups: KnownUser, the user's built-in (e.g., ProjectAdmin,
                 // ProjectMember) and non-built-in groups, possibly creator, and possibly SystemAdmin.
-                Vector(OntologyConstants.KnoraBase.KnownUser) ++ otherGroups ++ creatorOption ++ systemAdminOption
+                Vector(OntologyConstants.KnoraAdmin.KnownUser) ++ otherGroups ++ creatorOption ++ systemAdminOption
             case None =>
                 // The user is an unknown user; put them in the UnknownUser built-in group.
-                Vector(OntologyConstants.KnoraBase.UnknownUser)
+                Vector(OntologyConstants.KnoraAdmin.UnknownUser)
         }
 
         log.debug(s"getUserPermissionV1 - userGroups: $userGroups")
@@ -280,7 +280,7 @@ object PermissionUtilADM {
                 case None =>
                     // If the result is that they would get no permissions, give them user whatever permission an
                     // unknown user would have.
-                    calculateHighestGrantedPermission(subjectPermissions, Vector(OntologyConstants.KnoraBase.UnknownUser))
+                    calculateHighestGrantedPermission(subjectPermissions, Vector(OntologyConstants.KnoraAdmin.UnknownUser))
             }
         }
 
@@ -300,7 +300,7 @@ object PermissionUtilADM {
       *                    pertaining to the subject. The predicates must include
       *                    [[org.knora.webapi.OntologyConstants.KnoraBase.AttachedToUser]] and
       *                    [[org.knora.webapi.OntologyConstants.KnoraBase.AttachedToProject]], and should include
-      *                    [[org.knora.webapi.OntologyConstants.KnoraBase.HasPermissions]].
+      *                    [[org.knora.webapi.OntologyConstants.KnoraAdmin.HasPermissions]].
       *                    Other predicates may be included, but they will be ignored, so there is no need to filter
       *                    them before passing them to this function.
       * @param userProfile the profile of the user making the request.
@@ -315,7 +315,7 @@ object PermissionUtilADM {
         // Anything with permissions must have an creator and a project.
         val subjectCreator: IRI = assertionMap.getOrElse(OntologyConstants.KnoraBase.AttachedToUser, throw InconsistentTriplestoreDataException(s"Subject $subjectIri has no creator"))
         val subjectProject: IRI = assertionMap.getOrElse(OntologyConstants.KnoraBase.AttachedToProject, throw InconsistentTriplestoreDataException(s"Subject $subjectIri has no project"))
-        val subjectPermissionLiteral: String = assertionMap.getOrElse(OntologyConstants.KnoraBase.HasPermissions, throw InconsistentTriplestoreDataException(s"Subject $subjectIri has no knora-base:hasPermissions predicate"))
+        val subjectPermissionLiteral: String = assertionMap.getOrElse(OntologyConstants.KnoraAdmin.HasPermissions, throw InconsistentTriplestoreDataException(s"Subject $subjectIri has no knora-base:hasPermissions predicate"))
 
         getUserPermissionV1(subjectIri = subjectIri, subjectCreator = subjectCreator, subjectProject = subjectProject, subjectPermissionLiteral = subjectPermissionLiteral, userProfile = userProfile)
     }
@@ -325,23 +325,23 @@ object PermissionUtilADM {
       *
       * @param permissionListStr the literal to parse.
       * @return a [[Map]] in which the keys are permission abbreviations in
-      *         [[OntologyConstants.KnoraBase.ObjectAccessPermissionAbbreviations]], and the values are sets of
+      *         [[OntologyConstants.KnoraAdmin.ObjectAccessPermissionAbbreviations]], and the values are sets of
       *         user group IRIs.
       */
     def parsePermissions(permissionListStr: String): Map[String, Set[IRI]] = {
-        val permissions: Seq[String] = permissionListStr.split(OntologyConstants.KnoraBase.PermissionListDelimiter)
+        val permissions: Seq[String] = permissionListStr.split(OntologyConstants.KnoraAdmin.PermissionListDelimiter)
 
         permissions.map {
             permission =>
                 val splitPermission = permission.split(' ')
                 val abbreviation = splitPermission(0)
 
-                if (!OntologyConstants.KnoraBase.ObjectAccessPermissionAbbreviations.contains(abbreviation)) {
+                if (!OntologyConstants.KnoraAdmin.ObjectAccessPermissionAbbreviations.contains(abbreviation)) {
                     throw InconsistentTriplestoreDataException(s"Unrecognized permission abbreviation '$abbreviation'")
                 }
 
-                val shortGroups = splitPermission(1).split(OntologyConstants.KnoraBase.GroupListDelimiter).toSet
-                val groups = shortGroups.map(_.replace(OntologyConstants.KnoraBase.KnoraBasePrefix, OntologyConstants.KnoraBase.KnoraBasePrefixExpansion))
+                val shortGroups = splitPermission(1).split(OntologyConstants.KnoraAdmin.GroupListDelimiter).toSet
+                val groups = shortGroups.map(_.replace(OntologyConstants.KnoraAdmin.KnoraAdminPrefix, OntologyConstants.KnoraAdmin.KnoraAdminPrefixExpansion))
 
                 (abbreviation, groups)
         }.toMap
@@ -353,14 +353,14 @@ object PermissionUtilADM {
       *
       * @param maybePermissionListStr the literal to parse.
       * @return a [[Map]] in which the keys are permission abbreviations in
-      *         [[OntologyConstants.KnoraBase.ObjectAccessPermissionAbbreviations]], and the values are sets of
+      *         [[OntologyConstants.KnoraAdmin.ObjectAccessPermissionAbbreviations]], and the values are sets of
       *         user group IRIs.
       */
     def parsePermissionsWithType(maybePermissionListStr: Option[String], permissionType: PermissionType): Set[PermissionADM] = {
         maybePermissionListStr match {
             case Some(permissionListStr) => {
                 val cleanedPermissionListStr = permissionListStr replaceAll("[<>]", "")
-                val permissions: Seq[String] = cleanedPermissionListStr.split(OntologyConstants.KnoraBase.PermissionListDelimiter)
+                val permissions: Seq[String] = cleanedPermissionListStr.split(OntologyConstants.KnoraAdmin.PermissionListDelimiter)
                 log.debug(s"PermissionUtil.parsePermissionsWithType - split permissions: $permissions")
                 permissions.flatMap {
                     permission =>
@@ -369,24 +369,24 @@ object PermissionUtilADM {
 
                         permissionType match {
                             case PermissionType.AP =>
-                                if (!OntologyConstants.KnoraBase.AdministrativePermissionAbbreviations.contains(abbreviation)) {
+                                if (!OntologyConstants.KnoraAdmin.AdministrativePermissionAbbreviations.contains(abbreviation)) {
                                     throw InconsistentTriplestoreDataException(s"Unrecognized permission abbreviation '$abbreviation'")
                                 }
 
                                 if (splitPermission.length > 1) {
-                                    val shortGroups: Array[String] = splitPermission(1).split(OntologyConstants.KnoraBase.GroupListDelimiter)
-                                    val groups: Set[IRI] = shortGroups.map(_.replace(OntologyConstants.KnoraBase.KnoraBasePrefix, OntologyConstants.KnoraBase.KnoraBasePrefixExpansion)).toSet
+                                    val shortGroups: Array[String] = splitPermission(1).split(OntologyConstants.KnoraAdmin.GroupListDelimiter)
+                                    val groups: Set[IRI] = shortGroups.map(_.replace(OntologyConstants.KnoraAdmin.KnoraAdminPrefix, OntologyConstants.KnoraAdmin.KnoraAdminPrefixExpansion)).toSet
                                     buildPermissionObject(abbreviation, groups)
                                 } else {
                                     buildPermissionObject(abbreviation, Set.empty[IRI])
                                 }
 
                             case PermissionType.OAP =>
-                                if (!OntologyConstants.KnoraBase.ObjectAccessPermissionAbbreviations.contains(abbreviation)) {
+                                if (!OntologyConstants.KnoraAdmin.ObjectAccessPermissionAbbreviations.contains(abbreviation)) {
                                     throw InconsistentTriplestoreDataException(s"Unrecognized permission abbreviation '$abbreviation'")
                                 }
-                                val shortGroups: Array[String] = splitPermission(1).split(OntologyConstants.KnoraBase.GroupListDelimiter)
-                                val groups: Set[IRI] = shortGroups.map(_.replace(OntologyConstants.KnoraBase.KnoraBasePrefix, OntologyConstants.KnoraBase.KnoraBasePrefixExpansion)).toSet
+                                val shortGroups: Array[String] = splitPermission(1).split(OntologyConstants.KnoraAdmin.GroupListDelimiter)
+                                val groups: Set[IRI] = shortGroups.map(_.replace(OntologyConstants.KnoraAdmin.KnoraAdminPrefix, OntologyConstants.KnoraAdmin.KnoraAdminPrefixExpansion)).toSet
                                 buildPermissionObject(abbreviation, groups)
                         }
                 }
@@ -404,9 +404,9 @@ object PermissionUtilADM {
       */
     def buildPermissionObject(name: String, iris: Set[IRI]): Set[PermissionADM] = {
         name match {
-            case OntologyConstants.KnoraBase.ProjectResourceCreateAllPermission => Set(PermissionADM.ProjectResourceCreateAllPermission)
+            case OntologyConstants.KnoraAdmin.ProjectResourceCreateAllPermission => Set(PermissionADM.ProjectResourceCreateAllPermission)
 
-            case OntologyConstants.KnoraBase.ProjectResourceCreateRestrictedPermission =>
+            case OntologyConstants.KnoraAdmin.ProjectResourceCreateRestrictedPermission =>
                 if (iris.nonEmpty) {
                     log.debug(s"buildPermissionObject - ProjectResourceCreateRestrictedPermission - iris: $iris")
                     iris.map(iri => PermissionADM.projectResourceCreateRestrictedPermission(iri))
@@ -414,50 +414,50 @@ object PermissionUtilADM {
                     throw InconsistentTriplestoreDataException(s"Missing additional permission information.")
                 }
 
-            case OntologyConstants.KnoraBase.ProjectAdminAllPermission => Set(PermissionADM.ProjectAdminAllPermission)
+            case OntologyConstants.KnoraAdmin.ProjectAdminAllPermission => Set(PermissionADM.ProjectAdminAllPermission)
 
-            case OntologyConstants.KnoraBase.ProjectAdminGroupAllPermission => Set(PermissionADM.ProjectAdminGroupAllPermission)
+            case OntologyConstants.KnoraAdmin.ProjectAdminGroupAllPermission => Set(PermissionADM.ProjectAdminGroupAllPermission)
 
-            case OntologyConstants.KnoraBase.ProjectAdminGroupRestrictedPermission =>
+            case OntologyConstants.KnoraAdmin.ProjectAdminGroupRestrictedPermission =>
                 if (iris.nonEmpty) {
                     iris.map(iri => PermissionADM.projectAdminGroupRestrictedPermission(iri))
                 } else {
                     throw InconsistentTriplestoreDataException(s"Missing additional permission information.")
                 }
 
-            case OntologyConstants.KnoraBase.ProjectAdminRightsAllPermission => Set(PermissionADM.ProjectAdminRightsAllPermission)
+            case OntologyConstants.KnoraAdmin.ProjectAdminRightsAllPermission => Set(PermissionADM.ProjectAdminRightsAllPermission)
 
-            case OntologyConstants.KnoraBase.ProjectAdminOntologyAllPermission => Set(PermissionADM.ProjectAdminOntologyAllPermission)
+            case OntologyConstants.KnoraAdmin.ProjectAdminOntologyAllPermission => Set(PermissionADM.ProjectAdminOntologyAllPermission)
 
-            case OntologyConstants.KnoraBase.ChangeRightsPermission =>
+            case OntologyConstants.KnoraAdmin.ChangeRightsPermission =>
                 if (iris.nonEmpty) {
                     iris.map(iri => PermissionADM.changeRightsPermission(iri))
                 } else {
                     throw InconsistentTriplestoreDataException(s"Missing additional permission information.")
                 }
 
-            case OntologyConstants.KnoraBase.DeletePermission =>
+            case OntologyConstants.KnoraAdmin.DeletePermission =>
                 if (iris.nonEmpty) {
                     iris.map(iri => PermissionADM.deletePermission(iri))
                 } else {
                     throw InconsistentTriplestoreDataException(s"Missing additional permission information.")
                 }
 
-            case OntologyConstants.KnoraBase.ModifyPermission =>
+            case OntologyConstants.KnoraAdmin.ModifyPermission =>
                 if (iris.nonEmpty) {
                     iris.map(iri => PermissionADM.modifyPermission(iri))
                 } else {
                     throw InconsistentTriplestoreDataException(s"Missing additional permission information.")
                 }
 
-            case OntologyConstants.KnoraBase.ViewPermission =>
+            case OntologyConstants.KnoraAdmin.ViewPermission =>
                 if (iris.nonEmpty) {
                     iris.map(iri => PermissionADM.viewPermission(iri))
                 } else {
                     throw InconsistentTriplestoreDataException(s"Missing additional permission information.")
                 }
 
-            case OntologyConstants.KnoraBase.RestrictedViewPermission =>
+            case OntologyConstants.KnoraAdmin.RestrictedViewPermission =>
                 if (iris.nonEmpty) {
                     iris.map(iri => PermissionADM.restrictedViewPermission(iri))
                 } else {
@@ -507,7 +507,7 @@ object PermissionUtilADM {
 
     /**
       * Helper method used to transform a set of permissions into a permissions string ready to be written into the
-      * triplestore as the value for the 'knora-base:hasPermissions' property.
+      * triplestore as the value for the 'knora-admin:hasPermissions' property.
       *
       * @param permissions    the permissions to be formatted.
       * @param permissionType a [[PermissionType]] indicating the type of permissions to be formatted.
@@ -522,9 +522,9 @@ object PermissionUtilADM {
                     val groupedPermissions: Map[String, String] = permissions.groupBy(_.name).map { case (name, perms) =>
                         val shortGroupsString = perms.foldLeft("") { (acc, perm) =>
                             if (acc.isEmpty) {
-                                acc + perm.additionalInformation.get.replace(OntologyConstants.KnoraBase.KnoraBasePrefixExpansion, OntologyConstants.KnoraBase.KnoraBasePrefix)
+                                acc + perm.additionalInformation.get.replace(OntologyConstants.KnoraAdmin.KnoraAdminPrefixExpansion, OntologyConstants.KnoraAdmin.KnoraAdminPrefix)
                             } else {
-                                acc + OntologyConstants.KnoraBase.GroupListDelimiter + perm.additionalInformation.get.replace(OntologyConstants.KnoraBase.KnoraBasePrefixExpansion, OntologyConstants.KnoraBase.KnoraBasePrefix)
+                                acc + OntologyConstants.KnoraAdmin.GroupListDelimiter + perm.additionalInformation.get.replace(OntologyConstants.KnoraAdmin.KnoraAdminPrefixExpansion, OntologyConstants.KnoraAdmin.KnoraAdminPrefix)
                             }
                         }
                         (name, shortGroupsString)
@@ -540,7 +540,7 @@ object PermissionUtilADM {
                         if (acc.isEmpty) {
                             acc + perm._1 + " " + perm._2
                         } else {
-                            acc + OntologyConstants.KnoraBase.PermissionListDelimiter + perm._1 + " " + perm._2
+                            acc + OntologyConstants.KnoraAdmin.PermissionListDelimiter + perm._1 + " " + perm._2
                         }
                     }
                 } else {
@@ -550,10 +550,10 @@ object PermissionUtilADM {
     }
 
     /**
-      * Formats the literal object of the predicate `knora-base:hasPermissions`.
+      * Formats the literal object of the predicate `knora-admin:hasPermissions`.
       *
       * @param permissions a [[Map]] in which the keys are permission abbreviations in
-      *                    [[OntologyConstants.KnoraBase.ObjectAccessPermissionAbbreviations]], and the values are sets of
+      *                    [[OntologyConstants.KnoraAdmin.ObjectAccessPermissionAbbreviations]], and the values are sets of
       *                    user group IRIs.
       * @return a formatted string literal that can be used as the object of the predicate `knora-base:hasPermissions`.
       */
@@ -566,17 +566,17 @@ object PermissionUtilADM {
             }
 
             for ((abbreviation, groups) <- currentPermissionsSorted) {
-                if (!OntologyConstants.KnoraBase.ObjectAccessPermissionAbbreviations.contains(abbreviation)) {
+                if (!OntologyConstants.KnoraAdmin.ObjectAccessPermissionAbbreviations.contains(abbreviation)) {
                     throw InconsistentTriplestoreDataException(s"Unrecognized permission abbreviation '$abbreviation'")
                 }
 
                 if (permissionsLiteral.nonEmpty) {
-                    permissionsLiteral.append(OntologyConstants.KnoraBase.PermissionListDelimiter)
+                    permissionsLiteral.append(OntologyConstants.KnoraAdmin.PermissionListDelimiter)
                 }
 
                 permissionsLiteral.append(abbreviation).append(" ")
-                val shortGroups = groups.map(_.replace(OntologyConstants.KnoraBase.KnoraBasePrefixExpansion, OntologyConstants.KnoraBase.KnoraBasePrefix))
-                val delimitedGroups = shortGroups.toVector.mkString(OntologyConstants.KnoraBase.GroupListDelimiter.toString)
+                val shortGroups = groups.map(_.replace(OntologyConstants.KnoraAdmin.KnoraAdminPrefixExpansion, OntologyConstants.KnoraAdmin.KnoraAdminPrefix))
+                val delimitedGroups = shortGroups.toVector.mkString(OntologyConstants.KnoraAdmin.GroupListDelimiter.toString)
                 permissionsLiteral.append(delimitedGroups)
             }
 

--- a/webapi/src/main/scala/org/knora/webapi/util/TransformData.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/TransformData.scala
@@ -175,20 +175,20 @@ object TransformData extends App {
     )
 
     private val oldPermissionIri2Abbreviation = Map(
-        HasRestrictedViewPermission -> OntologyConstants.KnoraBase.RestrictedViewPermission,
-        HasViewPermission -> OntologyConstants.KnoraBase.ViewPermission,
-        HasModifyPermission -> OntologyConstants.KnoraBase.ModifyPermission,
-        HasDeletePermission -> OntologyConstants.KnoraBase.DeletePermission,
-        HasChangeRightsPermission -> OntologyConstants.KnoraBase.ChangeRightsPermission,
-        HasChangeRightsPermisson -> OntologyConstants.KnoraBase.ChangeRightsPermission
+        HasRestrictedViewPermission -> OntologyConstants.KnoraAdmin.RestrictedViewPermission,
+        HasViewPermission -> OntologyConstants.KnoraAdmin.ViewPermission,
+        HasModifyPermission -> OntologyConstants.KnoraAdmin.ModifyPermission,
+        HasDeletePermission -> OntologyConstants.KnoraAdmin.DeletePermission,
+        HasChangeRightsPermission -> OntologyConstants.KnoraAdmin.ChangeRightsPermission,
+        HasChangeRightsPermisson -> OntologyConstants.KnoraAdmin.ChangeRightsPermission
     )
 
     private val StandardClassesWithoutIsDeleted = Set(
-        OntologyConstants.KnoraBase.User,
-        OntologyConstants.KnoraBase.UserGroup,
-        OntologyConstants.KnoraBase.KnoraProject,
-        OntologyConstants.KnoraBase.Institution,
-        OntologyConstants.KnoraBase.ListNode
+        OntologyConstants.KnoraAdmin.User,
+        OntologyConstants.KnoraAdmin.UserGroup,
+        OntologyConstants.KnoraAdmin.KnoraProject,
+        OntologyConstants.KnoraAdmin.Institution,
+        OntologyConstants.KnoraAdmin.ListNode
     )
 
     private val ValueHasStartJDC = "http://www.knora.org/ontology/knora-base#valueHasStartJDC"
@@ -435,7 +435,7 @@ object TransformData extends App {
 
                         val permissionStatement = valueFactory.createStatement(
                             valueFactory.createIRI(subjectIri),
-                            valueFactory.createIRI(OntologyConstants.KnoraBase.HasPermissions),
+                            valueFactory.createIRI(OntologyConstants.KnoraAdmin.HasPermissions),
                             valueFactory.createLiteral(permissionLiteral)
                         )
 
@@ -833,18 +833,18 @@ object TransformData extends App {
                     val statementsWithoutCreatorOrPermissions = statements.filterNot {
                         (statement: Statement) =>
                             statement.getPredicate.stringValue == OntologyConstants.KnoraBase.AttachedToUser ||
-                                statement.getPredicate.stringValue == OntologyConstants.KnoraBase.HasPermissions
+                                statement.getPredicate.stringValue == OntologyConstants.KnoraAdmin.HasPermissions
                     }
 
                     val creatorStatement = valueFactory.createStatement(
                         valueFactory.createIRI(subjectIri),
                         valueFactory.createIRI(OntologyConstants.KnoraBase.AttachedToUser),
-                        valueFactory.createIRI(OntologyConstants.KnoraBase.SystemUser)
+                        valueFactory.createIRI(OntologyConstants.KnoraAdmin.SystemUser)
                     )
 
                     val permissionsStatement = valueFactory.createStatement(
                         valueFactory.createIRI(subjectIri),
-                        valueFactory.createIRI(OntologyConstants.KnoraBase.HasPermissions),
+                        valueFactory.createIRI(OntologyConstants.KnoraAdmin.HasPermissions),
                         valueFactory.createLiteral("CR knora-base:Creator|V knora-base:UnknownUser")
                     )
 
@@ -1097,7 +1097,7 @@ object TransformData extends App {
     }
 
     /**
-      * Transforms existing 'knora-base:Owner' group inside permissions statements to 'knora-base:Creator'
+      * Transforms existing 'knora-admin:Owner' group inside permissions statements to 'knora-admin:Creator'
       *
       * @param turtleWriter an [[RDFWriter]] that writes to the output file.
       */
@@ -1111,7 +1111,7 @@ object TransformData extends App {
                         statement =>
                             // If this statement has the 'hasPermissions' predicate, then see if the literal contains
                             // 'knora-base:Owner', and if so, replace with 'knora-base:Creator'.
-                            if (statement.getPredicate.stringValue == OntologyConstants.KnoraBase.HasPermissions) {
+                            if (statement.getPredicate.stringValue == OntologyConstants.KnoraAdmin.HasPermissions) {
 
                                 //log.debug(s"CreatorHandler - ${ScalaPrettyPrinter.prettyPrint(statement)}")
 
@@ -1147,8 +1147,8 @@ object TransformData extends App {
     }
 
     /**
-      * Adds 'knora-base:Creator' group to 'CR' permission statement. This corresponds to the previous behaviour with
-      * 'knora-base:Owner'. Use carefully as it will add permissions that where not there before.
+      * Adds 'knora-admin:Creator' group to 'CR' permission statement. This corresponds to the previous behaviour with
+      * 'knora-admin:Owner'. Use carefully as it will add permissions that where not there before.
       *
       * @param turtleWriter an [[RDFWriter]] that writes to the output file.
       */
@@ -1165,19 +1165,19 @@ object TransformData extends App {
                             statement => turtleWriter.handleStatement(statement)
                         }
                     } else {
-                        val currentPermissions: Set[PermissionADM] = getObject(subjectStatements, OntologyConstants.KnoraBase.HasPermissions) match {
+                        val currentPermissions: Set[PermissionADM] = getObject(subjectStatements, OntologyConstants.KnoraAdmin.HasPermissions) match {
                             case Some(permissionsLiteral) =>
                                 /* parse literal */
                                 val parsedPermissions: Set[PermissionADM] = PermissionUtilADM.parsePermissionsWithType(Some(permissionsLiteral), PermissionType.OAP)
 
                                 /* remove ony permissions referencing the creator */
-                                parsedPermissions.filter(perm => perm.additionalInformation.get != OntologyConstants.KnoraBase.Creator)
+                                parsedPermissions.filter(perm => perm.additionalInformation.get != OntologyConstants.KnoraAdmin.Creator)
 
                             case None => Set.empty[PermissionADM]
                         }
 
                         /* add CR for Creator */
-                        val permissionsWithCreator = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraBase.Creator)) ++ currentPermissions
+                        val permissionsWithCreator = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator)) ++ currentPermissions
 
                         /* transform back to literal */
                         val changedPermissionsLiteral: String = PermissionUtilADM.formatPermissions(permissionsWithCreator, PermissionType.OAP)
@@ -1185,11 +1185,11 @@ object TransformData extends App {
                         /* create statement with new literal */
                         val newHasPermissionsStatement = valueFactory.createStatement(
                             valueFactory.createIRI(subjectIri),
-                            valueFactory.createIRI(OntologyConstants.KnoraBase.HasPermissions),
+                            valueFactory.createIRI(OntologyConstants.KnoraAdmin.HasPermissions),
                             valueFactory.createLiteral(changedPermissionsLiteral)
                         )
 
-                        val subjectStatementsWithChangedPermissions = subjectStatements.filterNot(_.getPredicate.stringValue == OntologyConstants.KnoraBase.HasPermissions) :+ newHasPermissionsStatement
+                        val subjectStatementsWithChangedPermissions = subjectStatements.filterNot(_.getPredicate.stringValue == OntologyConstants.KnoraAdmin.HasPermissions) :+ newHasPermissionsStatement
 
                         subjectStatementsWithChangedPermissions.foreach {
                             statement => turtleWriter.handleStatement(statement)

--- a/webapi/src/test/resources/logback-test.xml
+++ b/webapi/src/test/resources/logback-test.xml
@@ -112,7 +112,7 @@
     <!-- Admin -->
     <logger name="org.knora.webapi.responders.admin.ListsAdminResponderSpec" level="INFO"/>
     <logger name="org.knora.webapi.responders.admin.UsersResponderADMSpec" level="INFO"/>
-    <logger name="org.knora.webapi.e2e.admin.ListsADME2ESpec" level="INFO"/>
+    <logger name="org.knora.webapi.e2e.admin.ListsADME2ESpec" level="DEBUG"/>
     <logger name="org.knora.webapi.e2e.admin.ProjectsADME2ESpec" level="INFO"/>
     <logger name="org.knora.webapi.e2e.admin.UsersADME2ESpecE2E" level="INFO"/>
 

--- a/webapi/src/test/scala/org/knora/webapi/SharedPermissionsTestData.scala
+++ b/webapi/src/test/scala/org/knora/webapi/SharedPermissionsTestData.scala
@@ -40,31 +40,31 @@ object SharedPermissionsTestData {
     val perm001_d1: doap =
         doap(
             iri = "http://rdfh.ch/permissions/001-d1",
-            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/001-d1", forProject = OntologyConstants.KnoraBase.SystemProject, forGroup = None, forResourceClass = Some(OntologyConstants.KnoraBase.LinkObj), forProperty = None, hasPermissions = Set(
-                                PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember),
-                                PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser),
-                                PermissionADM.viewPermission(OntologyConstants.KnoraBase.UnknownUser)
+            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/001-d1", forProject = OntologyConstants.KnoraAdmin.SystemProject, forGroup = None, forResourceClass = Some(OntologyConstants.KnoraBase.LinkObj), forProperty = None, hasPermissions = Set(
+                                PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                                PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
+                                PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.UnknownUser)
                             ))
         )
 
     val perm001_d2: doap =
         doap(
             iri = "http://rdfh.ch/permissions/001-d2",
-            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/001-d2", forProject = OntologyConstants.KnoraBase.SystemProject, forGroup = None, forResourceClass = Some(OntologyConstants.KnoraBase.Region), forProperty = None, hasPermissions = Set(
-                                PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember),
-                                PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser),
-                                PermissionADM.viewPermission(OntologyConstants.KnoraBase.UnknownUser)
+            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/001-d2", forProject = OntologyConstants.KnoraAdmin.SystemProject, forGroup = None, forResourceClass = Some(OntologyConstants.KnoraBase.Region), forProperty = None, hasPermissions = Set(
+                                PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                                PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
+                                PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.UnknownUser)
                             ))
         )
 
     val perm001_d3: doap =
         doap(
             iri = "http://rdfh.ch/permissions/001-d3",
-            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/001-d3", forProject = OntologyConstants.KnoraBase.SystemProject, forGroup = None, forResourceClass = None, forProperty = Some(OntologyConstants.KnoraBase.HasStillImageFileValue), hasPermissions = Set(
-                                PermissionADM.modifyPermission(OntologyConstants.KnoraBase.Creator),
-                                PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember),
-                                PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser),
-                                PermissionADM.restrictedViewPermission(OntologyConstants.KnoraBase.UnknownUser)
+            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/001-d3", forProject = OntologyConstants.KnoraAdmin.SystemProject, forGroup = None, forResourceClass = None, forProperty = Some(OntologyConstants.KnoraBase.HasStillImageFileValue), hasPermissions = Set(
+                                PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.Creator),
+                                PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                                PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
+                                PermissionADM.restrictedViewPermission(OntologyConstants.KnoraAdmin.UnknownUser)
                             ))
         )
 
@@ -76,13 +76,13 @@ object SharedPermissionsTestData {
     val perm002_a1: ap =
         ap(
             iri = "http://rdfh.ch/permissions/00FF/a1",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/00FF/a1", forProject = IMAGES_PROJECT_IRI, forGroup = OntologyConstants.KnoraBase.ProjectMember, hasPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission))
+            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/00FF/a1", forProject = IMAGES_PROJECT_IRI, forGroup = OntologyConstants.KnoraAdmin.ProjectMember, hasPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission))
         )
 
     val perm002_a2: ap =
         ap(
             iri = "http://rdfh.ch/permissions/00FF/a2",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/00FF/a2", forProject = IMAGES_PROJECT_IRI, forGroup = OntologyConstants.KnoraBase.ProjectAdmin, hasPermissions = Set(
+            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/00FF/a2", forProject = IMAGES_PROJECT_IRI, forGroup = OntologyConstants.KnoraAdmin.ProjectAdmin, hasPermissions = Set(
                                 PermissionADM.ProjectResourceCreateAllPermission,
                                 PermissionADM.ProjectAdminAllPermission
                             ))
@@ -100,20 +100,20 @@ object SharedPermissionsTestData {
     val perm002_d1: doap =
         doap(
             iri = "http://rdfh.ch/permissions/00FF/d1",
-            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/00FF/d1", forProject = IMAGES_PROJECT_IRI, forGroup = Some(OntologyConstants.KnoraBase.ProjectMember), forResourceClass = None, forProperty = None, hasPermissions = Set(
-                                PermissionADM.changeRightsPermission(OntologyConstants.KnoraBase.Creator),
-                                PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember),
-                                PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser)
+            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/00FF/d1", forProject = IMAGES_PROJECT_IRI, forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember), forResourceClass = None, forProperty = None, hasPermissions = Set(
+                                PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
+                                PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                                PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser)
                             ))
         )
 
     val perm002_d2: doap =
         doap(
             iri = "http://rdfh.ch/permissions/00FF/d2",
-            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/00FF/d2", forProject = IMAGES_PROJECT_IRI, forGroup = Some(OntologyConstants.KnoraBase.KnownUser), forResourceClass = None, forProperty = None, hasPermissions = Set(
-                PermissionADM.changeRightsPermission(OntologyConstants.KnoraBase.Creator),
-                PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember),
-                PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser)
+            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/00FF/d2", forProject = IMAGES_PROJECT_IRI, forGroup = Some(OntologyConstants.KnoraAdmin.KnownUser), forResourceClass = None, forProperty = None, hasPermissions = Set(
+                PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
+                PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser)
             ))
         )
 
@@ -124,13 +124,13 @@ object SharedPermissionsTestData {
     val perm003_a1: ap =
         ap(
             iri = "http://rdfh.ch/permissions/003-a1",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/003-a1", forProject = SharedTestDataV1.INCUNABULA_PROJECT_IRI, forGroup = OntologyConstants.KnoraBase.ProjectMember, hasPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission))
+            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/003-a1", forProject = SharedTestDataV1.INCUNABULA_PROJECT_IRI, forGroup = OntologyConstants.KnoraAdmin.ProjectMember, hasPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission))
         )
 
     val perm003_a2: ap =
         ap(
             iri = "http://rdfh.ch/permissions/003-a2",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/003-a2", forProject = SharedTestDataV1.INCUNABULA_PROJECT_IRI, forGroup = OntologyConstants.KnoraBase.ProjectAdmin, hasPermissions = Set(
+            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/003-a2", forProject = SharedTestDataV1.INCUNABULA_PROJECT_IRI, forGroup = OntologyConstants.KnoraAdmin.ProjectAdmin, hasPermissions = Set(
                                 PermissionADM.ProjectResourceCreateAllPermission,
                                 PermissionADM.ProjectAdminAllPermission
                             ))
@@ -140,10 +140,10 @@ object SharedPermissionsTestData {
         oap(
             iri = "http://data.knora.org/00014b43f902", // incunabula:page
             p = ObjectAccessPermissionADM(forResource = Some("http://data.knora.org/00014b43f902"), forValue = None, hasPermissions = Set(
-                                PermissionADM.changeRightsPermission(OntologyConstants.KnoraBase.Creator),
-                                PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember),
-                                PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser),
-                                PermissionADM.restrictedViewPermission(OntologyConstants.KnoraBase.UnknownUser)
+                                PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
+                                PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                                PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
+                                PermissionADM.restrictedViewPermission(OntologyConstants.KnoraAdmin.UnknownUser)
                             ))
         )
 
@@ -151,10 +151,10 @@ object SharedPermissionsTestData {
         oap(
             iri = "http://data.knora.org/00014b43f902/values/1ad3999ad60b", // knora-base:TextValue
             p = ObjectAccessPermissionADM(forResource = None, forValue = Some("http://data.knora.org/00014b43f902/values/1ad3999ad60b"), hasPermissions = Set(
-                                    PermissionADM.viewPermission(OntologyConstants.KnoraBase.UnknownUser),
-                                    PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser),
-                                    PermissionADM.viewPermission(OntologyConstants.KnoraBase.ProjectMember),
-                                    PermissionADM.changeRightsPermission(OntologyConstants.KnoraBase.Creator)
+                                    PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.UnknownUser),
+                                    PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
+                                    PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                                    PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator)
                                 ))
         )
 
@@ -164,14 +164,14 @@ object SharedPermissionsTestData {
             p = DefaultObjectAccessPermissionADM(
                 iri = "http://rdfh.ch/permissions/003-d1",
                 forProject = SharedTestDataV1.INCUNABULA_PROJECT_IRI,
-                forGroup = Some(OntologyConstants.KnoraBase.ProjectMember),
+                forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember),
                 forResourceClass = None,
                 forProperty = None,
                 hasPermissions = Set(
-                    PermissionADM.changeRightsPermission(OntologyConstants.KnoraBase.Creator),
-                    PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember),
-                    PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser),
-                    PermissionADM.restrictedViewPermission(OntologyConstants.KnoraBase.UnknownUser)
+                    PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
+                    PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                    PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
+                    PermissionADM.restrictedViewPermission(OntologyConstants.KnoraAdmin.UnknownUser)
                 ))
         )
 
@@ -185,10 +185,10 @@ object SharedPermissionsTestData {
                 forResourceClass = Some(INCUNABULA_BOOK_RESOURCE_CLASS),
                 forProperty = None,
                 hasPermissions = Set(
-                    PermissionADM.changeRightsPermission(OntologyConstants.KnoraBase.Creator),
-                    PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember),
-                    PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser),
-                    PermissionADM.restrictedViewPermission(OntologyConstants.KnoraBase.UnknownUser)
+                    PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
+                    PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                    PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
+                    PermissionADM.restrictedViewPermission(OntologyConstants.KnoraAdmin.UnknownUser)
                 ))
         )
 
@@ -202,9 +202,9 @@ object SharedPermissionsTestData {
                 forResourceClass = Some(INCUNABULA_PAGE_RESOURCE_CLASS),
                 forProperty = None,
                 hasPermissions = Set(
-                    PermissionADM.changeRightsPermission(OntologyConstants.KnoraBase.Creator),
-                    PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember),
-                    PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser)
+                    PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
+                    PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                    PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser)
                 ))
         )
 
@@ -215,13 +215,13 @@ object SharedPermissionsTestData {
     val perm005_a1: ap =
         ap(
             iri = "http://rdfh.ch/permissions/005-a1",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/005-a1", forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI, forGroup = OntologyConstants.KnoraBase.ProjectMember, hasPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission))
+            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/005-a1", forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI, forGroup = OntologyConstants.KnoraAdmin.ProjectMember, hasPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission))
         )
 
     val perm005_a2: ap =
         ap(
             iri = "http://rdfh.ch/permissions/005-a2",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/005-a2", forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI, forGroup = OntologyConstants.KnoraBase.ProjectAdmin, hasPermissions = Set(
+            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/005-a2", forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI, forGroup = OntologyConstants.KnoraAdmin.ProjectAdmin, hasPermissions = Set(
                                 PermissionADM.ProjectResourceCreateAllPermission,
                                 PermissionADM.ProjectAdminAllPermission
                             ))
@@ -230,11 +230,11 @@ object SharedPermissionsTestData {
     val perm005_d1: doap =
         doap(
             iri = "http://rdfh.ch/permissions/005-d1",
-            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/005-d1", forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI, forGroup = Some(OntologyConstants.KnoraBase.ProjectMember), forResourceClass = None, forProperty = None, hasPermissions = Set(
-                                PermissionADM.changeRightsPermission(OntologyConstants.KnoraBase.Creator),
-                                PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember),
-                                PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser),
-                                PermissionADM.restrictedViewPermission(OntologyConstants.KnoraBase.UnknownUser)
+            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/005-d1", forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI, forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember), forResourceClass = None, forProperty = None, hasPermissions = Set(
+                                PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
+                                PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                                PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
+                                PermissionADM.restrictedViewPermission(OntologyConstants.KnoraAdmin.UnknownUser)
                             ))
         )
 

--- a/webapi/src/test/scala/org/knora/webapi/SharedTestDataADM.scala
+++ b/webapi/src/test/scala/org/knora/webapi/SharedTestDataADM.scala
@@ -37,7 +37,7 @@ object SharedTestDataADM {
     /** System Admin Data                **/
     /** ***********************************/
 
-    val SYSTEM_PROJECT_IRI = OntologyConstants.KnoraBase.SystemProject // built-in project
+    val SYSTEM_PROJECT_IRI = OntologyConstants.KnoraAdmin.SystemProject // built-in project
 
     /* represents the user profile of 'root' as found in admin-data.ttl */
     def rootUser = UserADM(
@@ -54,7 +54,7 @@ object SharedTestDataADM {
         sessionId = None,
         permissions = PermissionsDataADM(
             groupsPerProject = Map(
-                SYSTEM_PROJECT_IRI -> List(s"${OntologyConstants.KnoraBase.SystemAdmin}")
+                SYSTEM_PROJECT_IRI -> List(s"${OntologyConstants.KnoraAdmin.SystemAdmin}")
             ),
             administrativePermissionsPerProject = Map.empty[IRI, Set[PermissionADM]]
         )
@@ -75,7 +75,7 @@ object SharedTestDataADM {
         sessionId = None,
         permissions = PermissionsDataADM(
             groupsPerProject = Map(
-                SYSTEM_PROJECT_IRI -> List(s"${OntologyConstants.KnoraBase.SystemAdmin}")
+                SYSTEM_PROJECT_IRI -> List(s"${OntologyConstants.KnoraAdmin.SystemAdmin}")
             )
         )
     )
@@ -131,8 +131,8 @@ object SharedTestDataADM {
         sessionId = None,
         permissions = PermissionsDataADM(
             groupsPerProject = Map(
-                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraBase.ProjectMember}", s"${OntologyConstants.KnoraBase.ProjectAdmin}"),
-                IMAGES_PROJECT_IRI -> List("http://rdfh.ch/groups/00FF/images-reviewer", s"${OntologyConstants.KnoraBase.ProjectMember}", s"${OntologyConstants.KnoraBase.ProjectAdmin}")
+                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraAdmin.ProjectMember}", s"${OntologyConstants.KnoraAdmin.ProjectAdmin}"),
+                IMAGES_PROJECT_IRI -> List("http://rdfh.ch/groups/00FF/images-reviewer", s"${OntologyConstants.KnoraAdmin.ProjectMember}", s"${OntologyConstants.KnoraAdmin.ProjectAdmin}")
             ),
             administrativePermissionsPerProject = Map(
                 INCUNABULA_PROJECT_IRI -> Set(
@@ -173,7 +173,7 @@ object SharedTestDataADM {
         sessionId = None,
         permissions = PermissionsDataADM(
             groupsPerProject = Map(
-                IMAGES_PROJECT_IRI -> List(OntologyConstants.KnoraBase.ProjectMember, OntologyConstants.KnoraBase.ProjectAdmin)
+                IMAGES_PROJECT_IRI -> List(OntologyConstants.KnoraAdmin.ProjectMember, OntologyConstants.KnoraAdmin.ProjectAdmin)
             ),
             administrativePermissionsPerProject = Map(
                 IMAGES_PROJECT_IRI -> Set(
@@ -199,7 +199,7 @@ object SharedTestDataADM {
         sessionId = None,
         permissions = PermissionsDataADM(
             groupsPerProject = Map(
-                IMAGES_PROJECT_IRI -> List(OntologyConstants.KnoraBase.ProjectMember)
+                IMAGES_PROJECT_IRI -> List(OntologyConstants.KnoraAdmin.ProjectMember)
             ),
             administrativePermissionsPerProject = Map(
                 IMAGES_PROJECT_IRI -> Set(
@@ -224,7 +224,7 @@ object SharedTestDataADM {
         sessionId = None,
         permissions = PermissionsDataADM(
             groupsPerProject = Map(
-                IMAGES_PROJECT_IRI -> List("http://rdfh.ch/groups/00FF/images-reviewer", s"${OntologyConstants.KnoraBase.ProjectMember}")
+                IMAGES_PROJECT_IRI -> List("http://rdfh.ch/groups/00FF/images-reviewer", s"${OntologyConstants.KnoraAdmin.ProjectMember}")
             ),
             administrativePermissionsPerProject = Map(
                 IMAGES_PROJECT_IRI -> Set(
@@ -304,7 +304,7 @@ object SharedTestDataADM {
         sessionId = None,
         permissions = PermissionsDataADM(
             groupsPerProject = Map(
-                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraBase.ProjectMember}", s"${OntologyConstants.KnoraBase.ProjectAdmin}")
+                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraAdmin.ProjectMember}", s"${OntologyConstants.KnoraAdmin.ProjectAdmin}")
             ),
             administrativePermissionsPerProject = Map(
                 INCUNABULA_PROJECT_IRI -> Set(
@@ -330,7 +330,7 @@ object SharedTestDataADM {
         sessionId = None,
         permissions = PermissionsDataADM(
             groupsPerProject = Map(
-                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraBase.ProjectMember}")
+                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraAdmin.ProjectMember}")
             ),
             administrativePermissionsPerProject = Map(
                 INCUNABULA_PROJECT_IRI -> Set(
@@ -355,7 +355,7 @@ object SharedTestDataADM {
         sessionId = None,
         permissions = PermissionsDataADM(
             groupsPerProject = Map(
-                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraBase.ProjectMember}")
+                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraAdmin.ProjectMember}")
             ),
             administrativePermissionsPerProject = Map(
                 INCUNABULA_PROJECT_IRI -> Set(
@@ -402,7 +402,7 @@ object SharedTestDataADM {
         sessionId = None,
         permissions = PermissionsDataADM(
             groupsPerProject = Map(
-                ANYTHING_PROJECT_IRI -> List(s"${OntologyConstants.KnoraBase.ProjectMember}")
+                ANYTHING_PROJECT_IRI -> List(s"${OntologyConstants.KnoraAdmin.ProjectMember}")
             ),
             administrativePermissionsPerProject = Map(
                 ANYTHING_PROJECT_IRI -> Set(
@@ -427,7 +427,7 @@ object SharedTestDataADM {
         sessionId = None,
         permissions = PermissionsDataADM(
             groupsPerProject = Map(
-                ANYTHING_PROJECT_IRI -> List(s"${OntologyConstants.KnoraBase.ProjectMember}")
+                ANYTHING_PROJECT_IRI -> List(s"${OntologyConstants.KnoraAdmin.ProjectMember}")
             ),
             administrativePermissionsPerProject = Map(
                 ANYTHING_PROJECT_IRI -> Set(

--- a/webapi/src/test/scala/org/knora/webapi/SharedTestDataV1.scala
+++ b/webapi/src/test/scala/org/knora/webapi/SharedTestDataV1.scala
@@ -34,7 +34,7 @@ object SharedTestDataV1 {
     /** System Admin Data                **/
     /** ***********************************/
 
-    val SYSTEM_PROJECT_IRI: IRI = OntologyConstants.KnoraBase.SystemProject // built-in project
+    val SYSTEM_PROJECT_IRI: IRI = OntologyConstants.KnoraAdmin.SystemProject // built-in project
 
     /* represents the user profile of 'root' as found in admin-data.ttl */
     def rootUser: UserProfileV1 = SharedTestDataADM.rootUser.asUserProfileV1
@@ -69,8 +69,8 @@ object SharedTestDataV1 {
         sessionId = None,
         permissionData = PermissionsDataADM(
             groupsPerProject = Map(
-                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraBase.ProjectMember}", s"${OntologyConstants.KnoraBase.ProjectAdmin}"),
-                IMAGES_PROJECT_IRI -> List("http://rdfh.ch/groups/00FF/images-reviewer", s"${OntologyConstants.KnoraBase.ProjectMember}", s"${OntologyConstants.KnoraBase.ProjectAdmin}")
+                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraAdmin.ProjectMember}", s"${OntologyConstants.KnoraAdmin.ProjectAdmin}"),
+                IMAGES_PROJECT_IRI -> List("http://rdfh.ch/groups/00FF/images-reviewer", s"${OntologyConstants.KnoraAdmin.ProjectMember}", s"${OntologyConstants.KnoraAdmin.ProjectAdmin}")
             ),
             administrativePermissionsPerProject = Map(
                 INCUNABULA_PROJECT_IRI -> Set(
@@ -113,7 +113,7 @@ object SharedTestDataV1 {
         sessionId = None,
         permissionData = PermissionsDataADM(
             groupsPerProject = Map(
-                IMAGES_PROJECT_IRI -> List(OntologyConstants.KnoraBase.ProjectMember, OntologyConstants.KnoraBase.ProjectAdmin)
+                IMAGES_PROJECT_IRI -> List(OntologyConstants.KnoraAdmin.ProjectMember, OntologyConstants.KnoraAdmin.ProjectAdmin)
             ),
             administrativePermissionsPerProject = Map(
                 IMAGES_PROJECT_IRI -> Set(
@@ -141,7 +141,7 @@ object SharedTestDataV1 {
         sessionId = None,
         permissionData = PermissionsDataADM(
             groupsPerProject = Map(
-                IMAGES_PROJECT_IRI -> List(OntologyConstants.KnoraBase.ProjectMember)
+                IMAGES_PROJECT_IRI -> List(OntologyConstants.KnoraAdmin.ProjectMember)
             ),
             administrativePermissionsPerProject = Map(
                 IMAGES_PROJECT_IRI -> Set(
@@ -168,7 +168,7 @@ object SharedTestDataV1 {
         sessionId = None,
         permissionData = PermissionsDataADM(
             groupsPerProject = Map(
-                IMAGES_PROJECT_IRI -> List("http://rdfh.ch/groups/00FF/images-reviewer", s"${OntologyConstants.KnoraBase.ProjectMember}")
+                IMAGES_PROJECT_IRI -> List("http://rdfh.ch/groups/00FF/images-reviewer", s"${OntologyConstants.KnoraAdmin.ProjectMember}")
             ),
             administrativePermissionsPerProject = Map(
                 IMAGES_PROJECT_IRI -> Set(
@@ -218,7 +218,7 @@ object SharedTestDataV1 {
         sessionId = None,
         permissionData = PermissionsDataADM(
             groupsPerProject = Map(
-                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraBase.ProjectMember}", s"${OntologyConstants.KnoraBase.ProjectAdmin}")
+                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraAdmin.ProjectMember}", s"${OntologyConstants.KnoraAdmin.ProjectAdmin}")
             ),
             administrativePermissionsPerProject = Map(
                 INCUNABULA_PROJECT_IRI -> Set(
@@ -246,7 +246,7 @@ object SharedTestDataV1 {
         sessionId = None,
         permissionData = PermissionsDataADM(
             groupsPerProject = Map(
-                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraBase.ProjectMember}")
+                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraAdmin.ProjectMember}")
             ),
             administrativePermissionsPerProject = Map(
                 INCUNABULA_PROJECT_IRI -> Set(
@@ -273,7 +273,7 @@ object SharedTestDataV1 {
         sessionId = None,
         permissionData = PermissionsDataADM(
             groupsPerProject = Map(
-                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraBase.ProjectMember}")
+                INCUNABULA_PROJECT_IRI -> List(s"${OntologyConstants.KnoraAdmin.ProjectMember}")
             ),
             administrativePermissionsPerProject = Map(
                 INCUNABULA_PROJECT_IRI -> Set(
@@ -320,7 +320,7 @@ object SharedTestDataV1 {
         sessionId = None,
         permissionData = PermissionsDataADM(
             groupsPerProject = Map(
-                ANYTHING_PROJECT_IRI -> List(OntologyConstants.KnoraBase.ProjectMember, OntologyConstants.KnoraBase.ProjectAdmin)
+                ANYTHING_PROJECT_IRI -> List(OntologyConstants.KnoraAdmin.ProjectMember, OntologyConstants.KnoraAdmin.ProjectAdmin)
             ),
             administrativePermissionsPerProject = Map(
                 ANYTHING_PROJECT_IRI -> Set(
@@ -347,7 +347,7 @@ object SharedTestDataV1 {
         sessionId = None,
         permissionData = PermissionsDataADM(
             groupsPerProject = Map(
-                ANYTHING_PROJECT_IRI -> List(OntologyConstants.KnoraBase.ProjectMember)
+                ANYTHING_PROJECT_IRI -> List(OntologyConstants.KnoraAdmin.ProjectMember)
             ),
             administrativePermissionsPerProject = Map(
                 ANYTHING_PROJECT_IRI -> Set(
@@ -373,7 +373,7 @@ object SharedTestDataV1 {
         sessionId = None,
         permissionData = PermissionsDataADM(
             groupsPerProject = Map(
-                ANYTHING_PROJECT_IRI -> List(OntologyConstants.KnoraBase.ProjectMember)
+                ANYTHING_PROJECT_IRI -> List(OntologyConstants.KnoraAdmin.ProjectMember)
             ),
             administrativePermissionsPerProject = Map(
                 ANYTHING_PROJECT_IRI -> Set(

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/OntologiesADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/OntologiesADME2ESpec.scala
@@ -55,7 +55,7 @@ class OntologiesADME2ESpec extends E2ESpec(OntologiesADME2ESpec.config) with Tri
 
         "return ontologies" in {
             val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
-            val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraBase.ProjectMember, "utf-8")
+            val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraAdmin.ProjectMember, "utf-8")
 
             val request = Get(baseApiUrl + s"/admin/ontologies")
             val response = singleAwaitingRequest(request, 1.seconds)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
@@ -54,7 +54,7 @@ class PermissionsADME2ESpec extends E2ESpec(PermissionsADME2ESpec.config) with T
 
         "return administrative permissions" in {
             val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
-            val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraBase.ProjectMember, "utf-8")
+            val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraAdmin.ProjectMember, "utf-8")
 
             val request = Get(baseApiUrl + s"/admin/permissions/$projectIri/$groupIri")
             val response = singleAwaitingRequest(request, 1.seconds)

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADMSpec.scala
@@ -250,7 +250,7 @@ class ListsMessagesADMSpec extends WordSpecLike with Matchers with ListADMJsonPr
 
             val thrown = the [BadRequestException] thrownBy payload.parseJson.convertTo[ChangeListInfoApiRequestADM]
 
-            thrown.getMessage should equal (REQUEST_NOT_CHANGING_DATA_ERROR)
+            thrown.getMessage should equal (REQUEST_REMOVING_ALL_LABELS_ERROR)
 
         }
 

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderADMSpec.scala
@@ -195,7 +195,7 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
             "return AdministrativePermission for project and group" in {
                 actorUnderTest ! AdministrativePermissionForProjectGroupGetRequestADM(
                     projectIri = IMAGES_PROJECT_IRI,
-                    groupIri = OntologyConstants.KnoraBase.ProjectMember,
+                    groupIri = OntologyConstants.KnoraAdmin.ProjectMember,
                     requestingUser = rootUser
                 )
                 expectMsg(AdministrativePermissionForProjectGroupGetResponseADM(perm002_a1.p))
@@ -225,13 +225,13 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
                     newAdministrativePermission = NewAdministrativePermissionADM(
                         iri = iri,
                         forProject = IMAGES_PROJECT_IRI,
-                        forGroup = OntologyConstants.KnoraBase.ProjectMember,
+                        forGroup = OntologyConstants.KnoraAdmin.ProjectMember,
                         hasOldPermissions = Set.empty[PermissionADM],
                         hasNewPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission)
                     ),
                     requestingUser = rootUser
                 )
-                expectMsg(Failure(DuplicateValueException(s"Permission for project: '${IMAGES_PROJECT_IRI}' and group: '${OntologyConstants.KnoraBase.ProjectMember}' combination already exists.")))
+                expectMsg(Failure(DuplicateValueException(s"Permission for project: '${IMAGES_PROJECT_IRI}' and group: '${OntologyConstants.KnoraAdmin.ProjectMember}' combination already exists.")))
             }
 
             "create and return an administrative permission " ignore {}
@@ -276,7 +276,7 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
             "return DefaultObjectAccessPermission for project and group" in {
                 actorUnderTest ! DefaultObjectAccessPermissionGetRequestADM(
                     projectIRI = INCUNABULA_PROJECT_IRI,
-                    groupIRI = Some(OntologyConstants.KnoraBase.ProjectMember),
+                    groupIRI = Some(OntologyConstants.KnoraAdmin.ProjectMember),
                     resourceClassIRI = None,
                     propertyIRI = None,
                     requestingUser = rootUser
@@ -465,11 +465,11 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
             }
 
             "return a combined and max set of permissions (default object access permissions) defined on the supplied groups (helper method used in queries before)" in {
-                val groups = List("http://rdfh.ch/groups/images-reviewer", s"${OntologyConstants.KnoraBase.ProjectMember}", s"${OntologyConstants.KnoraBase.ProjectAdmin}")
+                val groups = List("http://rdfh.ch/groups/images-reviewer", s"${OntologyConstants.KnoraAdmin.ProjectMember}", s"${OntologyConstants.KnoraAdmin.ProjectAdmin}")
                 val expected = Set(
-                        PermissionADM.changeRightsPermission(OntologyConstants.KnoraBase.Creator),
-                        PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser),
-                        PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember)
+                        PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
+                        PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
+                        PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember)
                     )
                 val result: Set[PermissionADM] = Await.result(underlyingActorUnderTest.defaultObjectAccessPermissionsForGroupsGetADM(IMAGES_PROJECT_IRI, groups), 1.seconds)
                 result should equal(expected)

--- a/webapi/src/test/scala/org/knora/webapi/util/PermissionUtilV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/PermissionUtilV1Spec.scala
@@ -58,10 +58,10 @@ class PermissionUtilV1Spec extends CoreSpec("PermissionUtilSpec") with ImplicitS
     val permissionLiteral = "RV knora-base:UnknownUser|V knora-base:KnownUser|M knora-base:ProjectMember|CR knora-base:Creator"
 
     val parsedPermissionLiteral = Map(
-        "RV" -> Set(OntologyConstants.KnoraBase.UnknownUser),
-        "V" -> Set(OntologyConstants.KnoraBase.KnownUser),
-        "M" -> Set(OntologyConstants.KnoraBase.ProjectMember),
-        "CR" -> Set(OntologyConstants.KnoraBase.Creator)
+        "RV" -> Set(OntologyConstants.KnoraAdmin.UnknownUser),
+        "V" -> Set(OntologyConstants.KnoraAdmin.KnownUser),
+        "M" -> Set(OntologyConstants.KnoraAdmin.ProjectMember),
+        "CR" -> Set(OntologyConstants.KnoraAdmin.Creator)
     )
 
     "PermissionUtil " should {
@@ -130,7 +130,7 @@ class PermissionUtilV1Spec extends CoreSpec("PermissionUtilSpec") with ImplicitS
             val assertions: Seq[(IRI, String)] = Seq(
                 (OntologyConstants.KnoraBase.AttachedToUser, "http://rdfh.ch/users/91e19f1e01"),
                 (OntologyConstants.KnoraBase.AttachedToProject, SharedTestDataV1.INCUNABULA_PROJECT_IRI),
-                (OntologyConstants.KnoraBase.HasPermissions, permissionLiteral)
+                (OntologyConstants.KnoraAdmin.HasPermissions, permissionLiteral)
             )
             PermissionUtilADM.getUserPermissionV1FromAssertions(
                 subjectIri = "http://rdfh.ch/00014b43f902",
@@ -153,11 +153,11 @@ class PermissionUtilV1Spec extends CoreSpec("PermissionUtilSpec") with ImplicitS
             val hasPermissionsString = "M knora-base:Creator,knora-base:ProjectMember|V knora-base:KnownUser,http://rdfh.ch/groups/customgroup|RV knora-base:UnknownUser"
 
             val permissionsSet = Set(
-                PermissionADM.modifyPermission(OntologyConstants.KnoraBase.Creator),
-                PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember),
-                PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser),
+                PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.Creator),
+                PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
                 PermissionADM.viewPermission("http://rdfh.ch/groups/customgroup"),
-                PermissionADM.restrictedViewPermission(OntologyConstants.KnoraBase.UnknownUser)
+                PermissionADM.restrictedViewPermission(OntologyConstants.KnoraAdmin.UnknownUser)
             )
 
             PermissionUtilADM.parsePermissionsWithType(Some(hasPermissionsString), PermissionType.OAP) should contain allElementsOf permissionsSet
@@ -178,7 +178,7 @@ class PermissionUtilV1Spec extends CoreSpec("PermissionUtilSpec") with ImplicitS
 
         "build a 'PermissionV1' object" in {
             PermissionUtilADM.buildPermissionObject(
-                name = OntologyConstants.KnoraBase.ProjectResourceCreateRestrictedPermission,
+                name = OntologyConstants.KnoraAdmin.ProjectResourceCreateRestrictedPermission,
                 iris = Set("1", "2", "3")
             ) should equal(
                 Set(
@@ -236,9 +236,9 @@ class PermissionUtilV1Spec extends CoreSpec("PermissionUtilSpec") with ImplicitS
             val permissions = Set(
                 PermissionADM.changeRightsPermission("1"),
                 PermissionADM.deletePermission("2"),
-                PermissionADM.changeRightsPermission(OntologyConstants.KnoraBase.Creator),
-                PermissionADM.modifyPermission(OntologyConstants.KnoraBase.ProjectMember),
-                PermissionADM.viewPermission(OntologyConstants.KnoraBase.KnownUser)
+                PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
+                PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser)
             )
 
             val permissionsString = "CR knora-base:Creator,1|D 2|M knora-base:ProjectMember|V knora-base:KnownUser"


### PR DESCRIPTION
### Summary

- [x] Make `projectShortcode` a requiered propterty in `knora-base.ttl`
- [ ] Change ProjectADM to require `projectShortcode`
- [x] Change `knora-admin.ttl` to `http://www.knora.org/ontology/knora-admin`
- [x] Add `KnoraAdmin` object to `OntologyConstants` and move all relevant properties
- [x] Make necessary changes to source-code so that `OntologyConstants` work again.
- [ ] Change `admin-data.ttl`
- [ ] Change `permissions-data.ttl`
- [ ] Change groups inside permission strings from `knora-base:GroupName` to `knora-admin:GroupName` in all test data.
- [ ] Maybe create a `TransformData` method for renaming `knora-base` into `knora-admin` for the data? Maybe reuse the existing (now obsolete) `knora-base:Owner` to `knora-base:Creator` method.
- [ ] Separate bare minimum data for `admin-data.ttl` and `permissions-data.ttl` into separate files and only load these in the `knora-prod` init script.

### Issues

- resolves #777 
- resolves #787