### PR TITLE
Don't allow class with cardinalities on P and on a subproperty of P

### DIFF
--- a/docs/src/paradox/00-release-notes/v1.8.0.md
+++ b/docs/src/paradox/00-release-notes/v1.8.0.md
@@ -11,3 +11,5 @@ See the
 ## New features:
 
 ## Bugfixes:
+
+- trouble with xml-checker and/or consistency-checker during bulk import (@github[#978](#978))

--- a/docs/src/paradox/02-knora-ontologies/knora-base.md
+++ b/docs/src/paradox/02-knora-ontologies/knora-base.md
@@ -1475,6 +1475,8 @@ this simplified example:
 -   If it's a standoff class, none of its cardinalities may be on Knora
     resource properties, and all its base classes with Knora IRIs must
     also be standoff classes.
+-   A class cannot have a cardinality on property P as well as a cardinality
+    on a subproperty of P.
 
 ### Restrictions on properties
 

--- a/webapi/_test_data/ontologies/anything-onto.ttl
+++ b/webapi/_test_data/ontologies/anything-onto.ttl
@@ -505,18 +505,6 @@
                          owl:onProperty :hasColor ;
                          owl:minCardinality "0"^^xsd:nonNegativeInteger ;
                          salsah-gui:guiOrder "10"^^xsd:nonNegativeInteger
-                      ] ,
-                      [
-                         rdf:type owl:Restriction ;
-                         owl:onProperty :hasBlueThing ;
-                         owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-                         salsah-gui:guiOrder "63"^^xsd:nonNegativeInteger
-                      ] ,
-                      [
-                         rdf:type owl:Restriction ;
-                         owl:onProperty :hasBlueThingValue ;
-                         owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-                         salsah-gui:guiOrder "16"^^xsd:nonNegativeInteger
                       ] ;
                       #[
                       #   rdf:type owl:Restriction ;
@@ -545,7 +533,19 @@
 
 :BlueThing rdf:type owl:Class ;
 
-      rdfs:subClassOf :Thing ;
+      rdfs:subClassOf :Thing ,
+      [
+         rdf:type owl:Restriction ;
+         owl:onProperty :hasBlueThing ;
+         owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+         salsah-gui:guiOrder "63"^^xsd:nonNegativeInteger
+      ] ,
+      [
+         rdf:type owl:Restriction ;
+         owl:onProperty :hasBlueThingValue ;
+         owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+         salsah-gui:guiOrder "16"^^xsd:nonNegativeInteger
+      ] ;
 
       rdfs:comment """Diese Resource-Klasse beschreibt ein blaues Ding"""@de ;
 

--- a/webapi/_test_data/responders.v2.OntologyResponderV2Spec/class-inherits-prop-and-subprop-onto.ttl
+++ b/webapi/_test_data/responders.v2.OntologyResponderV2Spec/class-inherits-prop-and-subprop-onto.ttl
@@ -1,0 +1,73 @@
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .
+@prefix salsah-gui: <http://www.knora.org/ontology/salsah-gui#> .
+@base <http://www.knora.org/ontology/invalid> .
+
+# An ontology containing a class that inherits a property from a base class
+# and a subproperty from another base class.
+
+@prefix : <http://www.knora.org/ontology/invalid#> .
+<http://www.knora.org/ontology/invalid> rdf:type owl:Ontology ;
+    rdfs:label "The invalid ontology" ;
+    knora-base:attachedToProject <http://rdfh.ch/projects/0001> .
+
+
+:hasAuthor rdf:type owl:ObjectProperty ;
+
+               rdfs:subPropertyOf knora-base:hasValue ;
+
+               rdfs:label "has author"@en ;
+
+               knora-base:objectClassConstraint knora-base:TextValue .
+
+
+:hasPoet rdf:type owl:ObjectProperty ;
+
+               rdfs:subPropertyOf :hasAuthor ;
+
+               rdfs:label "has poet"@en ;
+
+               knora-base:objectClassConstraint knora-base:TextValue .
+
+
+:Text rdf:type owl:Class ;
+
+      rdfs:subClassOf knora-base:Resource ,
+                      [
+                         rdf:type owl:Restriction ;
+                         owl:onProperty :hasAuthor ;
+                         owl:cardinality "1"^^xsd:nonNegativeInteger ;
+                         salsah-gui:guiOrder "1"^^xsd:nonNegativeInteger
+                      ] ;
+
+      knora-base:resourceIcon "thing.png" ;
+
+      rdfs:label "text"@en .
+
+
+:Poem rdf:type owl:Class ;
+
+      rdfs:subClassOf knora-base:Resource ,
+                      [
+                         rdf:type owl:Restriction ;
+                         owl:onProperty :hasPoet ;
+                         owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+                         salsah-gui:guiOrder "2"^^xsd:nonNegativeInteger
+                      ] ;
+
+      knora-base:resourceIcon "thing.png" ;
+
+      rdfs:label "poem"@en .
+
+
+:InvalidPoem rdf:type owl:Class ;
+
+      rdfs:subClassOf :Text, :Poem ;
+
+      knora-base:resourceIcon "thing.png" ;
+
+      rdfs:label "invalid poem"@en .

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -294,6 +294,7 @@ class OntologyResponderV2 extends Responder {
             classCardinalitiesWithInheritance = classCardinalitiesWithInheritance,
             directSubClassOfRelations = directSubClassOfRelations,
             allSubClassOfRelations = allSubClassOfRelations,
+            allSubPropertyOfRelations = allSubPropertyOfRelations,
             allPropertyDefs = allPropertyDefs,
             allKnoraResourceProps = allKnoraResourceProps,
             allLinkProps = allLinkProps,
@@ -497,6 +498,7 @@ class OntologyResponderV2 extends Responder {
       *                                          [[OwlCardinalityInfo]] objects.
       * @param directSubClassOfRelations         a map of class IRIs to their immediate base classes.
       * @param allSubClassOfRelations            a map of class IRIs to all their base classes.
+      * @param allSubPropertyOfRelations         a map of property IRIs to all their base properties.
       * @param allPropertyDefs                   a map of property IRIs to property definitions.
       * @param allKnoraResourceProps             a set of the IRIs of all Knora resource properties.
       * @param allLinkProps                      a set of the IRIs of all link properties.
@@ -509,6 +511,7 @@ class OntologyResponderV2 extends Responder {
                                    classCardinalitiesWithInheritance: Map[SmartIri, Map[SmartIri, OwlCardinalityInfo]],
                                    directSubClassOfRelations: Map[SmartIri, Set[SmartIri]],
                                    allSubClassOfRelations: Map[SmartIri, Set[SmartIri]],
+                                   allSubPropertyOfRelations: Map[SmartIri, Set[SmartIri]],
                                    allPropertyDefs: Map[SmartIri, PropertyInfoContentV2],
                                    allKnoraResourceProps: Set[SmartIri],
                                    allLinkProps: Set[SmartIri],
@@ -565,6 +568,20 @@ class OntologyResponderV2 extends Responder {
 
                     if (cardinalitiesOnMissingProps.nonEmpty) {
                         throw InconsistentTriplestoreDataException(s"Class $classIri has one or more cardinalities on undefined properties: ${cardinalitiesOnMissingProps.mkString(", ")}")
+                    }
+
+                    // It cannot have cardinalities both on property P and on a subproperty of P.
+
+                    val maybePropertyAndSubproperty: Option[(SmartIri, SmartIri)] = findPropertyAndSubproperty(
+                        propertyIris = allPropertyIrisForCardinalitiesInClass,
+                        subPropertyOfRelations = allSubPropertyOfRelations
+                    )
+
+                    maybePropertyAndSubproperty match {
+                        case Some((basePropertyIri, propertyIri)) =>
+                            throw InconsistentTriplestoreDataException(s"Class $classIri has a cardinality on property $basePropertyIri and on its subproperty $propertyIri")
+
+                        case None => ()
                     }
 
                     if (isKnoraResourceClass) {
@@ -925,20 +942,20 @@ class OntologyResponderV2 extends Responder {
                         // No. Is it among the classes removed from knora-base to create the requested schema?
                         classIri.getOntologySchema.get match {
                             case apiV2Schema: ApiV2Schema =>
-                                    val internalClassIri = classIri.toOntologySchema(InternalSchema)
+                                val internalClassIri = classIri.toOntologySchema(InternalSchema)
 
-                                    val knoraBaseClassesToRemove = apiV2Schema match {
-                                        case ApiV2Simple => KnoraApiV2Simple.KnoraBaseTransformationRules.KnoraBaseClassesToRemove
-                                        case ApiV2WithValueObjects => KnoraApiV2WithValueObjects.KnoraBaseTransformationRules.KnoraBaseClassesToRemove
-                                    }
+                                val knoraBaseClassesToRemove = apiV2Schema match {
+                                    case ApiV2Simple => KnoraApiV2Simple.KnoraBaseTransformationRules.KnoraBaseClassesToRemove
+                                    case ApiV2WithValueObjects => KnoraApiV2WithValueObjects.KnoraBaseTransformationRules.KnoraBaseClassesToRemove
+                                }
 
-                                    if (knoraBaseClassesToRemove.contains(internalClassIri)) {
-                                        // Yes. Include it in the set of unavailable classes.
-                                        acc + classIri
-                                    } else {
-                                        // No. It's available.
-                                        acc
-                                    }
+                                if (knoraBaseClassesToRemove.contains(internalClassIri)) {
+                                    // Yes. Include it in the set of unavailable classes.
+                                    acc + classIri
+                                } else {
+                                    // No. It's available.
+                                    acc
+                                }
 
                             case InternalSchema => acc
                         }
@@ -1775,7 +1792,7 @@ class OntologyResponderV2 extends Responder {
         internalClassDef.directCardinalities.keySet.foreach {
             propertyIri =>
                 if (!isKnoraResourceProperty(propertyIri, cacheData) || propertyIri.toString == OntologyConstants.KnoraBase.ResourceProperty || propertyIri.toString == OntologyConstants.KnoraBase.HasValue) {
-                    throw NotFoundException(s"Invalid property for cardinality: ${propertyIri.toOntologySchema(ApiV2WithValueObjects)}")
+                    throw NotFoundException(s"Invalid property for cardinality: <${propertyIri.toOntologySchema(ApiV2WithValueObjects)}>")
                 }
         }
 
@@ -1828,7 +1845,44 @@ class OntologyResponderV2 extends Responder {
             errorFun = { msg: String => throw BadRequestException(msg) }
         )
 
+        // It cannot have cardinalities both on property P and on a subproperty of P.
+
+        val maybePropertyAndSubproperty: Option[(SmartIri, SmartIri)] = findPropertyAndSubproperty(
+            propertyIris = cardinalitiesForClassWithInheritance.keySet,
+            subPropertyOfRelations = cacheData.subPropertyOfRelations
+        )
+
+        maybePropertyAndSubproperty match {
+            case Some((basePropertyIri, propertyIri)) =>
+                throw BadRequestException(s"Class <${internalClassDef.classIri.toOntologySchema(ApiV2WithValueObjects)}> has a cardinality on property <${basePropertyIri.toOntologySchema(ApiV2WithValueObjects)}> and on its subproperty <${propertyIri.toOntologySchema(ApiV2WithValueObjects)}>")
+
+            case None => ()
+        }
+
         cardinalitiesForClassWithInheritance
+    }
+
+    /**
+      * Given a set of property IRIs, determines whether the set contains a property P and a subproperty of P.
+      *
+      * @param propertyIris           the set of property IRIs.
+      * @param subPropertyOfRelations all the subproperty relations in the triplestore.
+      * @return a property and its subproperty, if found.
+      */
+    private def findPropertyAndSubproperty(propertyIris: Set[SmartIri], subPropertyOfRelations: Map[SmartIri, Set[SmartIri]]): Option[(SmartIri, SmartIri)] = {
+        propertyIris.flatMap {
+            propertyIri =>
+                val maybeBasePropertyIri: Option[SmartIri] = (propertyIris - propertyIri).find {
+                    otherPropertyIri =>
+                        subPropertyOfRelations.get(propertyIri).exists {
+                            baseProperties: Set[SmartIri] => baseProperties.contains(otherPropertyIri)
+                        }
+                }
+
+                maybeBasePropertyIri.map {
+                    basePropertyIri => (basePropertyIri, propertyIri)
+                }
+        }.headOption
     }
 
     /**

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
@@ -468,7 +468,6 @@ class OntologyV2R2RSpec extends R2RSpec {
             """.stripMargin
 
             val expectedProperties: Set[SmartIri] = Set(
-                "http://0.0.0.0:3333/ontology/0001/anything/v2#hasBlueThing".toSmartIri,
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasName".toSmartIri,
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasInterval".toSmartIri,
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue".toSmartIri,
@@ -491,7 +490,6 @@ class OntologyV2R2RSpec extends R2RSpec {
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasDecimal".toSmartIri,
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasBoolean".toSmartIri,
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasColor".toSmartIri,
-                "http://0.0.0.0:3333/ontology/0001/anything/v2#hasBlueThingValue".toSmartIri,
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext".toSmartIri,
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasUri".toSmartIri,
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger".toSmartIri,

--- a/webapi/src/test/scala/org/knora/webapi/responders/v1/ResourcesResponderV1Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v1/ResourcesResponderV1Spec.scala
@@ -1464,13 +1464,13 @@ class ResourcesResponderV1Spec extends CoreSpec(ResourcesResponderV1Spec.config)
 
         }
 
-        "not create an anything:Thing with property anything:hasBlueThing pointing to an anything:Thing" in {
+        "not create an anything:BlueThing with property anything:hasBlueThing pointing to an anything:Thing" in {
             val valuesToBeCreated = Map(
                 "http://www.knora.org/ontology/0001/anything#hasBlueThing" -> Vector(CreateValueV1WithComment(LinkUpdateV1(targetResourceIri = "http://rdfh.ch/0001/a-thing")))
             )
 
             actorUnderTest ! ResourceCreateRequestV1(
-                resourceTypeIri = "http://www.knora.org/ontology/0001/anything#Thing",
+                resourceTypeIri = "http://www.knora.org/ontology/0001/anything#BlueThing",
                 label = "Test Thing",
                 projectIri = "http://rdfh.ch/projects/0001",
                 values = valuesToBeCreated,

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -86,7 +86,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[ForbiddenException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[ForbiddenException] should ===(true)
             }
         }
 
@@ -139,6 +141,7 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
 
             expectMsgPF(timeout) {
                 case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
                     msg.cause.isInstanceOf[BadRequestException] should ===(true)
             }
         }
@@ -152,7 +155,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[NotFoundException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[NotFoundException] should ===(true)
             }
         }
 
@@ -165,7 +170,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[ForbiddenException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[ForbiddenException] should ===(true)
             }
         }
 
@@ -247,7 +254,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[BadRequestException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[BadRequestException] should ===(true)
             }
 
         }
@@ -262,7 +271,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[BadRequestException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[BadRequestException] should ===(true)
             }
 
         }
@@ -277,7 +288,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[BadRequestException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[BadRequestException] should ===(true)
             }
 
         }
@@ -292,7 +305,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[BadRequestException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[BadRequestException] should ===(true)
             }
 
         }
@@ -307,7 +322,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[BadRequestException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[BadRequestException] should ===(true)
             }
 
         }
@@ -322,7 +339,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[BadRequestException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[BadRequestException] should ===(true)
             }
 
         }
@@ -337,7 +356,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[BadRequestException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[BadRequestException] should ===(true)
             }
 
         }
@@ -397,7 +418,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[ForbiddenException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[ForbiddenException] should ===(true)
             }
         }
 
@@ -1647,7 +1670,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[ForbiddenException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[ForbiddenException] should ===(true)
             }
 
         }
@@ -1704,7 +1729,9 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             )
 
             expectMsgPF(timeout) {
-                case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[ForbiddenException] should ===(true)
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[ForbiddenException] should ===(true)
             }
 
         }
@@ -1787,6 +1814,49 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
 
         }
 
+        "not allow a user to create a class with cardinalities both on property P and on a subproperty of P" in {
+
+            val classIri = AnythingOntologyIri.makeEntityIri("InvalidThing")
+
+            val classInfoContent = ClassInfoContentV2(
+                classIri = classIri,
+                predicates = Map(
+                    OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
+                        predicateIri = OntologyConstants.Rdf.Type.toSmartIri,
+                        objects = Seq(SmartIriLiteralV2(OntologyConstants.Owl.Class.toSmartIri))
+                    ),
+                    OntologyConstants.Rdfs.Label.toSmartIri -> PredicateInfoV2(
+                        predicateIri = OntologyConstants.Rdfs.Label.toSmartIri,
+                        objects = Seq(StringLiteralV2("invalid thing", Some("en")))
+                    ),
+                    OntologyConstants.Rdfs.Comment.toSmartIri -> PredicateInfoV2(
+                        predicateIri = OntologyConstants.Rdfs.Comment.toSmartIri,
+                        objects = Seq(StringLiteralV2("A thing that is invalid", Some("en")))
+                    )
+                ),
+                directCardinalities = Map(
+                    AnythingOntologyIri.makeEntityIri("hasOtherThing") -> KnoraCardinalityInfo(Cardinality.MustHaveOne),
+                    AnythingOntologyIri.makeEntityIri("hasBlueThing") -> KnoraCardinalityInfo(cardinality = Cardinality.MustHaveOne)
+                ),
+                subClassOf = Set(AnythingOntologyIri.makeEntityIri("Thing")),
+                ontologySchema = ApiV2WithValueObjects
+            )
+
+            actorUnderTest ! CreateClassRequestV2(
+                classInfoContent = classInfoContent,
+                lastModificationDate = anythingLastModDate,
+                apiRequestID = UUID.randomUUID,
+                requestingUser = anythingAdminUser
+            )
+
+            expectMsgPF(timeout) {
+                case msg: akka.actor.Status.Failure =>
+                    if (printErrorMessages) println(msg.cause.getMessage)
+                    msg.cause.isInstanceOf[BadRequestException] should ===(true)
+            }
+
+        }
+
         "create a class anything:WildThing that is a subclass of anything:Thing, with a direct cardinality for anything:hasName, overriding the cardinality for anything:hasInteger" in {
             val classIri = AnythingOntologyIri.makeEntityIri("WildThing")
 
@@ -1825,7 +1895,6 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 "http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo",
                 "http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue",
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThingValue",
-                "http://0.0.0.0:3333/ontology/0001/anything/v2#hasBlueThing",
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasThingPicture",
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasDate",
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasBoolean",
@@ -1836,7 +1905,6 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#isPartOfOtherThing",
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasDecimal",
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasOtherThing",
-                "http://0.0.0.0:3333/ontology/0001/anything/v2#hasBlueThingValue",
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasInteger",
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasListItem",
                 "http://0.0.0.0:3333/ontology/0001/anything/v2#hasRichtext",
@@ -3389,6 +3457,15 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
         "not load a project-specific ontology containing an owl:TransitiveProperty" in {
             val invalidOnto = List(RdfDataObject(
                 path = "_test_data/responders.v2.OntologyResponderV2Spec/transitive-prop.ttl", name = "http://www.knora.org/ontology/invalid"
+            ))
+
+            customLoadTestData(invalidOnto)
+            expectMsgType[akka.actor.Status.Failure](timeout).cause.isInstanceOf[InconsistentTriplestoreDataException] should ===(true)
+        }
+
+        "not load a project-specific ontology with a class that has cardinalities both on property P and on a subproperty of P" in {
+            val invalidOnto = List(RdfDataObject(
+                path = "_test_data/responders.v2.OntologyResponderV2Spec/class-inherits-prop-and-subprop-onto.ttl", name = "http://www.knora.org/ontology/invalid"
             ))
 
             customLoadTestData(invalidOnto)

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/GraphDBConsistencyCheckingSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/GraphDBConsistencyCheckingSpec.scala
@@ -2538,7 +2538,7 @@ object GraphDBConsistencyCheckingSpec {
           |WHERE {
           |    BIND(IRI("http://www.knora.org/data/0001/anything") AS ?dataNamedGraph)
           |    BIND(IRI("http://rdfh.ch/wrongTargetClass") AS ?resource0)
-          |    BIND(IRI("http://www.knora.org/ontology/0001/anything#Thing") AS ?resourceClass0)
+          |    BIND(IRI("http://www.knora.org/ontology/0001/anything#BlueThing") AS ?resourceClass0)
           |    BIND(IRI("http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q") AS ?creatorIri)
           |    BIND(IRI("http://rdfh.ch/projects/0001") AS ?projectIri)
           |    BIND(str("Test Thing") AS ?label0)
@@ -2609,7 +2609,7 @@ object GraphDBConsistencyCheckingSpec {
           |WHERE {
           |    BIND(IRI("http://www.knora.org/data/0001/anything") AS ?dataNamedGraph)
           |    BIND(IRI("http://rdfh.ch/twoLabels") AS ?resource)
-          |    BIND(IRI("http://www.knora.org/ontology/0001/anything#Thing") AS ?resourceClass)
+          |    BIND(IRI("http://www.knora.org/ontology/0001/anything#BlueThing") AS ?resourceClass)
           |    BIND(IRI("http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q") AS ?creatorIri)
           |    BIND(IRI("http://rdfh.ch/projects/0001") AS ?projectIri)
           |    BIND(str("Test Thing") AS ?label)


### PR DESCRIPTION
This prevents the problem described in #978.

- [x] Check for this when loading ontologies on startup.
- [x] Check for this when creating a class via API v2.
- [x] Add tests.
- [x] Update docs and release notes.

Fixes #978.
