### PR TITLE
feature (webapi): allow changing of user’s password by system admin

### DIFF
--- a/webapi/WebapiBuild.sbt
+++ b/webapi/WebapiBuild.sbt
@@ -281,7 +281,7 @@ lazy val library =
         val scalaJava8Compat       = "org.scala-lang.modules"        % "scala-java8-compat_2.12"  % "0.8.0"
 
         // provides akka jackson (json) support
-        val akkaHttpCirce          = "de.heikoseeberger"            %% "akka-http-circe"          % "1.20.0"
+        val akkaHttpCirce          = "de.heikoseeberger"            %% "akka-http-circe"          % "1.20.1"
         val jacksonScala           = "com.fasterxml.jackson.module" %% "jackson-module-scala"     % "2.9.4"
 
         val jsonldJava             = "com.github.jsonld-java"        % "jsonld-java"              % "0.12.0"

--- a/webapi/WebapiBuild.sbt
+++ b/webapi/WebapiBuild.sbt
@@ -3,6 +3,7 @@ import NativePackagerHelper._
 import sbt.io.IO
 import sbtassembly.MergeStrategy
 import sbtassembly.MergeStrategy._
+import sun.util.logging.resources.logging
 
 connectInput in run := true
 
@@ -235,14 +236,15 @@ lazy val library =
         val jenaText               = "org.apache.jena"               % "jena-text"                % Version.jena exclude("org.slf4j", "slf4j-log4j12") exclude("commons-codec", "commons-codec")
 
         // logging
-        val scalaLogging           = "com.typesafe.scala-logging"   %% "scala-logging"            % "3.5.0"
-        val logbackClassic         = "ch.qos.logback"                % "logback-classic"          % "1.1.7"
+        val commonsLogging         = "commons-logging"               % "commons-logging"          % "1.2"
+        val scalaLogging           = "com.typesafe.scala-logging"   %% "scala-logging"            % "3.8.0"
+        val logbackClassic         = "ch.qos.logback"                % "logback-classic"          % "1.2.3"
 
         // input validation
         val commonsValidator       = "commons-validator"             % "commons-validator"        % "1.6" exclude("commons-logging", "commons-logging")
 
         // authentication
-        val springSecurityCore     = "org.springframework.security"  % "spring-security-core"     % "5.0.4.RELEASE" exclude("commons-logging", "commons-logging") exclude("org.springframework", "spring-aop")
+        val springSecurityCore     = "org.springframework.security"  % "spring-security-core"     % "4.2.5.RELEASE" exclude("commons-logging", "commons-logging") exclude("org.springframework", "spring-aop")
         val jwt                    = "io.igl"                       %% "jwt"                      % "1.2.2" exclude("commons-codec", "commons-codec")
 
         // caching
@@ -258,9 +260,9 @@ lazy val library =
 
         // other
         //"javax.transaction" % "transaction-api" % "1.1-rev-1",
-        val commonsLang3           = "org.apache.commons"            % "commons-lang3"            % "3.4"
-        val commonsIo              = "commons-io"                    % "commons-io"               % "2.4"
-        val commonsBeanUtil        = "commons-beanutils"             % "commons-beanutils"        % "1.9.2" exclude("commons-logging", "commons-logging") // not used by us, but need newest version to prevent this problem: http://stackoverflow.com/questions/14402745/duplicate-classes-in-commons-collections-and-commons-beanutils
+        val commonsLang3           = "org.apache.commons"            % "commons-lang3"            % "3.7"
+        val commonsIo              = "commons-io"                    % "commons-io"               % "2.6"
+        val commonsBeanUtil        = "commons-beanutils"             % "commons-beanutils"        % "1.9.3" exclude("commons-logging", "commons-logging") // not used by us, but need newest version to prevent this problem: http://stackoverflow.com/questions/14402745/duplicate-classes-in-commons-collections-and-commons-beanutils
         val jodd                   = "org.jodd"                      % "jodd"                     % "3.2.6"
         val jodaTime               = "joda-time"                     % "joda-time"                % "2.9.1"
         val jodaConvert            = "org.joda"                      % "joda-convert"             % "1.8"
@@ -282,7 +284,7 @@ lazy val library =
         val akkaHttpCirce          = "de.heikoseeberger"            %% "akka-http-circe"          % "1.20.0"
         val jacksonScala           = "com.fasterxml.jackson.module" %% "jackson-module-scala"     % "2.9.4"
 
