### PR TITLE
feature (webapi): OpenAPI / Swagger API documentation generation

### DIFF
--- a/docs/rst/03-knora-api-server/api_admin/api-general.rst
+++ b/docs/rst/03-knora-api-server/api_admin/api-general.rst
@@ -1,0 +1,74 @@
+.. Copyright © 2015-2018 the contributors (see Contributors.md).
+
+   This file is part of Knora.
+
+   Knora is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Knora is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public
+   License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+
+
+Introduction: Using Admin API
+=============================
+
+RESTful API
+-----------
+
+Knora Admin API is a RESTful API that allows for reading and adding of administrative resources from and to Knora and
+changing their values using HTTP requests. The actual data is submitted as JSON (request and response format). The
+diverse HTTP methods are applied according to the widespread practice of RESTful APIs: GET for reading, POST for adding,
+PUT for changing resources and values, and DELETE to delete resources or values (see RESTful_API_).
+
+.. _RESTful_API: http://www.restapitutorial.com/lessons/httpmethods.html
+
+Knora IRIs
+----------
+
+Every resource that is created or hosted by Knora is identified by a unique id, a so called Internationalized Resource
+Identifier (IRI). The IRI is required for every API operation to identify the resource in question. A Knora IRI has
+itself the format of a URL. For some API operations, the IRI has to be URL-encoded (HTTP GET requests).
+
+Admin Path Segment
+------------------
+
+Every request to Admin API includes ``admin`` as a path segment, e.g. ``http://host/admin/users/http%3A%2F%2Frdfh.ch%2Fusers%2Froot``.
+
+Knora API Response Format
+-------------------------
+
+In case an API request could be handled successfully, Knora responds with a 200 HTTP status code. The actual answer
+from Knora (the representation of the requested resource or information about the executed API operation) is sent in the
+HTTP body, encoded as JSON (using UTF-8).
+
+Placeholder ``host`` in sample URLs
+-----------------------------------
+
+Please note that all the sample URLs used in this documentation contain ``host`` as a placeholder. The placeholder
+``host`` has to be replaced by the actual hostname (and port) of the server the Knora instance is running on.
+
+Authentication
+--------------
+
+For all API operations that target at changing resources or values, the client has to provide credentials (username and
+password) so that the API server can authenticate the user making the request. Credentials can be sent as a part of the
+HTTP header or as parts of the URL (see :ref:`authentication`).
+
+OpenAPI / Swagger
+-----------------
+
+The Admin API uses OpenAPI_ for documentation purposes.
+
+.. _OpenAPI: http://www.restapitutorial.com/lessons/httpmethods.html
+
+Different Admin API Endpoints
+-----------------------------
+
+- TBD -

--- a/docs/rst/03-knora-api-server/api_admin/index.rst
+++ b/docs/rst/03-knora-api-server/api_admin/index.rst
@@ -15,26 +15,11 @@
    You should have received a copy of the GNU Affero General Public
    License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
 
-.. _knora-api-server:
-
-####################
-The Knora API Server
-####################
-
-The Knora API server implements Knora's HTTP-based API, and manages data
-stored in an RDF triplestore and in files. It is designed to work with any
-standards-compliant RDF triplestore, and is configured to work out of the box
-with `Ontotext GraphDB`_ and `Apache Jena`_.
+******************************
+Using ADMIN API
+******************************
 
 .. toctree::
    :maxdepth: 2
 
-   deployment/index
-   design-documentation/index
-   development/index
-   api_v1/index
-   api_v2/index
-   api_admin/index
-
-.. _Ontotext GraphDB: http://ontotext.com/products/graphdb/
-.. _Apache Jena: https://jena.apache.org/
+   api-general

--- a/webapi/WebapiBuild.sbt
+++ b/webapi/WebapiBuild.sbt
@@ -195,6 +195,7 @@ lazy val webApiLibs = Seq(
     library.scalaXml,
     library.scallop,
     library.springSecurityCore,
+    library.swaggerAkkaHttp,
     library.xmlunitCore
 )
 
@@ -285,6 +286,9 @@ lazy val library =
         val jacksonScala           = "com.fasterxml.jackson.module" %% "jackson-module-scala"     % "2.9.4"
 
         val jsonldJava             = "com.github.jsonld-java"        % "jsonld-java"              % "0.11.1"
