### PR TITLE
feature (search v2): limit fulltext search to standoff class

### DIFF
--- a/docs/src/paradox/03-webapi/api-v2/reading-and-searching-resources.md
+++ b/docs/src/paradox/03-webapi/api-v2/reading-and-searching-resources.md
@@ -125,7 +125,8 @@ combined using the Boolean `AND` operator. Please note that the search
 terms have to be URL-encoded.
 
 ```
-HTTP GET to http://host/v2/search/searchValue[limitToResourceClass=resourceClassIRI][limitToProject=projectIRI][offset=Integer]
+HTTP GET to http://host/v2/search/searchValue[limitToResourceClass=resourceClassIRI]
+[limitToStandoffClass=standoffClassIri][limitToProject=projectIRI][offset=Integer]
 ```
 
 Please note that the first parameter has to be preceded by a question
@@ -135,6 +136,9 @@ The default value for the parameter `offset` is 0 which returns the
 first page of search results. Subsequent pages of results can be fetched
 by increasing `offset` by one. The amount of results per page is defined
 in `app/v2` in `application.conf`.
+
+If the parameter `limitToStandoffClass` is provided, Knora will look for search terms 
+that are marked up with the indicated standoff class.
 
 The response to a full-text search request is a `ResourcesSequence` (see
 @ref:[Response Formats](response-formats.md)).
@@ -182,7 +186,7 @@ In order to perform a count query, just append the segment `count`:
 ```
 HTTP GET to http://host/v2/searchbylabel/count/searchValue[limitToResourceClass=resourceClassIRI][limitToProject=projectIRI][offset=Integer]
 
-HTTP GET to http://host/v2/search/count/searchValue[limitToResourceClass=resourceClassIRI][limitToProject=projectIRI][offset=Integer]
+HTTP GET to http://host/v2/search/count/searchValue[limitToResourceClass=resourceClassIRI][limitToStandoffClass=standoffClassIri][limitToProject=projectIRI][offset=Integer]
 
 HTTP GET to http://host/v2/searchextended/count/KnarQLQuery
 ```

--- a/webapi/_test_data/all_data/anything-data.ttl
+++ b/webapi/_test_data/all_data/anything-data.ttl
@@ -951,3 +951,50 @@
 	anything:hasText <http://rdfh.ch/0001/a-thing-with-text-valueslanguage/values/1> ;
 	knora-base:hasPermissions "V knora-base:UnknownUser|M knora-base:ProjectMember" ;
 	knora-base:creationDate "2016-03-02T15:05:10Z"^^xsd:dateTimeStamp .
