### PR TITLE
feature (webapi): add unit to jwt-longevity setting

### DIFF
--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -273,8 +273,8 @@ app {
     // the JSON Web Token secret which should be changed.
     jwt-secret-key = "super-secret-key"
 
-    // the JSON Web Token longevity in days.
-    jwt-longevity = 30
+    // the JSON Web Token longevity
+    jwt-longevity = 30 days
 
     knora-api {
         // relevant for direct communication inside the knora stack

--- a/webapi/src/main/scala/org/knora/webapi/Settings.scala
+++ b/webapi/src/main/scala/org/knora/webapi/Settings.scala
@@ -21,6 +21,7 @@ package org.knora.webapi
 
 import java.io.File
 
+import akka.ConfigurationException
 import akka.actor.{ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigValue}
@@ -151,7 +152,7 @@ class SettingsImpl(config: Config) extends Extension {
     val skipAuthentication: Boolean = config.getBoolean("app.skip-authentication")
 
     val jwtSecretKey: String = config.getString("app.jwt-secret-key")
-    val jwtLongevity: Long = config.getLong("app.jwt-longevity")
+    val jwtLongevity: FiniteDuration = getFiniteDuration("app.jwt-longevity", config)
 
     val fallbackLanguage: String = config.getString("user.default-language")
 
@@ -165,6 +166,12 @@ class SettingsImpl(config: Config) extends Extension {
     val prometheusReporter: Boolean = config.getBoolean("app.monitoring.prometheus-reporter")
     val zipkinReporter: Boolean = config.getBoolean("app.monitoring.zipkin-reporter")
     val jaegerReporter: Boolean = config.getBoolean("app.monitoring.jaeger-reporter")
+
+
+    private def getFiniteDuration(path: String, underlying: Config): FiniteDuration = Duration(underlying.getString(path)) match {
+        case x: FiniteDuration ⇒ x
+        case _                 ⇒ throw new ConfigurationException(s"Config setting '$path' must be a finite duration")
+    }
 
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
@@ -696,15 +696,16 @@ object JWTHelper {
       * @param longevity the token's longevity in days.
       * @return a [[String]] containg the JWT.
       */
-    def createToken(userIri: IRI, secretKey: String, longevity: Long): String = {
+    def createToken(userIri: IRI, secretKey: String, longevity: FiniteDuration): String = {
 
         // create required headers
         val headers = Seq[HeaderValue](Typ("JWT"), Alg(algorithm))
 
+        // now in seconds
         val now: Long = System.currentTimeMillis() / 1000l
 
-        // calculate longevity (days)
-        val nowPlusLongevity: Long = now + longevity * 60 * 60 * 24
+        // calculate expiration time (seconds)
+        val nowPlusLongevity: Long = now + longevity.toSeconds
 
         val identifier: String = UUID.randomUUID().toString()
 

--- a/webapi/src/test/scala/org/knora/webapi/routing/AuthenticatorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/routing/AuthenticatorSpec.scala
@@ -30,11 +30,10 @@ import org.knora.webapi.messages.v2.routing.authenticationmessages.{KnoraPasswor
 import org.knora.webapi.responders._
 import org.knora.webapi.routing.Authenticator.AUTHENTICATION_INVALIDATION_CACHE_NAME
 import org.knora.webapi.util.{ActorUtil, CacheUtil}
-import org.scalatest.{Assertion, PrivateMethodTester}
+import org.scalatest.PrivateMethodTester
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.{Success, Try}
 
 object AuthenticatorSpec {
     val config = ConfigFactory.parseString(

--- a/webapi/src/test/scala/org/knora/webapi/routing/JWTHelperSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/routing/JWTHelperSpec.scala
@@ -27,6 +27,7 @@ import org.knora.webapi.messages.v1.responder.usermessages.UserProfileV1
 import org.knora.webapi.{CoreSpec, SharedTestDataV1}
 
 import scala.concurrent.duration._
+import scala.language.postfixOps
 import scala.util.Try
 
 object JWTHelperSpec {
@@ -54,7 +55,7 @@ class JWTHelperSpec extends CoreSpec("AuthenticationTestSystem") with ImplicitSe
         val secret = "123456"
 
         "create token" in {
-            val token = JWTHelper.createToken("userIri", secret, 1)
+            val token = JWTHelper.createToken("userIri", secret, 1 day)
 
             val decodedJwt: Try[Jwt] = DecodedJwt.validateEncodedJwt(
                 token,
@@ -70,11 +71,11 @@ class JWTHelperSpec extends CoreSpec("AuthenticationTestSystem") with ImplicitSe
             decodedJwt.get.getClaim[Sub].map(_.value) should be(Some("userIri"))
         }
         "validate token" in {
-            val token = JWTHelper.createToken("userIri", secret, 1)
+            val token = JWTHelper.createToken("userIri", secret, 1 day)
             JWTHelper.validateToken(token, secret) should be(true)
         }
         "extract user's IRI" in {
-            val token = JWTHelper.createToken("userIri", secret, 1)
+            val token = JWTHelper.createToken("userIri", secret, 1 day)
             JWTHelper.extractUserIriFromToken(token, secret) should be(Some("userIri"))
         }
     }


### PR DESCRIPTION
### Summary

- add unit to `jwt-longevity`

### Issues

- resolves #957 