+
+        // swagger (api documentation)
+        val swaggerAkkaHttp        = "com.github.swagger-akka-http" %% "swagger-akka-http"        % "0.14.0"
     }
 
 lazy val javaRunOptions = Seq(

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -234,6 +234,8 @@ akka {
 
 app {
 
+    print-config = true // If true, key configuration parameters will be printed out at startup.
+
     default-timeout = 60 // seconds
 
     default-restore-timeout = 360 // seconds

--- a/webapi/src/main/scala/org/knora/webapi/Settings.scala
+++ b/webapi/src/main/scala/org/knora/webapi/Settings.scala
@@ -36,6 +36,9 @@ import scala.concurrent.duration._
   */
 class SettingsImpl(config: Config) extends Extension {
 
+    // print config
+    val printConfig: Boolean = config.getBoolean("app.print-config")
+
     // used for communication inside the knora stack
     val internalKnoraApiHost: String = config.getString("app.knora-api.internal-host")
     val internalKnoraApiPort: Int = config.getInt("app.knora-api.internal-port")

--- a/webapi/src/main/scala/org/knora/webapi/routing/SwaggerDocsRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/SwaggerDocsRoute.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015-2018 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.routing
+
+import akka.actor.ActorSystem
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.server.Route
+import com.github.swagger.akka.SwaggerHttpService
+import com.github.swagger.akka.model.Info
+import io.swagger.models.auth.BasicAuthDefinition
+import io.swagger.models.{ExternalDocs, Scheme}
+import org.knora.webapi.SettingsImpl
+import org.knora.webapi.routing.admin.UsersRouteADM
+
+import scala.concurrent.ExecutionContextExecutor
+
+class SwaggerDocsRoute(_system: ActorSystem, settings: SettingsImpl, log: LoggingAdapter) extends SwaggerHttpService {
+
+    implicit val system: ActorSystem = _system
+    implicit val executionContext: ExecutionContextExecutor = system.dispatcher
+
+    // List all routes here
+    override val apiClasses: Set[Class[_]] = Set(
+        classOf[UsersRouteADM]
+    )
+
+    override val schemes: List[Scheme] = if (settings.externalKnoraApiProtocol == "http") {
+        List(Scheme.HTTP)
+    } else if (settings.externalKnoraApiProtocol == "https") {
+        List(Scheme.HTTPS)
+    } else {
+        List(Scheme.HTTP)
+    }
+
+    override val host = settings.externalKnoraApiHostPort //the url of your api, not swagger's json endpoint
+    override val basePath = "/"    //the basePath for the API you are exposing
+    override val apiDocsPath = "api-docs" //where you want the swagger-json endpoint exposed
+    override val info = Info(version = "1.3.0") //provides license and other description details
+    override val externalDocs = Some(new ExternalDocs("Knora Docs", "http://www.knora.org/documentation/manual/rst/"))
+    override val securitySchemeDefinitions = Map("basicAuth" -> new BasicAuthDefinition())
+
+    def knoraApiPath: Route = {
+        routes
+    }
+
+}

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/GroupsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/GroupsRouteADM.scala
@@ -26,6 +26,8 @@ import akka.event.LoggingAdapter
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.util.Timeout
+import io.swagger.annotations._
+import javax.ws.rs.Path
 import org.knora.webapi.messages.admin.responder.groupsmessages._
 import org.knora.webapi.routing.{Authenticator, RouteUtilADM}
 import org.knora.webapi.util.StringFormatter
@@ -33,6 +35,12 @@ import org.knora.webapi.{BadRequestException, SettingsImpl}
 
 import scala.concurrent.ExecutionContextExecutor
 
+/**
+  * Provides a spray-routing function for API routes that deal with groups.
+  */
+
+@Api(value = "/admin/groups", produces = "application/json")
+@Path("/admin/groups")
 object GroupsRouteADM extends Authenticator with GroupsADMJsonProtocol {
 
     def knoraApiPath(_system: ActorSystem, settings: SettingsImpl, log: LoggingAdapter): Route = {

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ListsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ListsRouteADM.scala
@@ -26,6 +26,8 @@ import akka.event.LoggingAdapter
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.util.Timeout
+import io.swagger.annotations.Api
+import javax.ws.rs.Path
 import org.knora.webapi.messages.admin.responder.listsmessages._
 import org.knora.webapi.routing.{Authenticator, RouteUtilADM}
 import org.knora.webapi.util.StringFormatter
@@ -36,6 +38,9 @@ import scala.concurrent.ExecutionContextExecutor
 /**
   * Provides a spray-routing function for API routes that deal with lists.
   */
+
+@Api(value = "/admin/lists", produces = "application/json")
+@Path("/admin/lists")
 object ListsRouteADM extends Authenticator with ListADMJsonProtocol {
 
     def knoraApiPath(_system: ActorSystem, settings: SettingsImpl, log: LoggingAdapter): Route = {

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
@@ -24,6 +24,8 @@ import akka.event.LoggingAdapter
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.util.Timeout
+import io.swagger.annotations.Api
+import javax.ws.rs.Path
 import org.apache.commons.validator.routines.UrlValidator
 import org.knora.webapi.SettingsImpl
 import org.knora.webapi.messages.admin.responder.permissionsmessages.{AdministrativePermissionForProjectGroupGetRequestADM, PermissionType}
@@ -31,6 +33,8 @@ import org.knora.webapi.routing.{Authenticator, RouteUtilADM}
 
 import scala.concurrent.ExecutionContextExecutor
 
+@Api(value = "/admin/permissions", produces = "application/json")
+@Path("/admin/permissions")
 object PermissionsRouteADM extends Authenticator {
 
     private val schemes = Array("http", "https")

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteADM.scala
@@ -27,6 +27,8 @@ import akka.event.LoggingAdapter
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.util.Timeout
+import io.swagger.annotations.Api
+import javax.ws.rs.Path
 import org.apache.commons.validator.routines.UrlValidator
 import org.knora.webapi.messages.admin.responder.projectsmessages._
 import org.knora.webapi.routing.{Authenticator, RouteUtilADM}
@@ -35,6 +37,9 @@ import org.knora.webapi.{BadRequestException, SettingsImpl}
 
 import scala.concurrent.ExecutionContextExecutor
 
+
+@Api(value = "/admin/projects", produces = "application/json")
+@Path("/admin/projects")
 object ProjectsRouteADM extends Authenticator with ProjectsADMJsonProtocol {
 
     private val schemes = Array("http", "https")

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/StoreRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/StoreRouteADM.scala
@@ -24,6 +24,8 @@ import akka.event.LoggingAdapter
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.util.Timeout
+import io.swagger.annotations.Api
+import javax.ws.rs.Path
 import org.knora.webapi.SettingsImpl
 import org.knora.webapi.messages.admin.responder.storesmessages.{ResetTriplestoreContentRequestADM, StoresADMJsonProtocol}
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
@@ -34,6 +36,9 @@ import scala.concurrent.duration._
 /**
   * A route used to send requests which can directly affect the data stored inside the triplestore.
   */
+
+@Api(value = "/admin/store", produces = "application/json")
+@Path("/admin/store")
 object StoreRouteADM extends Authenticator with StoresADMJsonProtocol {
 
     def knoraApiPath(_system: ActorSystem, settings: SettingsImpl, log: LoggingAdapter) = Route {

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
@@ -26,8 +26,9 @@ import akka.event.LoggingAdapter
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.util.Timeout
+import io.swagger.annotations._
+import javax.ws.rs.Path
 import org.knora.webapi._
-
 import org.knora.webapi.messages.admin.responder.usersmessages.UsersADMJsonProtocol._
 import org.knora.webapi.messages.admin.responder.usersmessages._
 import org.knora.webapi.routing.{Authenticator, RouteUtilADM}
@@ -36,356 +37,57 @@ import org.knora.webapi.util.StringFormatter
 import scala.concurrent.ExecutionContextExecutor
 
 /**
-  * Provides a spray-routing function for API routes that deal with lists.
+  * Provides a spray-routing function for API routes that deal with users.
   */
-object UsersRouteADM extends Authenticator {
 
-    def knoraApiPath(_system: ActorSystem, settings: SettingsImpl, log: LoggingAdapter): Route = {
+@Api(value = "/admin/users", produces = "application/json")
+@Path("/admin/users")
+class UsersRouteADM(_system: ActorSystem, settings: SettingsImpl, log: LoggingAdapter) extends Authenticator {
 
+    implicit val system: ActorSystem = _system
+    implicit val executionContext: ExecutionContextExecutor = system.dispatcher
+    implicit val timeout: Timeout = settings.defaultTimeout
+    val responderManager = system.actorSelection("/user/responderManager")
+    val stringFormatter = StringFormatter.getGeneralInstance
 
-        implicit val system: ActorSystem = _system
-        implicit val executionContext: ExecutionContextExecutor = system.dispatcher
-        implicit val timeout: Timeout = settings.defaultTimeout
-        val responderManager = system.actorSelection("/user/responderManager")
-        val stringFormatter = StringFormatter.getGeneralInstance
+    @ApiOperation(value = "Get users", nickname = "getUsers", httpMethod = "GET", response = classOf[UsersGetResponseADM])
+    @ApiResponses(Array(
+        new ApiResponse(code = 500, message = "Internal server error")
+    ))
+    /* return all users */
+    def getUsers = path("admin" / "users") {
+        get {
+            requestContext =>
+                val requestingUser = getUserADM(requestContext)
+                val requestMessage = UsersGetRequestADM(requestingUser = requestingUser)
 
-        path("admin" / "users") {
-            get {
-                /* return all users */
-                requestContext =>
-                    val requestingUser = getUserADM(requestContext)
-                    val requestMessage = UsersGetRequestADM(requestingUser = requestingUser)
+                RouteUtilADM.runJsonRoute(
+                    requestMessage,
+                    requestContext,
+                    settings,
+                    responderManager,
+                    log
+                )
+        }
+    }
 
-                    RouteUtilADM.runJsonRoute(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            } ~
-            post {
-                /* create a new user */
-                entity(as[CreateUserApiRequestADM]) { apiRequest =>
-                    requestContext =>
-                        val requestingUser = getUserADM(requestContext)
-
-                        val requestMessage = UserCreateRequestADM(
-                            createRequest = apiRequest,
-                            requestingUser = requestingUser,
-                            apiRequestID = UUID.randomUUID()
-                        )
-
-                        RouteUtilADM.runJsonRoute(
-                            requestMessage,
-                            requestContext,
-                            settings,
-                            responderManager,
-                            log
-                        )
-                }
-            }
-        } ~
-        path("admin" / "users" / Segment) { value =>
-            get {
-                /* return a single user identified by iri or email */
-                parameters("identifier" ? "iri") { (identifier: String) =>
-                    requestContext =>
-                        val requestingUser = getUserADM(requestContext)
-
-                        /* check if email or iri was supplied */
-                        val requestMessage = if (identifier == "email") {
-                            UserGetRequestADM(maybeIri = None, maybeEmail = Some(value), UserInformationTypeADM.RESTRICTED, requestingUser)
-                        } else {
-                            val userIri = stringFormatter.validateAndEscapeIri(value, throw BadRequestException(s"Invalid user IRI $value"))
-                            UserGetRequestADM(maybeIri = Some(userIri), maybeEmail = None, UserInformationTypeADM.RESTRICTED, requestingUser)
-                        }
-                        RouteUtilADM.runJsonRoute(
-                            requestMessage,
-                            requestContext,
-                            settings,
-                            responderManager,
-                            log
-                        )
-                }
-            } ~
-            put {
-                /* update a user identified by iri */
-                entity(as[ChangeUserApiRequestADM]) { apiRequest =>
-                    requestContext =>
-
-                        val userIri = stringFormatter.validateAndEscapeIri(value, throw BadRequestException(s"Invalid user IRI $value"))
-                        val requestingUser = getUserADM(requestContext)
-
-                        /* the api request is already checked at time of creation. see case class. */
-
-                        val requestMessage = if (apiRequest.oldPassword.isDefined && apiRequest.newPassword.isDefined) {
-                            /* update existing user's password */
-                            UserChangePasswordRequestADM(
-                                userIri = userIri,
-                                changeUserRequest = apiRequest,
-                                requestingUser,
-                                apiRequestID = UUID.randomUUID()
-                            )
-                        } else if (apiRequest.status.isDefined) {
-                            /* update existing user's status */
-                            UserChangeStatusRequestADM(
-                                userIri,
-                                changeUserRequest = apiRequest,
-                                requestingUser,
-                                apiRequestID = UUID.randomUUID()
-                            )
-                        } else if (apiRequest.systemAdmin.isDefined) {
-                            /* update existing user's system admin membership status */
-                            UserChangeSystemAdminMembershipStatusRequestADM(
-                                userIri,
-                                changeUserRequest = apiRequest,
-                                requestingUser,
-                                apiRequestID = UUID.randomUUID()
-                            )
-                        } else {
-                            /* update existing user's basic information */
-                            UserChangeBasicUserInformationRequestADM(
-                                userIri,
-                                changeUserRequest = apiRequest,
-                                requestingUser,
-                                apiRequestID = UUID.randomUUID()
-                            )
-                        }
-
-                        RouteUtilADM.runJsonRoute(
-                            requestMessage,
-                            requestContext,
-                            settings,
-                            responderManager,
-                            log
-                        )
-                }
-            } ~
-            delete {
-                /* delete a user identified by iri */
-                requestContext => {
-                    val userIri = stringFormatter.validateAndEscapeIri(value, throw BadRequestException(s"Invalid user IRI $value"))
-                    val requestingUser = getUserADM(requestContext)
-
-                    /* update existing user's status to false */
-                    val requestMessage = UserChangeStatusRequestADM(
-                        userIri,
-                        changeUserRequest = ChangeUserApiRequestADM(status = Some(false)),
-                        requestingUser,
-                        apiRequestID = UUID.randomUUID()
-                    )
-
-                    RouteUtilADM.runJsonRoute(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-                }
-            }
-        } ~
-        path("admin" / "users" / "projects" / Segment) { userIri =>
-            get {
-                /* get user's project memberships */
+    @ApiOperation(value = "Add new user", nickname = "addUser", httpMethod = "POST", response = classOf[UserOperationResponseADM])
+    @ApiImplicitParams(Array(
+        new ApiImplicitParam(name = "body", value = "\"user\" to create", required = true,
+            dataTypeClass = classOf[CreateUserApiRequestADM], paramType = "body")
+    ))
+    @ApiResponses(Array(
+        new ApiResponse(code = 500, message = "Internal server error")
+    ))
+    /* create a new user */
+    def postUser = path("admin" / "users") {
+        post {
+            entity(as[CreateUserApiRequestADM]) { apiRequest =>
                 requestContext =>
                     val requestingUser = getUserADM(requestContext)
 
-                    val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
-
-                    val requestMessage = UserProjectMembershipsGetRequestADM(
-                        userIri = checkedUserIri,
-                        requestingUser = requestingUser,
-                        apiRequestID = UUID.randomUUID()
-                    )
-
-                    RouteUtilADM.runJsonRoute(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            }
-        } ~
-        path("admin" / "users" / "projects" / Segment / Segment) { (userIri, projectIri) =>
-            post {
-                /* add user to project */
-                requestContext =>
-                    val requestingUser = getUserADM(requestContext)
-
-                    val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
-                    val checkedProjectIri = stringFormatter.validateAndEscapeIri(projectIri, throw BadRequestException(s"Invalid project IRI $projectIri"))
-
-                    val requestMessage = UserProjectMembershipAddRequestADM(
-                        userIri = checkedUserIri,
-                        projectIri = checkedProjectIri,
-                        requestingUser = requestingUser,
-                        apiRequestID = UUID.randomUUID()
-                    )
-
-                    RouteUtilADM.runJsonRoute(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            } ~
-            delete {
-                /* remove user from project (and all groups belonging to this project) */
-                requestContext =>
-                    val requestingUser = getUserADM(requestContext)
-
-                    val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
-                    val checkedProjectIri = stringFormatter.validateAndEscapeIri(projectIri, throw BadRequestException(s"Invalid project IRI $projectIri"))
-
-                    val requestMessage = UserProjectMembershipRemoveRequestADM(
-                        userIri = checkedUserIri,
-                        projectIri = checkedProjectIri,
-                        requestingUser = requestingUser,
-                        apiRequestID = UUID.randomUUID()
-                    )
-
-                    RouteUtilADM.runJsonRoute(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            }
-        } ~
-        path("admin" / "users" / "projects-admin" / Segment) { userIri =>
-            get {
-                /* get user's project admin memberships */
-                requestContext =>
-                    val requestingUser = getUserADM(requestContext)
-
-                    val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
-
-                    val requestMessage = UserProjectAdminMembershipsGetRequestADM(
-                        userIri = checkedUserIri,
-                        requestingUser = requestingUser,
-                        apiRequestID = UUID.randomUUID()
-                    )
-
-                    RouteUtilADM.runJsonRoute(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            }
-        } ~
-        path("admin" / "users" / "projects-admin" / Segment / Segment) { (userIri, projectIri) =>
-            post {
-                /* add user to project admin */
-                requestContext =>
-                    val requestingUser = getUserADM(requestContext)
-
-                    val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
-                    val checkedProjectIri = stringFormatter.validateAndEscapeIri(projectIri, throw BadRequestException(s"Invalid project IRI $projectIri"))
-
-                    val requestMessage = UserProjectAdminMembershipAddRequestADM(
-                        userIri = checkedUserIri,
-                        projectIri = checkedProjectIri,
-                        requestingUser = requestingUser,
-                        apiRequestID = UUID.randomUUID()
-                    )
-
-                    RouteUtilADM.runJsonRoute(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            } ~
-            delete {
-                /* remove user from project admin */
-                requestContext =>
-                    val requestingUser = getUserADM(requestContext)
-
-                    val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
-                    val checkedProjectIri = stringFormatter.validateAndEscapeIri(projectIri, throw BadRequestException(s"Invalid project IRI $projectIri"))
-
-                    val requestMessage = UserProjectAdminMembershipRemoveRequestADM(
-                        userIri = checkedUserIri,
-                        projectIri = checkedProjectIri,
-                        requestingUser = requestingUser,
-                        apiRequestID = UUID.randomUUID()
-                    )
-
-                    RouteUtilADM.runJsonRoute(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            }
-        } ~
-        path("admin" / "users" / "groups" / Segment) { userIri =>
-            get {
-                /* get user's group memberships */
-                requestContext =>
-                    val requestingUser = getUserADM(requestContext)
-
-                    val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
-
-                    val requestMessage = UserGroupMembershipsGetRequestADM(
-                        userIri = checkedUserIri,
-                        requestingUser = requestingUser,
-                        apiRequestID = UUID.randomUUID()
-                    )
-
-                    RouteUtilADM.runJsonRoute(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            }
-        } ~
-        path("admin" / "users" / "groups" / Segment / Segment) { (userIri, groupIri) =>
-            post {
-                /* add user to group */
-                requestContext =>
-                    val requestingUser = getUserADM(requestContext)
-
-                    val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
-                    val checkedGroupIri = stringFormatter.validateAndEscapeIri(groupIri, throw BadRequestException(s"Invalid group IRI $groupIri"))
-
-                    val requestMessage = UserGroupMembershipAddRequestADM(
-                        userIri = checkedUserIri,
-                        groupIri = checkedGroupIri,
-                        requestingUser = requestingUser,
-                        apiRequestID = UUID.randomUUID()
-                    )
-
-                    RouteUtilADM.runJsonRoute(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            } ~
-            delete {
-                /* remove user from group */
-                requestContext =>
-                    val requestingUser = getUserADM(requestContext)
-
-                    val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
-                    val checkedGroupIri = stringFormatter.validateAndEscapeIri(groupIri, throw BadRequestException(s"Invalid group IRI $groupIri"))
-
-                    val requestMessage = UserGroupMembershipRemoveRequestADM(
-                        userIri = checkedUserIri,
-                        groupIri = checkedGroupIri,
+                    val requestMessage = UserCreateRequestADM(
+                        createRequest = apiRequest,
                         requestingUser = requestingUser,
                         apiRequestID = UUID.randomUUID()
                     )
@@ -400,4 +102,332 @@ object UsersRouteADM extends Authenticator {
             }
         }
     }
+
+    @Path("/{IRI}")
+    @ApiOperation(value = "Return a single user identified by IRI or Email", notes = "", nickname = "getUser", httpMethod = "GET")
+    @ApiImplicitParams(Array(
+        new ApiImplicitParam(name = "name", value = "Name of person to greet", required = false, dataType = "string", paramType = "path")
+    ))
+    @ApiResponses(Array(
+        new ApiResponse(code = 200, message = "Return User", response = classOf[UserResponseADM]),
+        new ApiResponse(code = 500, message = "Internal server error")
+    ))
+    /* return a single user identified by iri or email */
+    def getUser = path("admin" / "users" / Segment) { value =>
+        get {
+            parameters("identifier" ? "iri") { (identifier: String) =>
+                requestContext =>
+                    val requestingUser = getUserADM(requestContext)
+
+                    /* check if email or iri was supplied */
+                    val requestMessage = if (identifier == "email") {
+                        UserGetRequestADM(maybeIri = None, maybeEmail = Some(value), UserInformationTypeADM.RESTRICTED, requestingUser)
+                    } else {
+                        val userIri = stringFormatter.validateAndEscapeIri(value, throw BadRequestException(s"Invalid user IRI $value"))
+                        UserGetRequestADM(maybeIri = Some(userIri), maybeEmail = None, UserInformationTypeADM.RESTRICTED, requestingUser)
+                    }
+                    RouteUtilADM.runJsonRoute(
+                        requestMessage,
+                        requestContext,
+                        settings,
+                        responderManager,
+                        log
+                    )
+            }
+        }
+    }
+
+    /* concatenate paths in the CORRECT order and return */
+    def knoraApiPath: Route = getUsers ~ postUser ~ getUser ~
+            path("admin" / "users" / Segment) { value =>
+                put {
+                    /* update a user identified by iri */
+                    entity(as[ChangeUserApiRequestADM]) { apiRequest =>
+                        requestContext =>
+
+                            val userIri = stringFormatter.validateAndEscapeIri(value, throw BadRequestException(s"Invalid user IRI $value"))
+                            val requestingUser = getUserADM(requestContext)
+
+                            /* the api request is already checked at time of creation. see case class. */
+
+                            val requestMessage = if (apiRequest.oldPassword.isDefined && apiRequest.newPassword.isDefined) {
+                                /* update existing user's password */
+                                UserChangePasswordRequestADM(
+                                    userIri = userIri,
+                                    changeUserRequest = apiRequest,
+                                    requestingUser,
+                                    apiRequestID = UUID.randomUUID()
+                                )
+                            } else if (apiRequest.status.isDefined) {
+                                /* update existing user's status */
+                                UserChangeStatusRequestADM(
+                                    userIri,
+                                    changeUserRequest = apiRequest,
+                                    requestingUser,
+                                    apiRequestID = UUID.randomUUID()
+                                )
+                            } else if (apiRequest.systemAdmin.isDefined) {
+                                /* update existing user's system admin membership status */
+                                UserChangeSystemAdminMembershipStatusRequestADM(
+                                    userIri,
+                                    changeUserRequest = apiRequest,
+                                    requestingUser,
+                                    apiRequestID = UUID.randomUUID()
+                                )
+                            } else {
+                                /* update existing user's basic information */
+                                UserChangeBasicUserInformationRequestADM(
+                                    userIri,
+                                    changeUserRequest = apiRequest,
+                                    requestingUser,
+                                    apiRequestID = UUID.randomUUID()
+                                )
+                            }
+
+                            RouteUtilADM.runJsonRoute(
+                                requestMessage,
+                                requestContext,
+                                settings,
+                                responderManager,
+                                log
+                            )
+                    }
+                } ~
+                        delete {
+                            /* delete a user identified by iri */
+                            requestContext => {
+                                val userIri = stringFormatter.validateAndEscapeIri(value, throw BadRequestException(s"Invalid user IRI $value"))
+                                val requestingUser = getUserADM(requestContext)
+
+                                /* update existing user's status to false */
+                                val requestMessage = UserChangeStatusRequestADM(
+                                    userIri,
+                                    changeUserRequest = ChangeUserApiRequestADM(status = Some(false)),
+                                    requestingUser,
+                                    apiRequestID = UUID.randomUUID()
+                                )
+
+                                RouteUtilADM.runJsonRoute(
+                                    requestMessage,
+                                    requestContext,
+                                    settings,
+                                    responderManager,
+                                    log
+                                )
+                            }
+                        }
+            } ~
+            path("admin" / "users" / "projects" / Segment) { userIri =>
+                get {
+                    /* get user's project memberships */
+                    requestContext =>
+                        val requestingUser = getUserADM(requestContext)
+
+                        val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
+
+                        val requestMessage = UserProjectMembershipsGetRequestADM(
+                            userIri = checkedUserIri,
+                            requestingUser = requestingUser,
+                            apiRequestID = UUID.randomUUID()
+                        )
+
+                        RouteUtilADM.runJsonRoute(
+                            requestMessage,
+                            requestContext,
+                            settings,
+                            responderManager,
+                            log
+                        )
+                }
+            } ~
+            path("admin" / "users" / "projects" / Segment / Segment) { (userIri, projectIri) =>
+                post {
+                    /* add user to project */
+                    requestContext =>
+                        val requestingUser = getUserADM(requestContext)
+
+                        val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
+                        val checkedProjectIri = stringFormatter.validateAndEscapeIri(projectIri, throw BadRequestException(s"Invalid project IRI $projectIri"))
+
+                        val requestMessage = UserProjectMembershipAddRequestADM(
+                            userIri = checkedUserIri,
+                            projectIri = checkedProjectIri,
+                            requestingUser = requestingUser,
+                            apiRequestID = UUID.randomUUID()
+                        )
+
+                        RouteUtilADM.runJsonRoute(
+                            requestMessage,
+                            requestContext,
+                            settings,
+                            responderManager,
+                            log
+                        )
+                } ~
+                        delete {
+                            /* remove user from project (and all groups belonging to this project) */
+                            requestContext =>
+                                val requestingUser = getUserADM(requestContext)
+
+                                val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
+                                val checkedProjectIri = stringFormatter.validateAndEscapeIri(projectIri, throw BadRequestException(s"Invalid project IRI $projectIri"))
+
+                                val requestMessage = UserProjectMembershipRemoveRequestADM(
+                                    userIri = checkedUserIri,
+                                    projectIri = checkedProjectIri,
+                                    requestingUser = requestingUser,
+                                    apiRequestID = UUID.randomUUID()
+                                )
+
+                                RouteUtilADM.runJsonRoute(
+                                    requestMessage,
+                                    requestContext,
+                                    settings,
+                                    responderManager,
+                                    log
+                                )
+                        }
+            } ~
+            path("admin" / "users" / "projects-admin" / Segment) { userIri =>
+                get {
+                    /* get user's project admin memberships */
+                    requestContext =>
+                        val requestingUser = getUserADM(requestContext)
+
+                        val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
+
+                        val requestMessage = UserProjectAdminMembershipsGetRequestADM(
+                            userIri = checkedUserIri,
+                            requestingUser = requestingUser,
+                            apiRequestID = UUID.randomUUID()
+                        )
+
+                        RouteUtilADM.runJsonRoute(
+                            requestMessage,
+                            requestContext,
+                            settings,
+                            responderManager,
+                            log
+                        )
+                }
+            } ~
+            path("admin" / "users" / "projects-admin" / Segment / Segment) { (userIri, projectIri) =>
+                post {
+                    /* add user to project admin */
+                    requestContext =>
+                        val requestingUser = getUserADM(requestContext)
+
+                        val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
+                        val checkedProjectIri = stringFormatter.validateAndEscapeIri(projectIri, throw BadRequestException(s"Invalid project IRI $projectIri"))
+
+                        val requestMessage = UserProjectAdminMembershipAddRequestADM(
+                            userIri = checkedUserIri,
+                            projectIri = checkedProjectIri,
+                            requestingUser = requestingUser,
+                            apiRequestID = UUID.randomUUID()
+                        )
+
+                        RouteUtilADM.runJsonRoute(
+                            requestMessage,
+                            requestContext,
+                            settings,
+                            responderManager,
+                            log
+                        )
+                } ~
+                        delete {
+                            /* remove user from project admin */
+                            requestContext =>
+                                val requestingUser = getUserADM(requestContext)
+
+                                val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
+                                val checkedProjectIri = stringFormatter.validateAndEscapeIri(projectIri, throw BadRequestException(s"Invalid project IRI $projectIri"))
+
+                                val requestMessage = UserProjectAdminMembershipRemoveRequestADM(
+                                    userIri = checkedUserIri,
+                                    projectIri = checkedProjectIri,
+                                    requestingUser = requestingUser,
+                                    apiRequestID = UUID.randomUUID()
+                                )
+
+                                RouteUtilADM.runJsonRoute(
+                                    requestMessage,
+                                    requestContext,
+                                    settings,
+                                    responderManager,
+                                    log
+                                )
+                        }
+            } ~
+            path("admin" / "users" / "groups" / Segment) { userIri =>
+                get {
+                    /* get user's group memberships */
+                    requestContext =>
+                        val requestingUser = getUserADM(requestContext)
+
+                        val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
+
+                        val requestMessage = UserGroupMembershipsGetRequestADM(
+                            userIri = checkedUserIri,
+                            requestingUser = requestingUser,
+                            apiRequestID = UUID.randomUUID()
+                        )
+
+                        RouteUtilADM.runJsonRoute(
+                            requestMessage,
+                            requestContext,
+                            settings,
+                            responderManager,
+                            log
+                        )
+                }
+            } ~
+            path("admin" / "users" / "groups" / Segment / Segment) { (userIri, groupIri) =>
+                post {
+                    /* add user to group */
+                    requestContext =>
+                        val requestingUser = getUserADM(requestContext)
+
+                        val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
+                        val checkedGroupIri = stringFormatter.validateAndEscapeIri(groupIri, throw BadRequestException(s"Invalid group IRI $groupIri"))
+
+                        val requestMessage = UserGroupMembershipAddRequestADM(
+                            userIri = checkedUserIri,
+                            groupIri = checkedGroupIri,
+                            requestingUser = requestingUser,
+                            apiRequestID = UUID.randomUUID()
+                        )
+
+                        RouteUtilADM.runJsonRoute(
+                            requestMessage,
+                            requestContext,
+                            settings,
+                            responderManager,
+                            log
+                        )
+                } ~
+                        delete {
+                            /* remove user from group */
+                            requestContext =>
+                                val requestingUser = getUserADM(requestContext)
+
+                                val checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
+                                val checkedGroupIri = stringFormatter.validateAndEscapeIri(groupIri, throw BadRequestException(s"Invalid group IRI $groupIri"))
+
+                                val requestMessage = UserGroupMembershipRemoveRequestADM(
+                                    userIri = checkedUserIri,
+                                    groupIri = checkedGroupIri,
+                                    requestingUser = requestingUser,
+                                    apiRequestID = UUID.randomUUID()
+                                )
+
+                                RouteUtilADM.runJsonRoute(
+                                    requestMessage,
+                                    requestContext,
+                                    settings,
+                                    responderManager,
+                                    log
+                                )
+                        }
+            }
 }


### PR DESCRIPTION
### Summary

- add OpenAPI / Swagger API documentation generation

To try it out, run `webapi` and open `http://0.0.0.0:3333/api-docs/swagger.json` in http://petstore.swagger.io