### PR TITLE
Fix unescaping in update check and reading standoff URL

### DIFF
--- a/docs/src/paradox/00-release-notes/v3.x.x.md
+++ b/docs/src/paradox/00-release-notes/v3.x.x.md
@@ -7,4 +7,4 @@
 - [BREAKING API CHANGE] The `/admin/user` API has changed due to adding the `username` property. (@github[#1047](#1047))
 - [FIX] Incorrect standoff to XML conversion if empty tag has empty child tag (@github[#1054](#1054))
 - [FEATURE] Add default permission caching (@github[#1062](#1062))
-- [FIX] Fix unescaping of text when checking an update (@github[#1074](#1074))
+- [FIX] Fix unescaping in update check and reading standoff URL (@github[#1074](#1074))

--- a/docs/src/paradox/00-release-notes/v3.x.x.md
+++ b/docs/src/paradox/00-release-notes/v3.x.x.md
@@ -7,3 +7,4 @@
 - [BREAKING API CHANGE] The `/admin/user` API has changed due to adding the `username` property. (@github[#1047](#1047))
 - [FIX] Incorrect standoff to XML conversion if empty tag has empty child tag (@github[#1054](#1054))
 - [FEATURE] Add default permission caching (@github[#1062](#1062))
+- [FIX] Fix unescaping of text when checking an update (@github[#1074](#1074))

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -460,7 +460,7 @@ case class UpdateValueV2(resourceIri: IRI,
   * The IRI and content of a new value or value version whose existence in the triplestore needs to be verified.
   *
   * @param newValueIri the IRI that was assigned to the new value.
-  * @param value       the content of the new value.
+  * @param value       the content of the new value (still escaped as it was for the update).
   */
 case class UnverifiedValueV2(newValueIri: IRI, value: ValueContentV2, permissions: String)
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -459,10 +459,10 @@ case class UpdateValueV2(resourceIri: IRI,
 /**
   * The IRI and content of a new value or value version whose existence in the triplestore needs to be verified.
   *
-  * @param newValueIri the IRI that was assigned to the new value.
-  * @param value       the content of the new value (still escaped as it was for the update).
+  * @param newValueIri  the IRI that was assigned to the new value.
+  * @param valueContent the content of the new value (unescaped, as it would be read from the triplestore).
   */
-case class UnverifiedValueV2(newValueIri: IRI, value: ValueContentV2, permissions: String)
+case class UnverifiedValueV2(newValueIri: IRI, valueContent: ValueContentV2, permissions: String)
 
 /**
   * The content of the value of a Knora property.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
@@ -63,7 +63,7 @@ class ResourcesResponderV1 extends Responder {
       * [[Status.Failure]]. If a serious error occurs (i.e. an error that isn't the client's fault), this
       * method first returns `Failure` to the sender, then throws an exception.
       */
-    def receive = {
+    def receive: Receive = {
         case ResourceInfoGetRequestV1(resourceIri, userProfile) => future2Message(sender(), getResourceInfoResponseV1(resourceIri, userProfile), log)
         case ResourceFullGetRequestV1(resourceIri, userProfile, getIncoming) => future2Message(sender(), getFullResponseV1(resourceIri, userProfile, getIncoming), log)
         case ResourceContextGetRequestV1(resourceIri, userProfile, resinfo) => future2Message(sender(), getContextResponseV1(resourceIri, userProfile, resinfo), log)

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ValueUtilV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ValueUtilV1.scala
@@ -298,7 +298,7 @@ class ValueUtilV1(private val settings: SettingsImpl) {
                             }.foldLeft(Map.empty[String, String]) {
                                 // for each standoff node, we want to have just one Map
                                 // this foldLeft turns a Sequence of Maps into one Map (a predicate can only occur once)
-                                case (nodeValues: Map[String, String], (value: Map[String, String])) =>
+                                case (nodeValues: Map[String, String], value: Map[String, String]) =>
                                     nodeValues ++ value
                             }
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -671,7 +671,9 @@ class ResourcesResponderV2 extends ResponderWithStandoffV2 {
 
                     savedValues.zip(expectedValues).foreach {
                         case (savedValue, expectedValue) =>
-                            if (!(savedValue.valueContent.wouldDuplicateCurrentVersion(expectedValue.valueContent) &&
+                            val unescapedExpectedValueContent = expectedValue.valueContent.unescape
+
+                            if (!(unescapedExpectedValueContent.wouldDuplicateCurrentVersion(savedValue.valueContent) &&
                                 savedValue.permissions == expectedValue.permissions &&
                                 savedValue.attachedToUser == requestingUser.id)) {
                                 throw AssertionException(s"Resource <$resourceIri> was saved, but one or more of its values are not correct")

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -374,7 +374,7 @@ class ValuesResponderV2 extends Responder {
             _ <- (storeManager ? SparqlUpdateRequest(sparqlUpdate)).mapTo[SparqlUpdateResponse]
         } yield UnverifiedValueV2(
             newValueIri = newValueIri,
-            value = value.unescape,
+            value = value,
             permissions = valuePermissions
         )
     }
@@ -430,7 +430,7 @@ class ValuesResponderV2 extends Responder {
             _ <- (storeManager ? SparqlUpdateRequest(sparqlUpdate)).mapTo[SparqlUpdateResponse]
         } yield UnverifiedValueV2(
             newValueIri = sparqlTemplateLinkUpdate.newLinkValueIri,
-            value = linkValueContent.unescape,
+            value = linkValueContent,
             permissions = valuePermissions
         )
     }
@@ -983,7 +983,7 @@ class ValuesResponderV2 extends Responder {
 
         } yield UnverifiedValueV2(
             newValueIri = newValueIri,
-            value = newValueVersion.unescape,
+            value = newValueVersion,
             permissions = valuePermissions
         )
     }
@@ -1053,7 +1053,7 @@ class ValuesResponderV2 extends Responder {
             _ <- (storeManager ? SparqlUpdateRequest(sparqlUpdate)).mapTo[SparqlUpdateResponse]
         } yield UnverifiedValueV2(
             newValueIri = sparqlTemplateLinkUpdateForNewLink.newLinkValueIri,
-            value = newLinkValue.unescape,
+            value = newLinkValue,
             permissions = valuePermissions
         )
     }
@@ -1502,15 +1502,16 @@ class ValuesResponderV2 extends Responder {
 
             propertyValues = resource.values.getOrElse(propertyIriInResult, throw UpdateNotPerformedException())
             valueInTriplestore: ReadValueV2 = propertyValues.find(_.valueIri == unverifiedValue.newValueIri).getOrElse(throw UpdateNotPerformedException())
+            expectedUnescapedValueContent: ValueContentV2 = unverifiedValue.value.unescape
 
-            _ = if (!(unverifiedValue.value.wouldDuplicateCurrentVersion(valueInTriplestore.valueContent) &&
+            _ = if (!(expectedUnescapedValueContent.wouldDuplicateCurrentVersion(valueInTriplestore.valueContent) &&
                 valueInTriplestore.permissions == unverifiedValue.permissions &&
                 valueInTriplestore.attachedToUser == requestingUser.id)) {
                 /*
                 import org.knora.webapi.util.MessageUtil
                 println("==============================")
                 println("Submitted value:")
-                println(MessageUtil.toSource(unverifiedValue.value))
+                println(MessageUtil.toSource(expectedUnescapedValueContent))
                 println
                 println("==============================")
                 println("Saved value:")

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -237,7 +237,7 @@ class ValuesResponderV2 extends Responder {
 
             } yield CreateValueResponseV2(
                 valueIri = unverifiedValue.newValueIri,
-                valueType = unverifiedValue.value.valueType
+                valueType = unverifiedValue.valueContent.valueType
             )
         }
 
@@ -374,7 +374,7 @@ class ValuesResponderV2 extends Responder {
             _ <- (storeManager ? SparqlUpdateRequest(sparqlUpdate)).mapTo[SparqlUpdateResponse]
         } yield UnverifiedValueV2(
             newValueIri = newValueIri,
-            value = value,
+            valueContent = value.unescape,
             permissions = valuePermissions
         )
     }
@@ -430,7 +430,7 @@ class ValuesResponderV2 extends Responder {
             _ <- (storeManager ? SparqlUpdateRequest(sparqlUpdate)).mapTo[SparqlUpdateResponse]
         } yield UnverifiedValueV2(
             newValueIri = sparqlTemplateLinkUpdate.newLinkValueIri,
-            value = linkValueContent,
+            valueContent = linkValueContent.unescape,
             permissions = valuePermissions
         )
     }
@@ -554,7 +554,7 @@ class ValuesResponderV2 extends Responder {
             insertSparql = insertSparql,
             unverifiedValue = UnverifiedValueV2(
                 newValueIri = newValueIri,
-                value = valueToCreate.valueContent,
+                valueContent = valueToCreate.valueContent.unescape,
                 permissions = valueToCreate.permissions
             )
         )
@@ -813,7 +813,7 @@ class ValuesResponderV2 extends Responder {
 
             } yield UpdateValueResponseV2(
                 valueIri = unverifiedValue.newValueIri,
-                valueType = unverifiedValue.value.valueType
+                valueType = unverifiedValue.valueContent.valueType
             )
         }
 
@@ -983,7 +983,7 @@ class ValuesResponderV2 extends Responder {
 
         } yield UnverifiedValueV2(
             newValueIri = newValueIri,
-            value = newValueVersion,
+            valueContent = newValueVersion.unescape,
             permissions = valuePermissions
         )
     }
@@ -1053,7 +1053,7 @@ class ValuesResponderV2 extends Responder {
             _ <- (storeManager ? SparqlUpdateRequest(sparqlUpdate)).mapTo[SparqlUpdateResponse]
         } yield UnverifiedValueV2(
             newValueIri = sparqlTemplateLinkUpdateForNewLink.newLinkValueIri,
-            value = newLinkValue,
+            valueContent = newLinkValue.unescape,
             permissions = valuePermissions
         )
     }
@@ -1502,16 +1502,15 @@ class ValuesResponderV2 extends Responder {
 
             propertyValues = resource.values.getOrElse(propertyIriInResult, throw UpdateNotPerformedException())
             valueInTriplestore: ReadValueV2 = propertyValues.find(_.valueIri == unverifiedValue.newValueIri).getOrElse(throw UpdateNotPerformedException())
-            expectedUnescapedValueContent: ValueContentV2 = unverifiedValue.value.unescape
 
-            _ = if (!(expectedUnescapedValueContent.wouldDuplicateCurrentVersion(valueInTriplestore.valueContent) &&
+            _ = if (!(unverifiedValue.valueContent.wouldDuplicateCurrentVersion(valueInTriplestore.valueContent) &&
                 valueInTriplestore.permissions == unverifiedValue.permissions &&
                 valueInTriplestore.attachedToUser == requestingUser.id)) {
                 /*
                 import org.knora.webapi.util.MessageUtil
                 println("==============================")
                 println("Submitted value:")
-                println(MessageUtil.toSource(expectedUnescapedValueContent))
+                println(MessageUtil.toSource(unverifiedValue.value))
                 println
                 println("==============================")
                 println("Saved value:")

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -1510,7 +1510,7 @@ class ValuesResponderV2 extends Responder {
                 import org.knora.webapi.util.MessageUtil
                 println("==============================")
                 println("Submitted value:")
-                println(MessageUtil.toSource(unverifiedValue.value))
+                println(MessageUtil.toSource(unverifiedValue.valueContent))
                 println
                 println("==============================")
                 println("Saved value:")

--- a/webapi/src/main/scala/org/knora/webapi/util/jsonld/JsonLDUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/jsonld/JsonLDUtil.scala
@@ -794,7 +794,12 @@ object JsonLDUtil {
       * @return a [[JsonLDDocument]].
       */
     def parseJsonLD(jsonLDString: String): JsonLDDocument = {
-        val jsonObject: AnyRef = JsonUtils.fromString(jsonLDString)
+        val jsonObject: AnyRef = try {
+            JsonUtils.fromString(jsonLDString)
+        } catch {
+            case e: com.fasterxml.jackson.core.JsonParseException => throw BadRequestException(s"Couldn't parse JSON-LD: ${e.getMessage}")
+        }
+
         val context: java.util.HashMap[String, Any] = new java.util.HashMap[String, Any]()
         val options: JsonLdOptions = new JsonLdOptions()
         val compact: java.util.Map[IRI, AnyRef] = JsonLdProcessor.compact(jsonObject, context, options)

--- a/webapi/src/main/scala/org/knora/webapi/util/standoff/StandoffTagUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/standoff/StandoffTagUtilV2.scala
@@ -304,7 +304,7 @@ object StandoffTagUtilV2 {
         }
 
         textWithStandoff.standoff.map {
-            case standoffNodeFromXML: StandoffTag =>
+            standoffNodeFromXML: StandoffTag =>
 
                 val xmlNamespace = standoffNodeFromXML.xmlNamespace match {
                     case None => noNamespace
@@ -750,7 +750,8 @@ object StandoffTagUtilV2 {
                                 case Some(SmartIriLiteralV2(SmartIri(OntologyConstants.Xsd.Boolean))) =>
                                     StandoffTagBooleanAttributeV2(standoffPropertyIri = propIri, value = value.toBoolean)
 
-                                case Some(SmartIriLiteralV2(SmartIri(OntologyConstants.Xsd.Uri))) => StandoffTagIriAttributeV2(standoffPropertyIri = propIri, value = value)
+                                case Some(SmartIriLiteralV2(SmartIri(OntologyConstants.Xsd.Uri))) =>
+                                    StandoffTagUriAttributeV2(standoffPropertyIri = propIri, value = value)
 
                                 case None => throw InconsistentTriplestoreDataException(s"did not find ${OntologyConstants.KnoraBase.ObjectDatatypeConstraint} for $propIri")
 

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/CreateResourceWithEscape.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/CreateResourceWithEscape.jsonld
@@ -1,0 +1,21 @@
+{
+  "@type" : "anything:Thing",
+  "anything:hasText" : {
+    "@type" : "knora-api:TextValue",
+    "knora-api:textValueAsXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><text><p>\n test</p></text>",
+    "knora-api:textValueHasMapping" : {
+      "@id" : "http://rdfh.ch/standoff/mappings/StandardMapping"
+    }
+  },
+  "knora-api:attachedToProject" : {
+    "@id" : "http://rdfh.ch/projects/0001"
+  },
+  "rdfs:label" : "testEscape",
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+  }
+}

--- a/webapi/src/test/resources/test-data/valuesE2EV2/CreateValueWithEscape.jsonld
+++ b/webapi/src/test/resources/test-data/valuesE2EV2/CreateValueWithEscape.jsonld
@@ -1,0 +1,18 @@
+{
+  "@id" : "http://rdfh.ch/0001/a-thing",
+  "@type" : "anything:Thing",
+  "anything:hasText" : {
+    "@type" : "knora-api:TextValue",
+    "knora-api:textValueAsXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><text><p>\n test</p></text>",
+    "knora-api:textValueHasMapping" : {
+      "@id" : "http://rdfh.ch/standoff/mappings/StandardMapping"
+    }
+  },
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+  }
+}

--- a/webapi/src/test/resources/test-data/valuesE2EV2/UpdateValueWithEscape.jsonld
+++ b/webapi/src/test/resources/test-data/valuesE2EV2/UpdateValueWithEscape.jsonld
@@ -1,0 +1,19 @@
+{
+  "@id" : "http://rdfh.ch/0001/a-thing",
+  "@type" : "anything:Thing",
+  "anything:hasText" : {
+    "@id" : "VALUE_IRI",
+    "@type" : "knora-api:TextValue",
+    "knora-api:textValueAsXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?><text><p>\n test update</p></text>",
+    "knora-api:textValueHasMapping" : {
+      "@id" : "http://rdfh.ch/standoff/mappings/StandardMapping"
+    }
+  },
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+  }
+}

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ResourcesV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ResourcesV1R2RSpec.scala
@@ -970,6 +970,7 @@ class ResourcesV1R2RSpec extends R2RSpec {
 
                 // make sure that the correct standoff links and references
                 // xml3 contains a link to google.ch and to incunabulaBookBiechlin
+
                 val xml = XML.loadString(xmlString)
 
                 val links: NodeSeq = xml \ "a"
@@ -977,10 +978,12 @@ class ResourcesV1R2RSpec extends R2RSpec {
                 // there should be two links
                 assert(links.length == 2)
 
+                assert(links.head.attributes.asAttrMap.keySet.size == 1) // The URL has no class attribute
                 val linkToGoogle: Seq[Node] = links.head.attributes("href")
 
                 assert(linkToGoogle.nonEmpty && linkToGoogle.head.text == "http://www.google.ch")
 
+                assert(links(1).attributes.asAttrMap("class") == "salsah-link") // The link to a resource IRI has class="salsah-link"
                 val linkKnoraResource: Seq[Node] = links(1).attributes("href")
 
                 assert(linkKnoraResource.nonEmpty && linkKnoraResource.head.text == incunabulaBookBiechlin)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -328,7 +328,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
         }
 
         "create a resource with values" in {
-            val jsonLdEntity =
+            val jsonLDEntity =
                 """{
                   |  "@type" : "anything:Thing",
                   |  "anything:hasBoolean" : {
@@ -425,7 +425,17 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
                   |  }
                   |}""".stripMargin
 
-            val request = Post(s"$baseApiUrl/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLdEntity)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
+            val request = Post(s"$baseApiUrl/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
+            val response: HttpResponse = singleAwaitingRequest(request)
+            assert(response.status == StatusCodes.OK, response.toString)
+            val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)
+            val resourceIri: IRI = responseJsonDoc.body.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.validateAndEscapeIri)
+            assert(resourceIri.toSmartIri.isKnoraDataIri)
+        }
+
+        "create a resource containing escaped text" in {
+            val jsonLDEntity = FileUtil.readTextFile(new File("src/test/resources/test-data/resourcesR2RV2/CreateResourceWithEscape.jsonld"))
+            val request = Post(s"$baseApiUrl/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
             val response: HttpResponse = singleAwaitingRequest(request)
             assert(response.status == StatusCodes.OK, response.toString)
             val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)


### PR DESCRIPTION
This fixes two bugs:

- After a resource was created in API v2, and the values were read back from the triplestore to check that they were saved correctly, the saved values were compared with escaped expected values (e.g. a linefeed would be `\n`). This fixes the comparison so the expected values are unescaped (like the ones read from the triplestore).
- When a `StandoffUriTag` was read from the triplestore, it was given a `StandoffTagIriAttributeV2` instead of a `StandoffTagUriAttributeV2`.

Fixes #1069.