### PR TITLE
Try to fix docs build breakage on Travis

### DIFF
--- a/docs/src/jekyll/Gemfile.lock
+++ b/docs/src/jekyll/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       sass (~> 3.4)
     jekyll-watch (2.0.0)
       listen (~> 3.0)
-    kramdown (1.16.2)
+    kramdown (1.17.0)
     liquid (4.0.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)


### PR DESCRIPTION
```
/home/travis/.rvm/rubies/ruby-2.5.1/lib/ruby/site_ruby/2.5.0/bundler/runtime.rb:313:in `check_for_activated_spec!': You have already activated kramdown 1.17.0, but your Gemfile requires kramdown 1.16.2. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
```