+
+<http://rdfh.ch/0001/thing_with_richtext_with_markup> a anything:Thing ;
+    knora-base:isDeleted false ;
+    knora-base:attachedToUser <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> ;
+    anything:hasRichtext <http://rdfh.ch/0001/thing_with_richtext_with_markup/text1> ;
+    rdfs:label "test thing with markup" ;
+    knora-base:hasPermissions "V knora-base:UnknownUser|M knora-base:ProjectMember" ;
+    knora-base:creationDate "2018-01-31T15:05:10Z"^^xsd:dateTimeStamp .
+    
+<http://rdfh.ch/0001/thing_with_richtext_with_markup/text1> knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF> ;
+    knora-base:hasPermissions "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:KnownUser|RV knora-base:UnknownUser" ;
+    knora-base:isDeleted "false"^^<http://www.w3.org/2001/XMLSchema#boolean> ;
+    knora-base:valueCreationDate "2018-04-16T13:24:53.578Z"^^<http://www.w3.org/2001/XMLSchema#dateTimeStamp> ;
+    knora-base:valueHasMapping <http://rdfh.ch/standoff/mappings/StandardMapping> ;
+    knora-base:valueHasOrder "0"^^<http://www.w3.org/2001/XMLSchema#integer> ;
+    knora-base:valueHasStandoff <http://rdfh.ch/0001/thing_with_richtext_with_markup/text1/standoff1> , <http://rdfh.ch/0001/thing_with_richtext_with_markup/text1/standoff2> , <http://rdfh.ch/0001/thing_with_richtext_with_markup/text1/standoff3> , <http://rdfh.ch/0001/thing_with_richtext_with_markup/text1/standoff4> ;
+    knora-base:valueHasString "This is a test that contains marked up elements. This is interesting text in italics. This is boring text in italics." ;
+    a knora-base:TextValue .
+
+
+<http://rdfh.ch/0001/thing_with_richtext_with_markup/text1/standoff1> knora-base:standoffTagHasEnd 118 ;
+	knora-base:standoffTagHasStart 0 ;
+	knora-base:standoffTagHasStartIndex 0 ;
+	knora-base:standoffTagHasUUID "2cb01d47-bf01-4705-a5de-5e967e1c97fc" ;
+	a standoff:StandoffRootTag .
+
+<http://rdfh.ch/0001/thing_with_richtext_with_markup/text1/standoff2> knora-base:standoffTagHasEnd 117 ;
+	knora-base:standoffTagHasStart 0 ;
+	knora-base:standoffTagHasStartIndex 1 ;
+	knora-base:standoffTagHasStartParent <http://rdfh.ch/0001/thing_with_richtext_with_markup/text1/standoff1> ;
+	knora-base:standoffTagHasUUID "0a3e72a7-ac7b-430b-81ed-1c4239598231" ;
+	a standoff:StandoffParagraphTag .
+
+<http://rdfh.ch/0001/thing_with_richtext_with_markup/text1/standoff3> knora-base:standoffTagHasEnd 73 ;
+    knora-base:standoffTagHasStart 57 ;
+    knora-base:standoffTagHasStartIndex 2 ;
+    knora-base:standoffTagHasStartParent <http://rdfh.ch/0001/thing_with_richtext_with_markup/text1/standoff2> ;
+    knora-base:standoffTagHasUUID "265262c7-3919-4727-9178-60bb2ddec11c" ;
+    a standoff:StandoffItalicTag .
+
+<http://rdfh.ch/0001/thing_with_richtext_with_markup/text1/standoff4> knora-base:standoffTagHasEnd 105 ;
+    knora-base:standoffTagHasStart 94 ;
+    knora-base:standoffTagHasStartIndex 3 ;
+    knora-base:standoffTagHasStartParent <http://rdfh.ch/0001/thing_with_richtext_with_markup/text1/standoff2> ;
+    knora-base:standoffTagHasUUID "9c9fa856-6462-4337-94f7-9328668bb17d" ;
+    a standoff:StandoffItalicTag .

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/searchmessages/SearchMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/searchmessages/SearchMessagesV2.scala
@@ -45,6 +45,7 @@ sealed trait SearchResponderRequestV2 extends KnoraRequestV2 {
 case class FullTextSearchCountGetRequestV2(searchValue: String,
                                            limitToProject: Option[IRI],
                                            limitToResourceClass: Option[SmartIri],
+                                           limitToStandoffClass: Option[SmartIri],
                                            requestingUser: UserADM) extends SearchResponderRequestV2
 
 /**
@@ -60,6 +61,7 @@ case class FulltextSearchGetRequestV2(searchValue: String,
                                       offset: Int,
                                       limitToProject: Option[IRI],
                                       limitToResourceClass: Option[SmartIri],
+                                      limitToStandoffClass: Option[SmartIri],
                                       requestingUser: UserADM) extends SearchResponderRequestV2
 
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -139,8 +139,8 @@ object SearchResponderV2Constants {
 class SearchResponderV2 extends ResponderWithStandoffV2 {
 
     def receive = {
-        case FullTextSearchCountGetRequestV2(searchValue, limitToProject, limitToResourceClass, requestingUser) => future2Message(sender(), fulltextSearchCountV2(searchValue, limitToProject, limitToResourceClass, requestingUser), log)
-        case FulltextSearchGetRequestV2(searchValue, offset, limitToProject, limitToResourceClass, requestingUser) => future2Message(sender(), fulltextSearchV2(searchValue, offset, limitToProject, limitToResourceClass, requestingUser), log)
+        case FullTextSearchCountGetRequestV2(searchValue, limitToProject, limitToResourceClass, limitToStandoffClass, requestingUser) => future2Message(sender(), fulltextSearchCountV2(searchValue, limitToProject, limitToResourceClass, limitToStandoffClass, requestingUser), log)
+        case FulltextSearchGetRequestV2(searchValue, offset, limitToProject, limitToResourceClass, limitToStandoffClass, requestingUser) => future2Message(sender(), fulltextSearchV2(searchValue, offset, limitToProject, limitToResourceClass, limitToStandoffClass, requestingUser), log)
         case ExtendedSearchCountGetRequestV2(query, requestingUser) => future2Message(sender(), extendedSearchCountV2(inputQuery = query, requestingUser = requestingUser), log)
         case ExtendedSearchGetRequestV2(query, requestingUser) => future2Message(sender(), extendedSearchV2(inputQuery = query, requestingUser = requestingUser), log)
         case SearchResourceByLabelCountGetRequestV2(searchValue, limitToProject, limitToResourceClass, requestingUser) => future2Message(sender(), searchResourcesByLabelCountV2(searchValue, limitToProject, limitToResourceClass, requestingUser), log)
@@ -1313,7 +1313,7 @@ class SearchResponderV2 extends ResponderWithStandoffV2 {
       * @param requestingUser          the the client making the request.
       * @return a [[ReadResourcesSequenceV2]] representing the amount of resources that have been found.
       */
-    private def fulltextSearchCountV2(searchValue: String, limitToProject: Option[IRI], limitToResourceClass: Option[SmartIri], requestingUser: UserADM): Future[ReadResourcesSequenceV2] = {
+    private def fulltextSearchCountV2(searchValue: String, limitToProject: Option[IRI], limitToResourceClass: Option[SmartIri], limitToStandoffClass: Option[SmartIri], requestingUser: UserADM): Future[ReadResourcesSequenceV2] = {
 
         val searchTerms: CombineSearchTerms = CombineSearchTerms(searchValue)
 
@@ -1323,6 +1323,7 @@ class SearchResponderV2 extends ResponderWithStandoffV2 {
                 searchTerms = searchTerms,
                 limitToProject = limitToProject,
                 limitToResourceClass = limitToResourceClass.map(_.toString),
+                limitToStandoffClass.map(_.toString),
                 separator = None, // no separator needed for count query
                 limit = 1,
                 offset = 0,
@@ -1356,7 +1357,7 @@ class SearchResponderV2 extends ResponderWithStandoffV2 {
       * @param requestingUser          the the client making the request.
       * @return a [[ReadResourcesSequenceV2]] representing the resources that have been found.
       */
-    private def fulltextSearchV2(searchValue: String, offset: Int, limitToProject: Option[IRI], limitToResourceClass: Option[SmartIri], requestingUser: UserADM): Future[ReadResourcesSequenceV2] = {
+    private def fulltextSearchV2(searchValue: String, offset: Int, limitToProject: Option[IRI], limitToResourceClass: Option[SmartIri], limitToStandoffClass: Option[SmartIri], requestingUser: UserADM): Future[ReadResourcesSequenceV2] = {
 
         import SearchResponderV2Constants.FullTextSearchConstants._
 
@@ -1458,6 +1459,7 @@ class SearchResponderV2 extends ResponderWithStandoffV2 {
                 searchTerms = searchTerms,
                 limitToProject = limitToProject,
                 limitToResourceClass = limitToResourceClass.map(_.toString),
+                limitToStandoffClass = limitToStandoffClass.map(_.toString),
                 separator = Some(groupConcatSeparator),
                 limit = settings.v2ResultsPerPage,
                 offset = offset * settings.v2ResultsPerPage, // determine the actual offset

--- a/webapi/src/main/twirl/queries/sparql/v2/searchFulltext.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/searchFulltext.scala.txt
@@ -31,6 +31,7 @@
  * @param searchTerms search terms.
  * @param limitToProject limit search to the given project.
  * @param limitToResourceClass limit search to given resource class.
+ * @param limitToStandoffClass limit the search to given standoff class.
  * @param separator the separator to be used in aggregation functions.
  * @param limit maximal amount of rows to be returned
  * @param offset offset for paging (starts with 0)
@@ -40,6 +41,7 @@
   searchTerms: CombineSearchTerms,
   limitToProject: Option[IRI],
   limitToResourceClass: Option[IRI],
+  limitToStandoffClass: Option[IRI],
   separator: Option[Char],
   limit: Int,
   offset: Int,
@@ -50,6 +52,7 @@
         queries.sparql.v2.txt.searchFulltextGraphDB(searchTerms = searchTerms,
                                                     limitToProject = limitToProject,
                                                     limitToResourceClass = limitToResourceClass,
+                                                    limitToStandoffClass = limitToStandoffClass,
                                                     separator = separator,
                                                     limit = limit,
                                                     offset = offset,
@@ -61,6 +64,7 @@
                                                      searchTerms = searchTerms,
                                                      limitToProject = limitToProject,
                                                      limitToResourceClass = limitToResourceClass,
+                                                     limitToStandoffClass = limitToStandoffClass,
                                                      separator = separator,
                                                      limit = limit,
                                                      offset = offset,

--- a/webapi/src/main/twirl/queries/sparql/v2/searchFulltextGraphDB.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/searchFulltextGraphDB.scala.txt
@@ -36,6 +36,7 @@
  * @param separator the separator to be used in aggregation functions.
  * @param limitToProject limit search to the given project.
  * @param limitToResourceClass limit search to given resource class.
+ * @param limitToStandoffClass limit the search to given standoff class.
  * @param limit maximal amount of rows to be returned
  * @param offset offset for paging (starts with 0)
  * @param countQuery indicates whether it is a count query or the actual resources should be returned.
@@ -43,6 +44,7 @@
 @(searchTerms: CombineSearchTerms,
   limitToProject: Option[IRI],
   limitToResourceClass: Option[IRI],
+  limitToStandoffClass: Option[IRI],
   separator: Option[Char],
   limit: Int,
   offset: Int,
@@ -66,6 +68,31 @@ WHERE {
             }
 
             ?literal <http://www.ontotext.com/owlim/lucene#fullTextSearchIndex> '@searchTerms.combineSearchTermsWithLogicalAnd' .
+
+            @* standoff search *@
+            @if(limitToStandoffClass.nonEmpty) {
+
+                # ?matchingSubject is expected to be a TextValue
+                ?matchingSubject a knora-base:TextValue .
+
+                ?matchingSubject knora-base:valueHasStandoff ?standoffNode .
+
+                ?standoffNode a <@limitToStandoffClass.get> .
+
+                ?standoffNode knora-base:standoffTagHasStart ?start .
+
+                ?standoffNode knora-base:standoffTagHasEnd ?end .
+
+                # https://www.w3.org/TR/xpath-functions/#func-substring
+                # The first character of a string is located at position 1, not position 0. -> standoff uses a 0 based index
+                BIND(SUBSTR(?literal, ?start+1, ?end - ?start) AS ?markedup)
+
+                @* Loop over search terms and make sure they are all contained in the specified standoff markup *@
+                @for(term <- searchTerms.terms) {
+                    FILTER REGEX(?markedup, '@term', "i")
+                }
+
+             }
         }
     }
 

--- a/webapi/src/main/twirl/queries/sparql/v2/searchFulltextStandard.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/searchFulltextStandard.scala.txt
@@ -34,6 +34,7 @@
  * @param searchTerms search terms.
  * @param limitToProject limit search to the given project.
  * @param limitToResourceClass limit search to given resource class.
+ * @param limitToStandoffClass limit the search to given standoff class.
  * @param separator the separator to be used in aggregation functions.
  * @param limit maximal amount of rows to be returned
  * @param offset offset for paging (starts with 0)
@@ -43,6 +44,7 @@
   searchTerms: CombineSearchTerms,
   limitToProject: Option[IRI],
   limitToResourceClass: Option[IRI],
+  limitToStandoffClass: Option[IRI],
   separator: Option[Char],
   limit: Int,
   offset: Int,

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBooleanOptional.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBooleanOptional.jsonld
@@ -1,6 +1,6 @@
 {
   "@type" : "schema:ItemList",
-  "schema:itemListElement" : [  {
+  "schema:itemListElement" : [ {
     "@id" : "http://rdfh.ch/0001/nResNuvARcWYUdWyo0GWGw",
     "@type" : "p0001-anything:Thing",
     "rdfs:label" : "X-ray"
@@ -45,6 +45,10 @@
     "@type" : "p0001-anything:Thing",
     "rdfs:label" : "A thing that has a list value"
   }, {
+    "@id" : "http://rdfh.ch/0001/thing_with_richtext_with_markup",
+    "@type" : "p0001-anything:Thing",
+    "rdfs:label" : "test thing with markup"
+  }, {
     "@id" : "http://rdfh.ch/0001/thing_with_two_list_values",
     "@type" : "p0001-anything:Thing",
     "rdfs:label" : "A thing that has two list values"
@@ -58,7 +62,7 @@
     },
     "rdfs:label" : "Testding for extended search"
   } ],
-  "schema:numberOfItems" : 13,
+  "schema:numberOfItems" : 14,
   "@context" : {
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "p0001-anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#",

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithRichtextWithTermTextInParagraph.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithRichtextWithTermTextInParagraph.jsonld
@@ -1,0 +1,22 @@
+{
+  "@type" : "schema:ItemList",
+  "schema:itemListElement" : {
+    "@id" : "http://rdfh.ch/0001/thing_with_richtext_with_markup",
+    "@type" : "anything:Thing",
+    "anything:hasRichtext" : {
+      "@id" : "http://rdfh.ch/0001/thing_with_richtext_with_markup/text1",
+      "@type" : "knora-api:TextValue",
+      "knora-api:textValueAsXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<text><p>This is a test that contains marked up elements. This is <em>interesting text</em> in italics. This is <em>boring text</em> in italics.</p></text>",
+      "knora-api:textValueHasMapping" : "http://rdfh.ch/standoff/mappings/StandardMapping"
+    },
+    "rdfs:label" : "test thing with markup"
+  },
+  "schema:numberOfItems" : 1,
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "schema" : "http://schema.org/",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+  }
+}

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -1936,6 +1936,18 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
         }
 
+        "do a fulltext search count query for the term 'text' marked up as a paragraph" in {
+
+            Get("/v2/search/count/text?limitToStandoffClass=" + URLEncoder.encode("http://api.knora.org/ontology/standoff/simple/v2#StandoffParagraphTag", "UTF-8")) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                checkCountSearchQuery(responseAs[String], 1)
+
+            }
+
+        }
+
         "do a fulltext search for the term 'text' marked up as italic" in {
 
             Get("/v2/search/text?limitToStandoffClass=" + URLEncoder.encode("http://api.knora.org/ontology/standoff/simple/v2#StandoffItalicTag", "UTF-8")) ~> searchPath ~> check {
@@ -1950,6 +1962,17 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
         }
 
+        "do a fulltext search count query for the term 'text' marked up as italic" in {
+
+            Get("/v2/search/count/text?limitToStandoffClass=" + URLEncoder.encode("http://api.knora.org/ontology/standoff/simple/v2#StandoffItalicTag", "UTF-8")) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                checkCountSearchQuery(responseAs[String], 1)
+            }
+
+        }
+
         "do a fulltext search for the terms 'interesting' and 'text' marked up as italic" in {
 
             Get("/v2/search/interesting%20text?limitToStandoffClass=" + URLEncoder.encode("http://api.knora.org/ontology/standoff/simple/v2#StandoffItalicTag", "UTF-8")) ~> searchPath ~> check {
@@ -1960,6 +1983,17 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
 
+            }
+
+        }
+
+        "do a fulltext search count query for the terms 'interesting' and 'text' marked up as italic" in {
+
+            Get("/v2/search/interesting%20text?limitToStandoffClass=" + URLEncoder.encode("http://api.knora.org/ontology/standoff/simple/v2#StandoffItalicTag", "UTF-8")) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                checkCountSearchQuery(responseAs[String], 1)
             }
 
         }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -1558,13 +1558,13 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             Get("/v2/searchextended/" + URLEncoder.encode(sparqlSimplified, "UTF-8").replace("+", "%20")) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> searchPath ~> check {
 
                 assert(status == StatusCodes.OK, response.toString)
-
+                
                 val expectedAnswerJSONLD = FileUtil.readTextFile(new File("src/test/resources/test-data/searchR2RV2/ThingWithBooleanOptional.jsonld"))
 
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
 
                 // this is the second page of results
-                checkCountSearchQuery(responseAs[String], 13)
+                checkCountSearchQuery(responseAs[String], 14)
             }
 
         }
@@ -1921,6 +1921,72 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             }
 
         }
+
+        "do a fulltext search for the term 'text' marked up as a paragraph" in {
+
+            Get("/v2/search/text?limitToStandoffClass=" + URLEncoder.encode("http://api.knora.org/ontology/standoff/simple/v2#StandoffParagraphTag", "UTF-8")) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                val expectedAnswerJSONLD = FileUtil.readTextFile(new File("src/test/resources/test-data/searchR2RV2/ThingWithRichtextWithTermTextInParagraph.jsonld"))
+
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
+
+            }
+
+        }
+
+        "do a fulltext search for the term 'text' marked up as italic" in {
+
+            Get("/v2/search/text?limitToStandoffClass=" + URLEncoder.encode("http://api.knora.org/ontology/standoff/simple/v2#StandoffItalicTag", "UTF-8")) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                val expectedAnswerJSONLD = FileUtil.readTextFile(new File("src/test/resources/test-data/searchR2RV2/ThingWithRichtextWithTermTextInParagraph.jsonld"))
+
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
+
+            }
+
+        }
+
+        "do a fulltext search for the terms 'interesting' and 'text' marked up as italic" in {
+
+            Get("/v2/search/interesting%20text?limitToStandoffClass=" + URLEncoder.encode("http://api.knora.org/ontology/standoff/simple/v2#StandoffItalicTag", "UTF-8")) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                val expectedAnswerJSONLD = FileUtil.readTextFile(new File("src/test/resources/test-data/searchR2RV2/ThingWithRichtextWithTermTextInParagraph.jsonld"))
+
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
+
+            }
+
+        }
+
+        "do a fulltext search for the terms 'interesting' and 'boring' marked up as italic" in {
+
+            Get("/v2/search/interesting%20boring?limitToStandoffClass=" + URLEncoder.encode("http://api.knora.org/ontology/standoff/simple/v2#StandoffItalicTag", "UTF-8")) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                // there is no single italic element that contains both 'interesting' and 'boring':
+
+                /*
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <text>
+                     <p>
+                         This is a test that contains marked up elements. This is <em>interesting text</em> in italics. This is <em>boring text</em> in italics.
+                     </p>
+                    </text>
+                */
+
+                checkCountSearchQuery(responseAs[String], 0)
+
+            }
+
+        }
+
 
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2Spec.scala
@@ -68,7 +68,7 @@ class SearchResponderV2Spec extends CoreSpec() with ImplicitSender {
 
         "perform a fulltext search for 'Narr'" in {
 
-            actorUnderTest ! FulltextSearchGetRequestV2(searchValue = "Narr", offset = 0, limitToProject = None, limitToResourceClass = None, SharedTestDataADM.anonymousUser)
+            actorUnderTest ! FulltextSearchGetRequestV2(searchValue = "Narr", offset = 0, limitToProject = None, limitToResourceClass = None, limitToStandoffClass = None, SharedTestDataADM.anonymousUser)
 
             expectMsgPF(timeout) {
                 case response: ReadResourcesSequenceV2 =>
@@ -82,7 +82,7 @@ class SearchResponderV2Spec extends CoreSpec() with ImplicitSender {
 
         "perform a fulltext search for 'Dinge'" in {
 
-            actorUnderTest ! FulltextSearchGetRequestV2(searchValue = "Dinge", offset = 0, limitToProject = None, limitToResourceClass = None, SharedTestDataADM.anythingUser1)
+            actorUnderTest ! FulltextSearchGetRequestV2(searchValue = "Dinge", offset = 0, limitToProject = None, limitToResourceClass = None, limitToStandoffClass = None, SharedTestDataADM.anythingUser1)
 
             expectMsgPF(timeout) {
                 case response: ReadResourcesSequenceV2 =>


### PR DESCRIPTION
This PR replaces https://github.com/dhlab-basel/Knora/pull/826 (the branch `wip/standoff_search` still has to be deleted once this PR is merged).

This PR provides the possibility to restrict a fulltext search to a standoff class. 