-        val jsonldJava             = "com.github.jsonld-java"        % "jsonld-java"              % "0.11.1"
+        val jsonldJava             = "com.github.jsonld-java"        % "jsonld-java"              % "0.12.0"
     }
 
 lazy val javaRunOptions = Seq(

--- a/webapi/WebapiBuild.sbt
+++ b/webapi/WebapiBuild.sbt
@@ -161,7 +161,6 @@ lazy val webApiLibs = Seq(
     library.akkaStream,
     library.akkaStreamTestkit,
     library.akkaTestkit,
-    library.bcprov,
     library.commonsBeanUtil,
     library.commonsIo,
     library.commonsLang3,
@@ -243,8 +242,7 @@ lazy val library =
         val commonsValidator       = "commons-validator"             % "commons-validator"        % "1.6" exclude("commons-logging", "commons-logging")
 
         // authentication
-        val bcprov                 = "org.bouncycastle"              % "bcprov-jdk15on"           % "1.56"
-        val springSecurityCore     = "org.springframework.security"  % "spring-security-core"     % "4.2.3.RELEASE" exclude("commons-logging", "commons-logging") exclude("org.springframework", "spring-aop")
+        val springSecurityCore     = "org.springframework.security"  % "spring-security-core"     % "5.0.4.RELEASE" exclude("commons-logging", "commons-logging") exclude("org.springframework", "spring-aop")
         val jwt                    = "io.igl"                       %% "jwt"                      % "1.2.2" exclude("commons-codec", "commons-codec")
 
         // caching

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/usersmessages/UsersMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/usersmessages/UsersMessagesADM.scala
@@ -63,20 +63,20 @@ case class CreateUserApiRequestADM(email: String,
   * be changed include the user's email, given name, family name, language, password, user status, and system admin
   * membership.
   *
-  * @param email           the new email address. Needs to be unique on the server.
-  * @param givenName       the new given name.
-  * @param familyName      the new family name.
-  * @param lang            the new ISO 639-1 code of the new preferred language.
-  * @param currentPassword the current password of the user making the request.
-  * @param newPassword     the new password.
-  * @param status          the new user status (active = true, inactive = false).
-  * @param systemAdmin     the new system admin membership status.
+  * @param email             the new email address. Needs to be unique on the server.
+  * @param givenName         the new given name.
+  * @param familyName        the new family name.
+  * @param lang              the new ISO 639-1 code of the new preferred language.
+  * @param requesterPassword the password of the user making the request.
+  * @param newPassword       the new password.
+  * @param status            the new user status (active = true, inactive = false).
+  * @param systemAdmin       the new system admin membership status.
   */
 case class ChangeUserApiRequestADM(email: Option[String] = None,
                                    givenName: Option[String] = None,
                                    familyName: Option[String] = None,
                                    lang: Option[String] = None,
-                                   currentPassword: Option[String] = None,
+                                   requesterPassword: Option[String] = None,
                                    newPassword: Option[String] = None,
                                    status: Option[Boolean] = None,
                                    systemAdmin: Option[Boolean] = None) {
@@ -86,11 +86,13 @@ case class ChangeUserApiRequestADM(email: Option[String] = None,
         givenName,
         familyName,
         lang,
-        currentPassword,
+        requesterPassword,
         newPassword,
         status,
         systemAdmin
     ).flatten.size
+
+    // println(requesterPassword + " " + newPassword)
 
     // something needs to be sent, i.e. everything 'None' is not allowed
     if (parametersCount == 0) throw BadRequestException("No data sent in API request.")
@@ -99,7 +101,7 @@ case class ChangeUserApiRequestADM(email: Option[String] = None,
     /* check that only allowed information for the 4 cases is send and not more. */
 
     // change password case
-    if (currentPassword.isDefined || newPassword.isDefined) {
+    if (requesterPassword.isDefined || newPassword.isDefined) {
         if (parametersCount > 2) {
             throw BadRequestException("To many parameters sent for password change.")
         } else if (parametersCount < 2) {
@@ -466,8 +468,8 @@ case class UserADM(id: IRI,
     def compare(that: UserADM): Int = this.id.compareTo(that.id)
 
     /**
-      * Check password using either SHA-1 or SCrypt.
-      * The SCrypt password always starts with '$e0801$' (spring.framework implementation)
+      * Check password (in clear text) using SCrypt. The password supplied in clear text is hashed and
+      * compared against the stored hash.
       *
       * @param password the password to check.
       * @return true if password matches and false if password doesn't match.
@@ -475,15 +477,9 @@ case class UserADM(id: IRI,
     def passwordMatch(password: String): Boolean = {
         this.password.exists {
             hashedPassword =>
-                if (hashedPassword.startsWith("$e0801$")) {
-                    //println(s"UserProfileV1 - passwordMatch - password: $password, hashedPassword: hashedPassword")
-                    import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder
-                    val encoder = new SCryptPasswordEncoder
-                    encoder.matches(password, hashedPassword.toString)
-                } else {
-                    val md = java.security.MessageDigest.getInstance("SHA-1")
-                    md.digest(password.getBytes("UTF-8")).map("%02x".format(_)).mkString.equals(hashedPassword.toString)
-                }
+                import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder
+                val encoder = new SCryptPasswordEncoder
+                encoder.matches(password, hashedPassword.toString)
         }
     }
 
@@ -768,7 +764,7 @@ object UsersADMJsonProtocol extends SprayJsonSupport with DefaultJsonProtocol wi
 
     implicit val userADMFormat: JsonFormat[UserADM] = jsonFormat12(UserADM)
     implicit val createUserApiRequestADMFormat: RootJsonFormat[CreateUserApiRequestADM] = jsonFormat7(CreateUserApiRequestADM)
-    implicit val changeUserApiRequestADMFormat: RootJsonFormat[ChangeUserApiRequestADM] = jsonFormat(ChangeUserApiRequestADM, "email", "givenName", "familyName", "lang", "oldPassword", "newPassword", "status", "systemAdmin")
+    implicit val changeUserApiRequestADMFormat: RootJsonFormat[ChangeUserApiRequestADM] = jsonFormat(ChangeUserApiRequestADM, "email", "givenName", "familyName", "lang", "requesterPassword", "newPassword", "status", "systemAdmin")
     implicit val usersGetResponseADMFormat: RootJsonFormat[UsersGetResponseADM] = jsonFormat1(UsersGetResponseADM)
     implicit val userProfileResponseADMFormat: RootJsonFormat[UserResponseADM] = jsonFormat1(UserResponseADM)
     implicit val userProjectMembershipsGetResponseADMFormat: RootJsonFormat[UserProjectMembershipsGetResponseADM] = jsonFormat1(UserProjectMembershipsGetResponseADM)

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/usersmessages/UsersMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/usersmessages/UsersMessagesADM.scala
@@ -63,20 +63,20 @@ case class CreateUserApiRequestADM(email: String,
   * be changed include the user's email, given name, family name, language, password, user status, and system admin
   * membership.
   *
-  * @param email       the new email address. Needs to be unique on the server.
-  * @param givenName   the new given name.
-  * @param familyName  the new family name.
-  * @param lang        the new ISO 639-1 code of the new preferred language.
-  * @param oldPassword the old password.
-  * @param newPassword the new password.
-  * @param status      the new user status (active = true, inactive = false).
-  * @param systemAdmin the new system admin membership status.
+  * @param email           the new email address. Needs to be unique on the server.
+  * @param givenName       the new given name.
+  * @param familyName      the new family name.
+  * @param lang            the new ISO 639-1 code of the new preferred language.
+  * @param currentPassword the current password of the user making the request.
+  * @param newPassword     the new password.
+  * @param status          the new user status (active = true, inactive = false).
+  * @param systemAdmin     the new system admin membership status.
   */
 case class ChangeUserApiRequestADM(email: Option[String] = None,
                                    givenName: Option[String] = None,
                                    familyName: Option[String] = None,
                                    lang: Option[String] = None,
-                                   oldPassword: Option[String] = None,
+                                   currentPassword: Option[String] = None,
                                    newPassword: Option[String] = None,
                                    status: Option[Boolean] = None,
                                    systemAdmin: Option[Boolean] = None) {
@@ -86,7 +86,7 @@ case class ChangeUserApiRequestADM(email: Option[String] = None,
         givenName,
         familyName,
         lang,
-        oldPassword,
+        currentPassword,
         newPassword,
         status,
         systemAdmin
@@ -99,7 +99,7 @@ case class ChangeUserApiRequestADM(email: Option[String] = None,
     /* check that only allowed information for the 4 cases is send and not more. */
 
     // change password case
-    if (oldPassword.isDefined || newPassword.isDefined) {
+    if (currentPassword.isDefined || newPassword.isDefined) {
         if (parametersCount > 2) {
             throw BadRequestException("To many parameters sent for password change.")
         } else if (parametersCount < 2) {
@@ -154,10 +154,10 @@ case class UsersGetRequestADM(userInformationTypeADM: UserInformationTypeADM = U
 /**
   * A message that requests a user's profile either by IRI or email. A successful response will be a [[UserADM]].
   *
-  * @param maybeIri           the IRI of the user to be queried.
-  * @param maybeEmail the email of the user to be queried.
+  * @param maybeIri               the IRI of the user to be queried.
+  * @param maybeEmail             the email of the user to be queried.
   * @param userInformationTypeADM the extent of the information returned.
-  * @param requestingUser the user initiating the request.
+  * @param requestingUser         the user initiating the request.
   */
 case class UserGetADM(maybeIri: Option[IRI],
                       maybeEmail: Option[String],
@@ -173,10 +173,10 @@ case class UserGetADM(maybeIri: Option[IRI],
 /**
   * A message that requests a user's profile either by IRI or email. A successful response will be a [[UserResponseADM]].
   *
-  * @param maybeIri           the IRI of the user to be queried.
-  * @param maybeEmail the email of the user to be queried.
+  * @param maybeIri               the IRI of the user to be queried.
+  * @param maybeEmail             the email of the user to be queried.
   * @param userInformationTypeADM the extent of the information returned.
-  * @param requestingUser the user initiating the request.
+  * @param requestingUser         the user initiating the request.
   */
 case class UserGetRequestADM(maybeIri: Option[IRI],
                              maybeEmail: Option[String],

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
@@ -371,7 +371,7 @@ class UsersResponderADM extends Responder {
       * Change the users password. The old password needs to be supplied for security purposes.
       *
       * @param userIri           the IRI of the existing user that we want to update.
-      * @param changeUserRequest the old and new password.
+      * @param changeUserRequest the current password of the requesting user and the new password.
       * @param requestingUser    the requesting user.
       * @param apiRequestID      the unique api request ID.
       * @return a future containing a [[UserOperationResponseADM]].
@@ -391,21 +391,17 @@ class UsersResponderADM extends Responder {
 
             // check if necessary information is present
             _ <- Future(if (userIri.isEmpty) throw BadRequestException("User IRI cannot be empty"))
-            _ = if (changeUserRequest.oldPassword.isEmpty || changeUserRequest.newPassword.isEmpty) throw BadRequestException("The user's old and new password need to be both supplied")
+            _ = if (changeUserRequest.currentPassword.isEmpty || changeUserRequest.newPassword.isEmpty) throw BadRequestException("The user's old and new password need to be both supplied")
 
-            // check if the requesting user is allowed to perform updates
-            _ = if (!requestingUser.id.equalsIgnoreCase(userIri)) {
-                // not the user
-                //log.debug("same user: {}", userProfile.userData.user_id.contains(userIri))
-                throw ForbiddenException("User's password can only be changed by the user itself")
+            // check if the requesting user is allowed to perform password change. it needs to be either the user himself, or a system admin
+            _ = if (!requestingUser.id.equalsIgnoreCase(userIri) && !requestingUser.permissions.isSystemAdmin) {
+                // not the user or system admin
+                throw ForbiddenException("User's password can only be changed by the user itself or a system admin.")
             }
 
-            // check if old password matches current user password
-            maybeUserADM <- userGetADM(maybeUserIri = Some(userIri), maybeUserEmail = None, requestingUser = KnoraSystemInstances.Users.SystemUser, userInformationType = UserInformationTypeADM.FULL)
-            userADM = maybeUserADM.getOrElse(throw NotFoundException(s"User '$userIri' not found"))
-            _ = if (!userADM.passwordMatch(changeUserRequest.oldPassword.get)) {
-                log.debug("supplied oldPassword: {}, current hash: {}", changeUserRequest.oldPassword.get, userADM.password.get)
-                throw ForbiddenException("The supplied old password does not match the current users password.")
+            // check if supplied password matches requesting user's password
+            _ = if (!requestingUser.passwordMatch(changeUserRequest.currentPassword.get)) {
+                throw ForbiddenException("The supplied password does not match the current user's password.")
             }
 
             // create the update request

--- a/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
@@ -302,7 +302,7 @@ trait Authenticator {
             log.debug("getUserProfileV1 - I got a UserProfileV1: {}", user.toString)
 
             /* we return the userProfileV1 without sensitive information */
-            user.ofType(UserInformationTypeADM.RESTRICTED)
+            user.ofType(UserInformationTypeADM.FULL)
         }
     }
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
@@ -301,7 +301,7 @@ trait Authenticator {
             val user: UserADM = getUserADMThroughCredentialsV2(credentials)
             log.debug("getUserProfileV1 - I got a UserProfileV1: {}", user.toString)
 
-            /* we return the userProfileV1 without sensitive information */
+            /* we return the complete UserADM */
             user.ofType(UserInformationTypeADM.FULL)
         }
     }

--- a/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
@@ -343,13 +343,9 @@ object Authenticator {
       * @throws BadCredentialsException when no credentials are supplied; when user is not active;
       *                                 when the password does not match; when the supplied token is not valid.
       */
-    private def authenticateCredentialsV2(credentials: Option[KnoraCredentialsV2])(implicit system: ActorSystem, executionContext: ExecutionContext): Boolean = {
+    def authenticateCredentialsV2(credentials: Option[KnoraCredentialsV2])(implicit system: ActorSystem, executionContext: ExecutionContext): Boolean = {
 
         val settings = Settings(system)
-
-        if (credentials.isEmpty) {
-            throw BadCredentialsException(BAD_CRED_NONE_SUPPLIED)
-        }
 
         credentials match {
             case Some(passCreds: KnoraPasswordCredentialsV2) => {

--- a/webapi/src/main/scala/org/knora/webapi/routing/RejectingRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/RejectingRoute.scala
@@ -20,7 +20,10 @@ import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import akka.util.Timeout
 import org.knora.webapi.{Settings, SettingsImpl}
+
+import scala.concurrent.ExecutionContextExecutor
 
 /**
   * A route used for faking the image server.
@@ -28,16 +31,17 @@ import org.knora.webapi.{Settings, SettingsImpl}
 object RejectingRoute {
 
     def knoraApiPath(_system: ActorSystem, settings: SettingsImpl, log: LoggingAdapter): Route = {
-        implicit val system = _system
-        implicit val executionContext = system.dispatcher
-        implicit val timeout = settings.defaultTimeout
+
+        implicit val system: ActorSystem = _system
+        implicit val executionContext: ExecutionContextExecutor = system.dispatcher
+        implicit val timeout: Timeout = settings.defaultTimeout
 
         path(Remaining) { wholepath =>
                 requestContext => {
                     log.debug(s"got request: ${requestContext.toString}")
                     val settings = Settings(system)
-                    val reject: Seq[Option[Boolean]] = settings.routesToReject.map { pathtoreject =>
-                        if (wholepath.contains(pathtoreject.toCharArray)) {
+                    val reject: Seq[Option[Boolean]] = settings.routesToReject.map { pathToReject =>
+                        if (wholepath.contains(pathToReject.toCharArray)) {
                             Some(true)
                         } else {
                             None

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
@@ -118,7 +118,7 @@ object UsersRouteADM extends Authenticator {
 
                         /* the api request is already checked at time of creation. see case class. */
 
-                        val requestMessage = if (apiRequest.oldPassword.isDefined && apiRequest.newPassword.isDefined) {
+                        val requestMessage = if (apiRequest.currentPassword.isDefined && apiRequest.newPassword.isDefined) {
                             /* update existing user's password */
                             UserChangePasswordRequestADM(
                                 userIri = userIri,

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
@@ -118,7 +118,7 @@ object UsersRouteADM extends Authenticator {
 
                         /* the api request is already checked at time of creation. see case class. */
 
-                        val requestMessage = if (apiRequest.currentPassword.isDefined && apiRequest.newPassword.isDefined) {
+                        val requestMessage = if (apiRequest.requesterPassword.isDefined && apiRequest.newPassword.isDefined) {
                             /* update existing user's password */
                             UserChangePasswordRequestADM(
                                 userIri = userIri,

--- a/webapi/src/test/resources/logback-test.xml
+++ b/webapi/src/test/resources/logback-test.xml
@@ -87,7 +87,7 @@
 
     <!-- Admin -->
     <logger name="org.knora.webapi.responders.admin.GroupsResponderADM" level="INFO"/>
-    <logger name="org.knora.webapi.responders.admin.ListsResponderADM" level="DEBUG"/>
+    <logger name="org.knora.webapi.responders.admin.ListsResponderADM" level="INFO"/>
     <logger name="org.knora.webapi.responders.admin.OntologiesResponderADM" level="INFO"/>
     <logger name="org.knora.webapi.responders.admin.ProjectsResponderADM" level="INFO"/>
     <logger name="org.knora.webapi.responders.admin.StoresResponderADM" level="INFO"/>
@@ -114,7 +114,7 @@
     <logger name="org.knora.webapi.responders.admin.UsersResponderADMSpec" level="INFO"/>
     <logger name="org.knora.webapi.e2e.admin.ListsADME2ESpec" level="INFO"/>
     <logger name="org.knora.webapi.e2e.admin.ProjectsADME2ESpec" level="INFO"/>
-    <logger name="org.knora.webapi.e2e.admin.UsersADME2ESpecE2E" level="INFO"/>
+    <logger name="org.knora.webapi.e2e.admin.UsersADME2ESpec" level="INFO"/>
 
 
     <root level="INFO">

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/UsersResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/UsersResponderADMSpec.scala
@@ -35,7 +35,6 @@ import org.knora.webapi.messages.admin.responder.projectsmessages.{ProjectAdminM
 import org.knora.webapi.messages.admin.responder.usersmessages._
 import org.knora.webapi.messages.store.triplestoremessages._
 import org.knora.webapi.messages.v1.responder.ontologymessages.{LoadOntologiesRequest, LoadOntologiesResponse}
-import org.knora.webapi.messages.v2.routing.authenticationmessages
 import org.knora.webapi.messages.v2.routing.authenticationmessages.KnoraPasswordCredentialsV2
 import org.knora.webapi.responders.{RESPONDER_MANAGER_ACTOR_NAME, ResponderManager}
 import org.knora.webapi.routing.Authenticator
@@ -352,7 +351,7 @@ class UsersResponderADMSpec extends CoreSpec(UsersResponderADMSpec.config) with 
                 actorUnderTest ! UserChangePasswordRequestADM(
                     userIri = SharedTestDataADM.normalUser.id,
                     changeUserRequest = ChangeUserApiRequestADM(
-                        currentPassword = Some("test"), // of the requesting user
+                        requesterPassword = Some("test"), // of the requesting user
                         newPassword = Some("test123456")
                     ),
                     requestingUser = SharedTestDataADM.normalUser,
@@ -365,11 +364,11 @@ class UsersResponderADMSpec extends CoreSpec(UsersResponderADMSpec.config) with 
                 Authenticator.authenticateCredentialsV2(Some(KnoraPasswordCredentialsV2(normalUser.email, "test123456"))) should be (true)
             }
 
-            "UPDATE the user's password (by system admin)" in {
+            "UPDATE the user's password (by a system admin)" in {
                 actorUnderTest ! UserChangePasswordRequestADM(
                     userIri = SharedTestDataADM.normalUser.id,
                     changeUserRequest = ChangeUserApiRequestADM(
-                        currentPassword = Some("test"), // of the requesting user
+                        requesterPassword = Some("test"), // of the requesting user
                         newPassword = Some("test654321")
                     ),
                     requestingUser = SharedTestDataADM.rootUser,
@@ -447,7 +446,7 @@ class UsersResponderADMSpec extends CoreSpec(UsersResponderADMSpec.config) with 
                 actorUnderTest ! UserChangePasswordRequestADM(
                     userIri = SharedTestDataADM.superUser.id,
                     changeUserRequest = ChangeUserApiRequestADM(
-                        currentPassword = Some("test"),
+                        requesterPassword = Some("test"),
                         newPassword = Some("test123456")
                     ),
                     requestingUser = SharedTestDataADM.normalUser,

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/UsersResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/UsersResponderADMSpec.scala
@@ -35,7 +35,10 @@ import org.knora.webapi.messages.admin.responder.projectsmessages.{ProjectAdminM
 import org.knora.webapi.messages.admin.responder.usersmessages._
 import org.knora.webapi.messages.store.triplestoremessages._
 import org.knora.webapi.messages.v1.responder.ontologymessages.{LoadOntologiesRequest, LoadOntologiesResponse}
+import org.knora.webapi.messages.v2.routing.authenticationmessages
+import org.knora.webapi.messages.v2.routing.authenticationmessages.KnoraPasswordCredentialsV2
 import org.knora.webapi.responders.{RESPONDER_MANAGER_ACTOR_NAME, ResponderManager}
+import org.knora.webapi.routing.Authenticator
 import org.knora.webapi.store.{STORE_MANAGER_ACTOR_NAME, StoreManager}
 
 import scala.concurrent.duration._
@@ -53,7 +56,7 @@ object UsersResponderADMSpec {
 /**
   * This spec is used to test the messages received by the [[UsersResponderADM]] actor.
   */
-class UsersResponderADMSpec extends CoreSpec(UsersResponderADMSpec.config) with ImplicitSender {
+class UsersResponderADMSpec extends CoreSpec(UsersResponderADMSpec.config) with ImplicitSender with Authenticator {
 
     private implicit val executionContext = system.dispatcher
     private val timeout = 5.seconds
@@ -345,35 +348,38 @@ class UsersResponderADMSpec extends CoreSpec(UsersResponderADMSpec.config) with 
 
             }
 
-            "UPDATE the user's password" in {
+            "UPDATE the user's password (by himself)" in {
                 actorUnderTest ! UserChangePasswordRequestADM(
                     userIri = SharedTestDataADM.normalUser.id,
                     changeUserRequest = ChangeUserApiRequestADM(
-                        oldPassword = Some("test"),
+                        currentPassword = Some("test"), // of the requesting user
                         newPassword = Some("test123456")
                     ),
                     requestingUser = SharedTestDataADM.normalUser,
                     apiRequestID = UUID.randomUUID()
                 )
 
-                // Can't check if password was changed directly, since it will not be returned. If no error message
-                // is returned, then I can assume that the password was successfully changed, as this check is
-                // performed in the responder itself.
                 expectMsgType[UserOperationResponseADM](timeout)
 
+                // need to be able to authenticate credentials with new password
+                Authenticator.authenticateCredentialsV2(Some(KnoraPasswordCredentialsV2(normalUser.email, "test123456"))) should be (true)
+            }
 
-                // By doing the change again, I can check if the first change was indeed successful.
+            "UPDATE the user's password (by system admin)" in {
                 actorUnderTest ! UserChangePasswordRequestADM(
                     userIri = SharedTestDataADM.normalUser.id,
                     changeUserRequest = ChangeUserApiRequestADM(
-                        oldPassword = Some("test123456"),
-                        newPassword = Some("test")
+                        currentPassword = Some("test"), // of the requesting user
+                        newPassword = Some("test654321")
                     ),
-                    requestingUser = SharedTestDataADM.normalUser,
+                    requestingUser = SharedTestDataADM.rootUser,
                     apiRequestID = UUID.randomUUID()
                 )
 
                 expectMsgType[UserOperationResponseADM](timeout)
+
+                // need to be able to authenticate credentials with new password
+                Authenticator.authenticateCredentialsV2(Some(KnoraPasswordCredentialsV2(normalUser.email, "test654321"))) should be (true)
             }
 
             "UPDATE the user's status, (deleting) making him inactive " in {
@@ -441,13 +447,13 @@ class UsersResponderADMSpec extends CoreSpec(UsersResponderADMSpec.config) with 
                 actorUnderTest ! UserChangePasswordRequestADM(
                     userIri = SharedTestDataADM.superUser.id,
                     changeUserRequest = ChangeUserApiRequestADM(
-                        oldPassword = Some("test"),
+                        currentPassword = Some("test"),
                         newPassword = Some("test123456")
                     ),
                     requestingUser = SharedTestDataADM.normalUser,
                     UUID.randomUUID
                 )
-                expectMsg(Failure(ForbiddenException("User's password can only be changed by the user itself")))
+                expectMsg(Failure(ForbiddenException("User's password can only be changed by the user itself or a system admin.")))
 
                 /* Status is updated by other normal user */
                 actorUnderTest ! UserChangeStatusRequestADM(


### PR DESCRIPTION
### Summary

- system admin can now change passwords of other users
- removed code for checking SHA-1 hashed passwords. remnants of times gone by.

### Issues

- resolves #795 