### PR TITLE
Fix image orientation in SALSAH 1 (moved from #768)

### DIFF
--- a/docs/rst/00-release-notes/v1.4.0.rst
+++ b/docs/rst/00-release-notes/v1.4.0.rst
@@ -42,6 +42,7 @@ Bugfixes:
 ---------
 
 - API v1 extended search was not properly handling multiple conditions on list values (issue #800)
+- Fix image orientation in SALSAH 1 (issue #726)
 
 .. _release: https://github.com/dhlab-basel/Knora/releases/tag/v1.4.0
 .. _v1.4.0 milestone: https://github.com/dhlab-basel/Knora/milestone/8

--- a/salsah1/src/public/js/imagebase.js
+++ b/salsah1/src/public/js/imagebase.js
@@ -2355,7 +2355,7 @@ $(function() {
 			//zoom_slider.ele.css('width', localdata.settings.slider_width + 'px'); // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! woher kommt localdata??
 		}
 
-		navigator_map.ele = $('<img>').css({position: 'absolute'}).appendTo(navigator_area.ele);
+		navigator_map.ele = $('<img>').css({position: 'absolute', 'image-orientation': 'from-image'}).appendTo(navigator_area.ele);
 
 		navigator_maprect.ele = $('<div>', {'class': 'mapRect'}).css({position: 'absolute'}).appendTo(navigator_area.ele);
 
@@ -2513,6 +2513,7 @@ $(function() {
 				);
 				image.src = src;
 				image.ele.attr({src: src});
+				image.ele.css({'image-orientation': 'from-image'});
 				if (viewer_settings.left_image_area) { // image is to the left
 					//
 					// create and activate the image zoomer

--- a/salsah1/src/public/js/jquery.location.js
+++ b/salsah1/src/public/js/jquery.location.js
@@ -105,7 +105,7 @@
 									$this.find('.uploadButton').remove();
 
 									$this.append($('<div>').addClass('thumbNail')
-										.append($('<img>', {src: data.preview_path}))
+										.append($('<img>', {src: data.preview_path, style: "image-orientation: from-image"}))
 										.append($('<br>'))
 										.append(data.original_filename)
 									);


### PR DESCRIPTION
This is PR #768, adapted for the current `develop`.

The Knora-Sipi integration tests pass.

@loicjaouen Can you check that this does what you want? If so, I think we can merge it.

fixes: #726