### PR TITLE
Fix Browser Tests for Salsah1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,11 +99,11 @@ jobs:
         # install bundler
         - gem install bundler
         # install jekyll
-        - gem install jekyll -v 3.8.1
+        # - gem install jekyll -v 3.8.1
         # install typedoc
         - npm install --global typedoc
         # install jekyll dependencies
-        - cd $TRAVIS_BUILD_DIR/docs/src/jekyll && bundle install
+        - cd $TRAVIS_BUILD_DIR/docs/src/jekyll && bundle exec install
         # compile and build all docs (paradox, typescript, jekyll)
         - cd $TRAVIS_BUILD_DIR/docs && sbt makeSite
     # Salsah browser tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
         # install typedoc
         - npm install --global typedoc
         # install jekyll dependencies
-        - cd $TRAVIS_BUILD_DIR/docs/src/jekyll && bundle exec install
+        - cd $TRAVIS_BUILD_DIR/docs/src/jekyll && bundle install
         # compile and build all docs (paradox, typescript, jekyll)
         - cd $TRAVIS_BUILD_DIR/docs && sbt makeSite
     # Salsah browser tests

--- a/docs/DocsBuild.sbt
+++ b/docs/DocsBuild.sbt
@@ -69,8 +69,9 @@ buildPrequisites := {
     val clean: Seq[String] = shell :+ "make clean"
     val jsonformat: Seq[String] = shell :+ "make jsonformat"
     val graphvizfigures: Seq[String] = shell :+ "make graphvizfigures"
+    val jsonformattest: Seq[String] = shell :+ "make jsonformattest"
     s.log.info("building typescript documentation and graphviz diagrams...")
-    if ((clean #&& jsonformat #&& graphvizfigures !) == 0) {
+    if ((clean #&& jsonformat #&& jsonformattest #&& graphvizfigures !) == 0) {
         Thread.sleep(500)
         s.log.success("typescript documentation and graphviz diagrams built successfully")
     } else {

--- a/docs/DocsBuild.sbt
+++ b/docs/DocsBuild.sbt
@@ -71,7 +71,7 @@ buildPrequisites := {
     val graphvizfigures: Seq[String] = shell :+ "make graphvizfigures"
     val jsonformattest: Seq[String] = shell :+ "make jsonformattest"
     s.log.info("building typescript documentation and graphviz diagrams...")
-    if ((clean #&& jsonformat #&& jsonformattest #&& graphvizfigures !) == 0) {
+    if ((clean #&& jsonformattest #&& jsonformat #&& graphvizfigures !) == 0) {
         Thread.sleep(500)
         s.log.success("typescript documentation and graphviz diagrams built successfully")
     } else {

--- a/docs/src/paradox/05-internals/development/build-process.md
+++ b/docs/src/paradox/05-internals/development/build-process.md
@@ -30,20 +30,23 @@ TODO: complete this file.
 
 ## Building and Running
 
-### Using Fuseki
+### Starting a Triplestore
 
-Start the provided Fuseki triplestore:
+Start a triplestore (GraphDB-Free or GraphDB-SE). Download distribution from [Ontotext](http://ontotext.com). Unzip distribution
+ to a place of your choosing and run the following:
 
 ```
-$ cd KNORA_PROJECT_DIRECTORY/triplestores/fuseki
-$ ./fuseki-server
+$ cd /to/unziped/location
+$ ./bin/graphdb -Dgraphdb.license.file=/path/to/GRAPHDB_SE.license
 ```
 
-Then in another terminal, load some test data into the triplestore:
+Here we use GraphDB-SE which needs to be licensed separately.
+
+Then in another terminal, initialize the data repository and load some test data:
 
 ```
 $ cd KNORA_PROJECT_DIRECTORY/webapi/scripts
-$ ./fuseki-load-test-data.sh
+$ ./graphdb-se-local-init-knora-test.sh
 ```
 
 Then go back to the webapi root directory and use SBT to start the API
@@ -53,7 +56,7 @@ server:
 $ cd KNORA_PROJECT_DIRECTORY/webapi
 $ sbt
 > compile
-> re-start
+> reStart
 ```
 
 To shut down Knora:
@@ -198,7 +201,7 @@ $ sbt
 ```
 ### `allowReloadOverHTTP` - Flag
 
-When the webapi.server is started with the `allowReloadOverHTTP` flag,
+When the webapi.server is started with the `allowReloadOverHTTP` flag (`reStart -r`),
 then the `v1/store/ResetTriplestoreContent` route is activated. This
 route accepts a `POST` request, with a JSON payload consisting of the
 following example content:

--- a/docs/src/paradox/05-internals/development/build-process.md
+++ b/docs/src/paradox/05-internals/development/build-process.md
@@ -65,60 +65,9 @@ To shut down Knora:
 > re-stop
 ```
 
-### Using GraphDB
-
-The archive with the newest supported version of the GraphDB SE
-triplestore is provided under `triplestores/graphdb-se`. Please keep
-in mind that GraphDB-SE must be licensed separately by the user, and
-that no license file is provided in the repository. GraphDB SE will not run
-without a license file.
-
-Unzip `graphdb-se-x.x.x-dist.zip` to a place of your choosing and run
-the following, to start graphdb:
-
-```
-$ cd /to/unziped/location
-$ ./bin/graphdb -Dgraphdb.license.file=/path/to/GRAPHDB_SE.license
-```
-
-After the GraphDB inside the docker container has started, you can find
-the GraphDB workbench here: <http://localhost:7200>
-
-Then in another terminal, load some test data into the triplestore:
-
-```
-$ cd KNORA_PROJECT_DIRECTORY/webapi/scripts
-$ ./graphdb-se-local-init-knora-test.sh
-```
-
-Then go back to the webapi root directory and use SBT to start the API
-server:
-
-```
-$ cd KNORA_PROJECT_DIRECTORY/webapi
-$ sbt
-> compile
-> reStart
-```
-
-To shut down Knora:
-
-```
-> re-stop
-```
 ## Running the automated tests
 
-### Running Tests with Fuseki
-
-Make sure you've started Fuseki as shown above. Then at the SBT prompt:
-
-```
-> fuseki:test
-```
-
-### Running Tests with GraphDB
-
-Make sure GraphDB is running (as described earlier).
+Make sure you've started the triplestore as shown above.
 
 Then in another terminal, initialise the repository used for automated
 testing:

--- a/docs/src/paradox/05-internals/development/build-process.md
+++ b/docs/src/paradox/05-internals/development/build-process.md
@@ -98,7 +98,7 @@ server:
 $ cd KNORA_PROJECT_DIRECTORY/webapi
 $ sbt
 > compile
-> re-start
+> reStart
 ```
 
 To shut down Knora:

--- a/docs/src/paradox/06-salsah/index.md
+++ b/docs/src/paradox/06-salsah/index.md
@@ -36,7 +36,7 @@ with the test configuration (`--config=config/sipi.knora-test-docker-config.lua`
 the same SBT session:
 
 ```
-$ cd KNORA_PROJECT_DIRECTORY/salsah
+$ cd KNORA_PROJECT_DIRECTORY/salsah1
 $ sbt
 > compile
 > reStart

--- a/docs/src/paradox/06-salsah/index.md
+++ b/docs/src/paradox/06-salsah/index.md
@@ -31,7 +31,7 @@ download it from
 and install it in this directory.
 
 Then, launch the services as described above; the triple store with the
-test data, the wapi server with `reStart -r` (`allowReloadOverHTTP`-flag) from SBT (from ``KNORA_PROJECT_DIRECTORY/webapi``), Sipi
+test data, the Knora server with `reStart -r` (`allowReloadOverHTTP`-flag) from SBT (from ``KNORA_PROJECT_DIRECTORY/webapi``), Sipi
 with the test configuration (`--config=config/sipi.knora-test-docker-config.lua`) and SALSAH 1 where you can run the tests in
 the same SBT session:
 

--- a/docs/src/paradox/06-salsah/index.md
+++ b/docs/src/paradox/06-salsah/index.md
@@ -31,8 +31,8 @@ download it from
 and install it in this directory.
 
 Then, launch the services as described above; the triple store with the
-test data, the api server with the `-r` option, Sipi
-with the test configuration and SALSAH 1 where you can run the tests in
+test data, the wapi server with `reStart -r` (`allowReloadOverHTTP`-flag) from SBT (from ``KNORA_PROJECT_DIRECTORY/webapi``), Sipi
+with the test configuration (`--config=config/sipi.knora-test-docker-config.lua`) and SALSAH 1 where you can run the tests in
 the same SBT session:
 
 ```
@@ -43,5 +43,5 @@ $ sbt
 > test
 ```
 
-Note: please be patient as SALSAH 1 can take up to one mimute (end of a
+Note: please be patient as SALSAH 1 can take up to one minute (end of a
 time-out) before reporting some errors.

--- a/salsah1/src/test/scala/org.knora.salsah/browser/SearchAndEditSpec.scala
+++ b/salsah1/src/test/scala/org.knora.salsah/browser/SearchAndEditSpec.scala
@@ -428,7 +428,7 @@ class SearchAndEditSpec extends SalsahSpec {
             // get a list of editing fields
             val editFields = page.getEditingFieldsFromMetadataSection(metadataSection)
 
-            val pubdateField = editFields(7)
+            val pubdateField = editFields(6)
 
             page.clickEditButton(pubdateField)
 
@@ -565,7 +565,7 @@ class SearchAndEditSpec extends SalsahSpec {
             val editFields = page.getEditingFieldsFromMetadataSection(metadataSection)
 
             // get the field representing the seqnum of the page
-            val creatorField = editFields(2)
+            val creatorField = editFields(3)
 
             page.clickAddButton(creatorField)
 


### PR DESCRIPTION
Fixes failing tests in automated tests for Salsah1. Adds more instructions how run the automated browser tests for Salsah 1.

replaces #831 

closes #847 