### PR TITLE
feature (webapi): not return or allow changing of built-in users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,6 @@ jobs:
         - cd $TRAVIS_BUILD_DIR/webapi/scripts && ./graphdb-se-docker-init-knora-test-unit.sh
         # start the sipi container (with production config)
         - cd $TRAVIS_BUILD_DIR/sipi/ && docker-compose up -d
-        # - cd $TRAVIS_BUILD_DIR/sipi/ && docker run -d --add-host webapihost:$DOCKERHOST -v $PWD/config:/sipi/config -v $PWD/scripts:/sipi/scripts -v /tmp:/tmp -v $HOME:$HOME -p 1024:1024 dhlabbasel/sipi:develop --config=/sipi/config/sipi.knora-docker-it-config.lua
         # start the integration tests
         - cd $TRAVIS_BUILD_DIR/webapi/ && sbt coverage it:test coverageReport
         # upload code coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,8 @@ jobs:
         - sleep 15
         - cd $TRAVIS_BUILD_DIR/webapi/scripts && ./graphdb-se-docker-init-knora-test-unit.sh
         # start the sipi container (with production config)
-        - cd $TRAVIS_BUILD_DIR/sipi/ && docker run -d --add-host webapihost:$DOCKERHOST -v $PWD/config:/sipi/config -v $PWD/scripts:/sipi/scripts -v /tmp:/tmp -v $HOME:$HOME -p 1024:1024 dhlabbasel/sipi:develop --config=/sipi/config/sipi.knora-docker-it-config.lua
+        - cd $TRAVIS_BUILD_DIR/sipi/ && docker-compose up -d
+        # - cd $TRAVIS_BUILD_DIR/sipi/ && docker run -d --add-host webapihost:$DOCKERHOST -v $PWD/config:/sipi/config -v $PWD/scripts:/sipi/scripts -v /tmp:/tmp -v $HOME:$HOME -p 1024:1024 dhlabbasel/sipi:develop --config=/sipi/config/sipi.knora-docker-it-config.lua
         # start the integration tests
         - cd $TRAVIS_BUILD_DIR/webapi/ && sbt coverage it:test coverageReport
         # upload code coverage report

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
@@ -92,6 +92,8 @@ class UsersResponderADM extends Responder {
 
         //log.debug("usersGetV1")
 
+        // ToDO: need to have certain permissions to allow access
+
         for {
             sparqlQueryString <- Future(queries.sparql.admin.txt.getUsers(
                 triplestore = settings.triplestoreType,
@@ -1126,6 +1128,10 @@ class UsersResponderADM extends Responder {
         // log.debug("updateUserV1 - userUpdatePayload: {}", userUpdatePayload)
 
         /* Remember: some checks on UserUpdatePayloadV1 are implemented in the case class */
+
+        if (userIri.contains(KnoraSystemInstances.Users.SystemUser.id) || userIri.contains(KnoraSystemInstances.Users.AnonymousUser.id)) {
+            throw BadRequestException("Changes to built-in users are not allowed.")
+        }
 
         if (userUpdatePayload.email.nonEmpty) {
             // changing email address, so we need to invalidate the cached profile under this email

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
@@ -92,7 +92,7 @@ class UsersResponderADM extends Responder {
 
         //log.debug("usersGetV1")
 
-        // ToDO: need to have certain permissions to allow access
+        // ToDO: need to have certain permissions to allow access (#961)
 
         for {
             sparqlQueryString <- Future(queries.sparql.admin.txt.getUsers(
@@ -154,6 +154,8 @@ class UsersResponderADM extends Responder {
       */
     private def userGetADM(maybeUserIri: Option[IRI], maybeUserEmail: Option[String], userInformationType: UserInformationTypeADM, requestingUser: UserADM): Future[Option[UserADM]] = {
         // log.debug(s"userGetADM: maybeUserIri: {}, maybeUserEmail: {}, userInformationType: {}, requestingUser: {}", maybeUserIri, maybeUserEmail, userInformationType, requestingUser )
+
+        // ToDO: need to have certain permissions to allow access (#961)
 
         val userFromCache = if (maybeUserIri.nonEmpty) {
             CacheUtil.get[UserADM](USER_ADM_CACHE_NAME, maybeUserIri.get)

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
@@ -156,6 +156,10 @@ class UsersRouteADM(_system: ActorSystem, settings: SettingsImpl, log: LoggingAd
 
                             val userIri = stringFormatter.validateAndEscapeIri(value, throw BadRequestException(s"Invalid user IRI $value"))
 
+                            if (userIri.equals(KnoraSystemInstances.Users.SystemUser.id) || userIri.equals(KnoraSystemInstances.Users.AnonymousUser.id)) {
+                                throw BadRequestException("Changes to built-in users are not allowed.")
+                            }
+
                             /* the api request is already checked at time of creation. see case class. */
 
                             val requestMessage = for {
@@ -207,6 +211,10 @@ class UsersRouteADM(_system: ActorSystem, settings: SettingsImpl, log: LoggingAd
                     /* delete a user identified by iri */
                     requestContext => {
                         val userIri = stringFormatter.validateAndEscapeIri(value, throw BadRequestException(s"Invalid user IRI $value"))
+
+                        if (userIri.equals(KnoraSystemInstances.Users.SystemUser.id) || userIri.equals(KnoraSystemInstances.Users.AnonymousUser.id)) {
+                            throw BadRequestException("Changes to built-in users are not allowed.")
+                        }
 
                         /* update existing user's status to false */
                         val requestMessage = for {

--- a/webapi/src/main/twirl/queries/sparql/admin/getProjectAdminMembers.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/admin/getProjectAdminMembers.scala.txt
@@ -18,6 +18,7 @@
  *@
 
 @import org.knora.webapi.IRI
+@import org.knora.webapi.KnoraSystemInstances
 
 @**
  * Gets all admin members of a project, given the project's IRI, shortname, and/or shortcode.
@@ -59,4 +60,6 @@ WHERE {
     ?s knora-base:isInProjectAdminGroup ?project .
 
     ?s rdf:type knora-base:User .
+
+    FILTER(!(?s = IRI("@KnoraSystemInstances.Users.AnonymousUser.id") || ?s = IRI("@KnoraSystemInstances.Users.SystemUser.id")))
 }

--- a/webapi/src/main/twirl/queries/sparql/admin/getProjectMembers.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/admin/getProjectMembers.scala.txt
@@ -18,6 +18,7 @@
  *@
 
 @import org.knora.webapi.IRI
+@import org.knora.webapi.KnoraSystemInstances
 
 @**
  * Gets all members of a project, given the project's IRI, shortname, and/or shortcode.
@@ -59,4 +60,6 @@ WHERE {
     ?s knora-base:isInProject ?project .
 
     ?s rdf:type knora-base:User .
+
+    FILTER(!(?s = IRI("@KnoraSystemInstances.Users.AnonymousUser.id") || ?s = IRI("@KnoraSystemInstances.Users.SystemUser.id")))
 }

--- a/webapi/src/main/twirl/queries/sparql/admin/getUsers.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/admin/getUsers.scala.txt
@@ -18,6 +18,8 @@
  *@
 
 @import org.knora.webapi.IRI
+@import org.knora.webapi.KnoraSystemInstances
+
 
 @**
  * Gets all information about a single or all user.
@@ -50,4 +52,6 @@ WHERE {
 
     ?s rdf:type knora-base:User .
     ?s ?p ?o .
+
+    FILTER(!(?s = IRI("@KnoraSystemInstances.Users.AnonymousUser.id") || ?s = IRI("@KnoraSystemInstances.Users.SystemUser.id")))
 }

--- a/webapi/src/main/twirl/queries/sparql/admin/updateUser.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/admin/updateUser.scala.txt
@@ -18,6 +18,7 @@
  *@
 
 @import org.knora.webapi.IRI
+@import org.knora.webapi.KnoraSystemInstances
 
 @**
  * Updates an existing user with the provided values.
@@ -193,4 +194,6 @@ WHERE {
     optional {?user knora-base:isInGroup ?currentGroups .}
 
     ?user knora-base:isInSystemAdminGroup ?currentIsInSystemAdminGroup .
+
+    FILTER(!(?user = IRI("@KnoraSystemInstances.Users.AnonymousUser.id") || ?s = IRI("@KnoraSystemInstances.Users.SystemUser.id")))
 }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/UsersADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/UsersADME2ESpec.scala
@@ -32,7 +32,7 @@ import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtoc
 import org.knora.webapi.messages.v1.responder.sessionmessages.SessionJsonProtocol
 import org.knora.webapi.messages.v1.routing.authenticationmessages.CredentialsV1
 import org.knora.webapi.util.{AkkaHttpUtils, MutableTestIri}
-import org.knora.webapi.{E2ESpec, IRI, SharedTestDataADM, SharedTestDataV1}
+import org.knora.webapi._
 
 import scala.concurrent.duration._
 
@@ -301,6 +301,65 @@ class UsersADME2ESpec extends E2ESpec(UsersADME2ESpec.config) with ProjectsADMJs
                 // log.debug(jsonResult)
 
             }
+
+            "not allow changing the system user" in {
+
+                val systemUserIriEncoded = java.net.URLEncoder.encode(KnoraSystemInstances.Users.SystemUser.id, "utf-8")
+
+                val params =
+                    s"""
+                    {
+                        "status": false
+                    }
+                    """.stripMargin
+
+
+                val request = Put(baseApiUrl + s"/admin/users/" + systemUserIriEncoded, HttpEntity(ContentTypes.`application/json`, params)) ~> addCredentials(BasicHttpCredentials(rootCreds.email, rootCreds.password))
+                val response: HttpResponse = singleAwaitingRequest(request)
+                response.status should be(StatusCodes.BadRequest)
+            }
+
+            "not allow changing the anonymous user" in {
+
+                val anonymousUserIriEncoded = java.net.URLEncoder.encode(KnoraSystemInstances.Users.AnonymousUser.id, "utf-8")
+
+                val params =
+                    s"""
+                    {
+                        "status": false
+                    }
+                    """.stripMargin
+
+
+                val request = Put(baseApiUrl + s"/admin/users/" + anonymousUserIriEncoded, HttpEntity(ContentTypes.`application/json`, params)) ~> addCredentials(BasicHttpCredentials(rootCreds.email, rootCreds.password))
+                val response: HttpResponse = singleAwaitingRequest(request)
+                response.status should be(StatusCodes.BadRequest)
+            }
+
+            "not allow deleting the system user" in {
+                val systemUserIriEncoded = java.net.URLEncoder.encode(KnoraSystemInstances.Users.SystemUser.id, "utf-8")
+
+                val params =
+                    s"""
+                    {
+                        "status": false
+                    }
+                    """.stripMargin
+
+
+                val request = Delete(baseApiUrl + s"/admin/users/" + systemUserIriEncoded) ~> addCredentials(BasicHttpCredentials(rootCreds.email, rootCreds.password))
+                val response: HttpResponse = singleAwaitingRequest(request)
+                response.status should be(StatusCodes.BadRequest)
+            }
+
+            "not allow deleting the anonymous user" in {
+                val anonymousUserIriEncoded = java.net.URLEncoder.encode(KnoraSystemInstances.Users.AnonymousUser.id, "utf-8")
+
+                val request = Delete(baseApiUrl + s"/admin/users/" + anonymousUserIriEncoded) ~> addCredentials(BasicHttpCredentials(rootCreds.email, rootCreds.password))
+                val response: HttpResponse = singleAwaitingRequest(request)
+                response.status should be(StatusCodes.BadRequest)
+            }
+
         }
 
         "used to query project memberships" should {


### PR DESCRIPTION
### Summary

 - filter out the `System` and `Anonymous` user from any API requests thus not returning it
 - not allow any kind of changes to these users

### Issues

- resolves #772