### PR TITLE
Update resource metadata in API v2

### DIFF
--- a/docs/src/paradox/00-release-notes/next.md
+++ b/docs/src/paradox/00-release-notes/next.md
@@ -12,3 +12,4 @@ Also, please change the "HINT" to the appropriate level:
 ## HINT => LEVEL
 
 - BUGFIX CHANGE: Triplestore connection error when using dockerComposeUp (@github[#1122](#1122))
+- MINOR CHANGE: Update resource metadata in API v2 (@github[#1131](#1131))

--- a/docs/src/paradox/03-apis/api-v2/editing-resources.md
+++ b/docs/src/paradox/03-apis/api-v2/editing-resources.md
@@ -201,7 +201,8 @@ The submitted JSON-LD object must also contain one or more of the following pred
 
 - `rdfs:label`: a string
 - `knora-api:hasPermissions`, in the format described in @ref:[Permissions](../../02-knora-ontologies/knora-base.md#permissions)
-- `knora-api:newModificationDate`: an `xsd:dateTimeStamp`
+- `knora-api:newModificationDate`: an [xsd:dateTimeStamp](https://www.w3.org/TR/xmlschema11-2/#dateTimeStamp).
+  This is used to make sure that the resource has not been modified by someone else since you last read it.
 
 Here is an example:
 

--- a/docs/src/paradox/03-apis/api-v2/editing-resources.md
+++ b/docs/src/paradox/03-apis/api-v2/editing-resources.md
@@ -173,6 +173,66 @@ The response is a JSON-LD document containing a
 @ref:[preview](reading-and-searching-resources.md#get-the-preview-of-a-resource-by-its-iri)
 of the resource.
 
-## Modifying a Resource
+## Modifying a Resource's Values
 
-To modify a resource, you can modify its values; see @ref:[Editing Values](editing-values.md).
+See @ref:[Editing Values](editing-values.md).
+
+## Modifying a Resource's Metadata
+
+You can modify the following metadata attached to a resource:
+
+- label
+- permissions
+- last modification date
+
+To do this, use this route:
+
+```
+HTTP PUT to http://host/v2/resources
+```
+
+The request body is a JSON-LD object containing the following information about the resource:
+
+- `@id`: the resource's IRI
+- `@type`: the resource's class IRI
+- `knora-api:lastModificationDate`: an `xsd:dateTimeStamp` representing the last modification date that is currently attached to the resource, if any
+
+The submitted JSON-LD object must also contain one or more of the following predicates, representing the metadata you want to change:
+
+- `rdfs:label`: a string
+- `knora-api:hasPermissions`, in the format described in @ref:[Permissions](../../02-knora-ontologies/knora-base.md#permissions)
+- `knora-api:newModificationDate`: an `xsd:dateTimeStamp`
+
+Here is an example:
+
+```jsonld
+{
+  "@id" : "http://rdfh.ch/0001/a-thing",
+  "@type" : "anything:Thing",
+  "rdfs:label" : "this is the new label",
+  "knora-api:hasPermissions" : "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:ProjectMember",
+  "knora-api:lastModificationDate" : {
+    "@type" : "xsd:dateTimeStamp",
+    "@value" : "2017-11-20T15:55:17Z"
+  }
+  "knora-api:newModificationDate" : {
+    "@type" : "xsd:dateTimeStamp",
+    "@value" : "2018-12-21T16:56:18Z"
+  },
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+  }
+}
+```
+
+If you submit a `knora-api:lastModificationDate` that is different from the resource's actual last modification
+date, you will get an HTTP 409 (Conflict) error.
+
+If you submit a `knora-api:newModificationDate` that is earlier than the resource's `knora-api:lastModificationDate`,
+you will get an HTTP 400 (Bad Request) error.
+
+A successful response is an HTTP 200 (OK) status containing a confirmation message.

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -699,6 +699,7 @@ object OntologyConstants {
         val HasPermissions: IRI = KnoraApiV2PrefixExpansion + "hasPermissions"
         val CreationDate: IRI = KnoraApiV2PrefixExpansion + "creationDate"
         val LastModificationDate: IRI = KnoraApiV2PrefixExpansion + "lastModificationDate"
+        val NewModificationDate: IRI = KnoraApiV2PrefixExpansion + "newModificationDate"
         val IsDeleted: IRI = KnoraApiV2PrefixExpansion + "isDeleted"
         val DeleteDate: IRI = KnoraApiV2PrefixExpansion + "deleteDate"
         val DeleteComment: IRI = KnoraApiV2PrefixExpansion + "deleteComment"

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -74,7 +74,7 @@ object OntologyConstants {
           * Cardinality IRIs expressed as OWL restrictions, which specify the properties that resources of
           * a particular type can have.
           */
-        val cardinalityOWLRestrictions = Set(
+        val cardinalityOWLRestrictions: Set[IRI] = Set(
             Cardinality,
             MinCardinality,
             MaxCardinality
@@ -135,7 +135,7 @@ object OntologyConstants {
     /**
       * Ontology labels that are reserved for built-in ontologies.
       */
-    val BuiltInOntologyLabels = Set(
+    val BuiltInOntologyLabels: Set[String] = Set(
         KnoraBase.KnoraBaseOntologyLabel,
         KnoraApi.KnoraApiOntologyLabel,
         SalsahGui.SalsahGuiOntologyLabel,
@@ -508,7 +508,7 @@ object OntologyConstants {
         val ExternalResource: IRI = OntologyConstants.KnoraBase.KnoraBasePrefixExpansion + "ExternalResource"
         val ExternalResValue: IRI = OntologyConstants.KnoraBase.KnoraBasePrefixExpansion + "ExternalResValue"
 
-        val AbstractResourceClasses = Set(
+        val AbstractResourceClasses: Set[IRI] = Set(
             Resource,
             ExternalResource,
             Representation,
@@ -740,7 +740,7 @@ object OntologyConstants {
         val TextFileValue: IRI = KnoraApiV2PrefixExpansion + "TextFileValue"
         val DocumentFileValue: IRI = KnoraApiV2PrefixExpansion + "DocumentFileValue"
 
-        val FileValueClasses = Set(
+        val FileValueClasses: Set[IRI] = Set(
             FileValue,
             StillImageFileValue,
             MovingImageFileValue,
@@ -750,7 +750,7 @@ object OntologyConstants {
             DocumentFileValue
         )
 
-        val ValueClasses = Set(
+        val ValueClasses: Set[IRI] = Set(
             TextValue,
             IntValue,
             DecimalValue,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2WithValueObjectsTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2WithValueObjectsTransformationRules.scala
@@ -247,6 +247,26 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         objectType = Some(OntologyConstants.Xsd.Boolean)
     )
 
+    private val NewModificationDate: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.NewModificationDate,
+        propertyType = OntologyConstants.Owl.DatatypeProperty,
+        predicates = Seq(
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Label,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "new modification date",
+                )
+            ),
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Comment,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "Specifies the new modification date of a resource"
+                )
+            )
+        ),
+        objectType = Some(OntologyConstants.Xsd.DateTimeStamp)
+    )
+
     private val OntologyName: ReadPropertyInfoV2 = makeProperty(
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.OntologyName,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
@@ -1415,6 +1435,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         IsLinkProperty,
         IsLinkValueProperty,
         IsInherited,
+        NewModificationDate,
         OntologyName,
         MappingHasName,
         ValueAsString,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -490,7 +490,9 @@ case class UpdateResourceMetadataRequestV2(resourceIri: IRI,
                                            lastModificationDate: Instant,
                                            maybeLabel: Option[String],
                                            maybePermissions: Option[String],
-                                           maybeNewModificationDate: Option[Instant])
+                                           maybeNewModificationDate: Option[Instant],
+                                           requestingUser: UserADM,
+                                           apiRequestID: UUID) extends ResourcesResponderRequestV2
 
 object UpdateResourceMetadataRequestV2 extends KnoraJsonLDRequestReaderV2[UpdateResourceMetadataRequestV2] {
     /**
@@ -514,10 +516,16 @@ object UpdateResourceMetadataRequestV2 extends KnoraJsonLDRequestReaderV2[Update
                             storeManager: ActorSelection,
                             settings: SettingsImpl,
                             log: LoggingAdapter)(implicit timeout: Timeout, executionContext: ExecutionContext): Future[UpdateResourceMetadataRequestV2] = {
-        Future(fromJsonLDSync(jsonLDDocument))
+        Future {
+            fromJsonLDSync(
+                jsonLDDocument = jsonLDDocument,
+                requestingUser = requestingUser,
+                apiRequestID = apiRequestID
+            )
+        }
     }
 
-    def fromJsonLDSync(jsonLDDocument: JsonLDDocument): UpdateResourceMetadataRequestV2 = {
+    def fromJsonLDSync(jsonLDDocument: JsonLDDocument, requestingUser: UserADM, apiRequestID: UUID): UpdateResourceMetadataRequestV2 = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
         val resourceIri: IRI = jsonLDDocument.getIDAsKnoraDataIri.toString
@@ -548,7 +556,9 @@ object UpdateResourceMetadataRequestV2 extends KnoraJsonLDRequestReaderV2[Update
             lastModificationDate = lastModificationDate,
             maybeLabel = maybeLabel,
             maybePermissions = maybePermissions,
-            maybeNewModificationDate = maybeNewModificationDate
+            maybeNewModificationDate = maybeNewModificationDate,
+            requestingUser = requestingUser,
+            apiRequestID = apiRequestID
         )
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -478,16 +478,16 @@ object CreateResourceRequestV2 extends KnoraJsonLDRequestReaderV2[CreateResource
 /**
   * Represents a request to update a resource's metadata.
   *
-  * @param resourceIri              the IRI of the resource.
-  * @param resourceClassIri         the IRI of the resource class.
-  * @param lastModificationDate     the resource's last modification date.
-  * @param maybeLabel               the resource's new `rdfs:label`.
-  * @param maybePermissions         the resource's new permissions.
-  * @param maybeNewModificationDate the resource's new last modification date.
+  * @param resourceIri               the IRI of the resource.
+  * @param resourceClassIri          the IRI of the resource class.
+  * @param maybeLastModificationDate the resource's last modification date, if any.
+  * @param maybeLabel                the resource's new `rdfs:label`, if any.
+  * @param maybePermissions          the resource's new permissions, if any.
+  * @param maybeNewModificationDate  the resource's new last modification date, if any.
   */
 case class UpdateResourceMetadataRequestV2(resourceIri: IRI,
                                            resourceClassIri: SmartIri,
-                                           lastModificationDate: Instant,
+                                           maybeLastModificationDate: Option[Instant],
                                            maybeLabel: Option[String],
                                            maybePermissions: Option[String],
                                            maybeNewModificationDate: Option[Instant],
@@ -531,7 +531,7 @@ object UpdateResourceMetadataRequestV2 extends KnoraJsonLDRequestReaderV2[Update
         val resourceIri: IRI = jsonLDDocument.getIDAsKnoraDataIri.toString
         val resourceClassIri: SmartIri = jsonLDDocument.getTypeAsKnoraTypeIri
 
-        val lastModificationDate: Instant = jsonLDDocument.requireDatatypeValueInObject(
+        val maybeLastModificationDate: Option[Instant] = jsonLDDocument.maybeDatatypeValueInObject(
             key = OntologyConstants.KnoraApiV2WithValueObjects.LastModificationDate,
             expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
             validationFun = stringFormatter.toInstant
@@ -553,7 +553,7 @@ object UpdateResourceMetadataRequestV2 extends KnoraJsonLDRequestReaderV2[Update
         UpdateResourceMetadataRequestV2(
             resourceIri = resourceIri,
             resourceClassIri = resourceClassIri,
-            lastModificationDate = lastModificationDate,
+            maybeLastModificationDate = maybeLastModificationDate,
             maybeLabel = maybeLabel,
             maybePermissions = maybePermissions,
             maybeNewModificationDate = maybeNewModificationDate,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -487,10 +487,10 @@ object CreateResourceRequestV2 extends KnoraJsonLDRequestReaderV2[CreateResource
   */
 case class UpdateResourceMetadataRequestV2(resourceIri: IRI,
                                            resourceClassIri: SmartIri,
-                                           maybeLastModificationDate: Option[Instant],
-                                           maybeLabel: Option[String],
-                                           maybePermissions: Option[String],
-                                           maybeNewModificationDate: Option[Instant],
+                                           maybeLastModificationDate: Option[Instant] = None,
+                                           maybeLabel: Option[String] = None,
+                                           maybePermissions: Option[String] = None,
+                                           maybeNewModificationDate: Option[Instant] = None,
                                            requestingUser: UserADM,
                                            apiRequestID: UUID) extends ResourcesResponderRequestV2
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -30,6 +30,7 @@ import org.knora.webapi._
 import org.knora.webapi.messages.admin.responder.permissionsmessages.{DefaultObjectAccessPermissionsStringForResourceClassGetADM, DefaultObjectAccessPermissionsStringResponseADM, ResourceCreateOperation}
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.store.triplestoremessages._
+import org.knora.webapi.messages.v2.responder.SuccessResponseV2
 import org.knora.webapi.messages.v2.responder.ontologymessages._
 import org.knora.webapi.messages.v2.responder.resourcemessages._
 import org.knora.webapi.messages.v2.responder.searchmessages.GravsearchRequestV2
@@ -68,6 +69,7 @@ class ResourcesResponderV2 extends ResponderWithStandoffV2 {
         case ResourcesPreviewGetRequestV2(resIris, requestingUser) => future2Message(sender(), getResourcePreview(resIris, requestingUser), log)
         case ResourceTEIGetRequestV2(resIri, textProperty, mappingIri, gravsearchTemplateIri, headerXSLTIri, requestingUser) => future2Message(sender(), getResourceAsTEI(resIri, textProperty, mappingIri, gravsearchTemplateIri, headerXSLTIri, requestingUser), log)
         case createResourceRequestV2: CreateResourceRequestV2 => future2Message(sender(), createResourceV2(createResourceRequestV2), log)
+        case updateResourceMetadataRequestV2: UpdateResourceMetadataRequestV2 => future2Message(sender(), updateResourceMetadataV2(updateResourceMetadataRequestV2), log)
         case graphDataGetRequest: GraphDataGetRequestV2 => future2Message(sender(), getGraphDataResponseV2(graphDataGetRequest), log)
         case other => handleUnexpectedMessage(sender(), other, log, this.getClass.getName)
     }
@@ -232,6 +234,17 @@ class ResourcesResponderV2 extends ResponderWithStandoffV2 {
             requestingUser = createResourceRequestV2.requestingUser
         )
 
+    }
+
+    /**
+      * Updates a resources metadata.
+      *
+      * @param updateResourceMetadataRequestV2 the update request.
+      * @return a [[SuccessResponseV2]].
+      */
+    def updateResourceMetadataV2(updateResourceMetadataRequestV2: UpdateResourceMetadataRequestV2): Future[SuccessResponseV2] = {
+        // TODO
+        Future(SuccessResponseV2("Resource metadata updated"))
     }
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -284,7 +284,12 @@ class ResourcesResponderV2 extends ResponderWithStandoffV2 {
                 dataNamedGraph: IRI = stringFormatter.projectDataNamedGraphV2(projectInfoResponse.project)
 
                 newModificationDate: Instant = updateResourceMetadataRequestV2.maybeNewModificationDate match {
-                    case Some(submittedNewModificationDate) => submittedNewModificationDate
+                    case Some(submittedNewModificationDate) =>
+                        if (resource.lastModificationDate.exists(_.isAfter(submittedNewModificationDate))) {
+                            throw BadRequestException(s"Submitted knora-api:newModificationDate is before the resource's current knora-api:lastModificationDate")
+                        } else {
+                            submittedNewModificationDate
+                        }
                     case None => Instant.now
                 }
 

--- a/webapi/src/main/twirl/queries/sparql/v2/changeResourceMetadata.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/changeResourceMetadata.scala.txt
@@ -1,0 +1,138 @@
+@*
+ * Copyright © 2015-2018 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ *@
+
+@import org.knora.webapi._
+@import org.knora.webapi.util.SmartIri
+@import java.time.Instant
+
+@*
+ * Changes the metadata of a resource.
+ *
+ * @param triplestore the name of the triplestore being used.
+ * @param dataNamedGraph the named graph in which the project stores its data.
+ * @param resourceIri the IRI of the resource.
+ * @param resourceClassIri the IRI of the resource class.
+ * @param lastModificationDate the xsd:dateTimeStamp that was attached to the resource when it was last modified.
+ * @param newModificationDate the xsd:dateTimeStamp to be attached to the resource as a result of this modification.
+ * @param maybeLabel the resource's new label, if any.
+ * @param maybePermissions the resource's new permissions, if any.
+ *@
+@(triplestore: String,
+  dataNamedGraph: IRI,
+  resourceIri: IRI,
+  resourceClassIri: SmartIri,
+  maybeLastModificationDate: Option[Instant],
+  newModificationDate: Instant,
+  maybeLabel: Option[String],
+  maybePermissions: Option[String])
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX knora-base: <http://www.knora.org/ontology/knora-base#>
+
+DELETE {
+    GRAPH ?dataNamedGraph {
+        @maybeLastModificationDate match {
+            case Some(lastModificationDate) => {
+                ?resource knora-base:lastModificationDate "@lastModificationDate"^^xsd:dateTimeStamp .
+            }
+
+            case None => {}
+        }
+
+        @maybeLabel match {
+            case Some(newLabel) => {
+                ?resource rdfs:label ?oldLabel .
+            }
+
+            case None => {}
+        }
+
+        @maybePermissions match {
+            case Some(newPermissions) => {
+                ?resource knora-base:hasPermissions ?oldPermissions .
+            }
+
+            case None => {}
+        }
+    }
+} INSERT {
+    GRAPH ?dataNamedGraph {
+        ?resource knora-base:lastModificationDate "@newModificationDate"^^xsd:dateTimeStamp .
+
+        @maybeLabel match {
+            case Some(newLabel) => {
+                ?resource rdfs:label """@newLabel"""^^xsd:string .
+            }
+
+            case None => {}
+        }
+
+        @maybePermissions match {
+            case Some(newPermissions) => {
+                ?resource knora-base:hasPermissions "@newPermissions"^^xsd:string .
+            }
+
+            case None => {}
+        }
+    }
+}
+@* Ensure that inference is not used in the WHERE clause of this update. *@
+@if(triplestore.startsWith("graphdb")) {
+    USING <http://www.ontotext.com/explicit>
+}
+WHERE {
+    BIND(IRI("@dataNamedGraph") AS ?dataNamedGraph)
+    BIND(IRI("@resourceIri") AS ?resource)
+    BIND(IRI("@resourceClassIri") AS ?resourceClass)
+
+    GRAPH ?dataNamedGraph {
+        ?resource rdf:type ?resourceClass .
+
+        @maybeLastModificationDate match {
+            case Some(lastModificationDate) => {
+                ?resource knora-base:lastModificationDate "@lastModificationDate"^^xsd:dateTimeStamp .
+            }
+
+            case None => {
+                FILTER NOT EXISTS {
+                    ?resource knora-base:lastModificationDate ?anyLastModificationDate .
+                }
+            }
+        }
+
+        @maybeLabel match {
+            case Some(newLabel) => {
+                ?resource rdfs:label ?oldLabel .
+            }
+
+            case None => {}
+        }
+
+        @maybePermissions match {
+            case Some(newPermissions) => {
+                ?resource knora-base:hasPermissions ?oldPermissions .
+            }
+
+            case None => {}
+        }
+    }
+}

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
@@ -4919,6 +4919,14 @@
       "@id" : "knora-api:valueHas"
     }
   }, {
+    "@id" : "knora-api:newModificationDate",
+    "@type" : "owl:DatatypeProperty",
+    "knora-api:objectType" : {
+      "@id" : "xsd:dateTimeStamp"
+    },
+    "rdfs:comment" : "Specifies the new modification date of a resource",
+    "rdfs:label" : "new modification date"
+  }, {
     "@id" : "knora-api:objectType",
     "@type" : "rdf:Property",
     "rdfs:comment" : "Specifies the required type of the objects of a property",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
@@ -17,40 +17,40 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic class for representing annotations</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b14"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Resource">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents something in the world, or an abstract thing</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Resource</rdfs:label>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b300"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b301"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b302"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b303"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b304"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b305"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b306"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b307"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b308"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b309"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b310"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b311"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b300"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b301"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b302"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b303"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b304"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b305"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b306"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b307"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b308"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b309"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b310"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b311"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b0">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -61,7 +61,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b1">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -72,7 +72,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b2">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -83,7 +83,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b3">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -93,7 +93,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b4">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -103,7 +103,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b5">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b5">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasComment">
@@ -118,7 +118,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b6">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -133,7 +133,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b7">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b7">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -142,7 +142,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b8">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -157,7 +157,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b9">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -172,7 +172,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b10">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b10">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOf">
@@ -186,7 +186,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b11">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b11">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOfValue">
@@ -199,7 +199,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b12">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b12">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -209,7 +209,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b13">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b13">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -218,7 +218,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b14">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b14">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -227,38 +227,38 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an audio file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b25"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#FileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b141"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b142"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b143"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b144"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b145"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b146"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b147"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b148"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b149"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b150"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b141"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b142"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b143"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b144"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b145"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b146"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b147"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b148"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b149"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b150"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b15">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b15">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b16">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b16">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#audioFileValueHasDuration">
@@ -270,17 +270,17 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b17">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b17">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b18">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b18">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b19">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b19">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -293,7 +293,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b20">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b20">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -306,17 +306,17 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b21">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b21">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b22">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b22">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b23">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b23">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -327,7 +327,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b24">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b24">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -338,7 +338,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b25">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b25">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -355,65 +355,65 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containing audio data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Audio)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b38"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Representation">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can store one or more files</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b287"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b288"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b289"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b290"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b291"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b292"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b293"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b294"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b295"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b296"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b297"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b298"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b299"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b287"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b288"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b289"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b290"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b291"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b292"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b293"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b294"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b295"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b296"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b297"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b298"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b299"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b26">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b26">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b27">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b27">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b28">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b28">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b29">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b29">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b30">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b30">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b31">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b31">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasAudioFileValue">
@@ -428,47 +428,47 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b32">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b32">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b33">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b33">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b34">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b34">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b35">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b35">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b36">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b36">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b37">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b37">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b38">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b38">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#BooleanBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b39"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b39">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b39">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean">
@@ -485,70 +485,70 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b48"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Value">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The base class of classes representing Knora values</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b491"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b492"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b493"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b494"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b495"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b496"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b497"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b498"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b491"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b492"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b493"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b494"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b495"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b496"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b497"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b498"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b40">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b40">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b41">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b41">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b42">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b42">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b43">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b43">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b44">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b44">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b45">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b45">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b46">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b46">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b47">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b47">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b48">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b48">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -556,7 +556,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ColorBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b49">
+		<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b49">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor">
@@ -575,57 +575,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in HTML format, e.g. "#33eeff"</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b51"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b58"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b50">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b50">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b51">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b51">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b52">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b52">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b53">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b53">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b54">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b54">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b55">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b55">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b56">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b56">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b57">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b57">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b58">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b58">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -634,63 +634,63 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This represents some 3D-object with mesh data, point cloud, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b62"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b63"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b66"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b63"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b68"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b59">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b59">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b60">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b60">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b61">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b61">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b62">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b62">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b63">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b63">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b64">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b64">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b65">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b65">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b66">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b66">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b67">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b67">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b68">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b68">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -700,46 +700,46 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containg 3D data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (3D)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b71"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b74"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b77"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b79"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b81"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b69">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b69">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b70">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b70">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b71">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b71">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b72">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b72">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b73">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b73">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b74">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b74">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDDDFileValue">
@@ -754,54 +754,54 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b75">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b75">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b76">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b76">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b77">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b77">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b78">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b78">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b79">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b79">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b80">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b80">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b81">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b81">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DateBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b83"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b84"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b85"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b86"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b87"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b89"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b90"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b85"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b86"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b87"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b88"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b89"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b90"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b82">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b82">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar">
@@ -813,7 +813,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b83">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b83">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay">
@@ -825,7 +825,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b84">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b84">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra">
@@ -837,7 +837,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b85">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b85">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth">
@@ -849,7 +849,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b86">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b86">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear">
@@ -861,7 +861,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b87">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b87">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay">
@@ -873,7 +873,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b88">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b88">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra">
@@ -885,7 +885,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b89">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b89">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth">
@@ -897,7 +897,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b90">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b90">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear">
@@ -914,105 +914,105 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Knora date value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b91"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b92"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b93"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b94"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b95"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b96"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b97"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b98"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b99"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b100"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b101"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b102"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b103"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b104"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b105"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b106"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b107"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b91"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b92"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b93"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b94"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b95"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b96"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b97"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b98"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b99"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b100"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b101"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b102"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b103"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b104"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b105"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b106"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b107"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b91">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b91">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b92">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b92">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b93">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b93">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b94">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b94">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b95">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b95">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b96">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b96">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b97">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b97">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b98">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b98">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b99">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b99">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b100">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b100">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b101">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b101">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b102">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b102">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b103">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b103">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b104">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b104">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b105">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b105">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b106">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b106">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b107">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b107">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1020,7 +1020,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DecimalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b108">
+		<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b108">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal">
@@ -1039,57 +1039,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary-precision decimal value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b109"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b110"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b111"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b112"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b113"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b114"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b115"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b116"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b117"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b109"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b110"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b111"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b112"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b113"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b114"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b115"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b116"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b117"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b109">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b109">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b110">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b110">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b111">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b111">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b112">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b112">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b113">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b113">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b114">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b114">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b115">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b115">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b116">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b116">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b117">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b117">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1097,63 +1097,63 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DocumentFileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b118"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b119"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b120"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b121"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b122"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b123"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b124"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b125"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b126"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b127"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b118"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b119"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b120"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b121"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b122"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b123"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b124"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b125"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b126"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b127"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b118">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b118">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b119">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b119">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b120">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b120">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b121">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b121">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b122">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b122">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b123">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b123">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b124">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b124">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b125">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b125">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b126">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b126">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b127">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b127">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1162,46 +1162,46 @@
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Document)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b128"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b129"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b130"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b131"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b132"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b133"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b134"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b135"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b136"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b137"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b138"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b139"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b140"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b128"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b129"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b130"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b131"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b132"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b133"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b134"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b135"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b136"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b137"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b138"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b139"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b140"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b128">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b128">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b129">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b129">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b130">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b130">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b131">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b131">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b132">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b132">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b133">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b133">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDocumentFileValue">
@@ -1216,85 +1216,85 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b134">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b134">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b135">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b135">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b136">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b136">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b137">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b137">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b138">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b138">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b139">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b139">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b140">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b140">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b141">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b141">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b142">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b142">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b143">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b143">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b144">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b144">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b145">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b145">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b146">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b146">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b147">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b147">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b148">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b148">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b149">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b149">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b150">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b150">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1304,80 +1304,80 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b151"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b152"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b153"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b154"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b155"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b156"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b157"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b158"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b159"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b160"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b161"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b162"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b163"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b151"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b152"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b153"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b154"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b155"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b156"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b157"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b158"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b159"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b160"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b161"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b162"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b163"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b151">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b151">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b152">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b152">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b153">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b153">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b154">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b154">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b155">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b155">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b156">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b156">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b157">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b157">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b158">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b158">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b159">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b159">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b160">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b160">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b161">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b161">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b162">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b162">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b163">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b163">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -1386,32 +1386,32 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometrical objects as JSON string</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b164"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b165"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b166"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b167"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b168"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b169"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b170"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b171"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b172"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b164"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b165"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b166"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b167"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b168"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b169"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b170"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b171"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b172"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b164">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b164">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b165">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b165">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b166">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b166">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b167">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b167">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geometryValueAsGeometry">
@@ -1423,27 +1423,27 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b168">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b168">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b169">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b169">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b170">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b170">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b171">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b171">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b172">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b172">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1451,32 +1451,32 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#GeonameValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b173"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b174"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b175"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b176"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b177"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b178"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b179"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b180"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b181"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b173"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b174"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b175"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b176"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b177"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b178"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b179"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b180"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b181"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b173">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b173">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b174">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b174">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b175">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b175">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b176">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b176">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geonameValueAsGeonameCode">
@@ -1488,27 +1488,27 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b177">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b177">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b178">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b178">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b179">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b179">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b180">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b180">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b181">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b181">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1516,7 +1516,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b182">
+		<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b182">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intValueAsInt">
@@ -1535,71 +1535,71 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b183"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b184"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b185"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b186"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b187"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b188"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b189"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b190"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b191"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b183"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b184"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b185"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b186"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b187"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b188"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b189"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b190"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b191"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b183">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b183">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b184">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b184">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b185">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b185">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b186">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b186">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b187">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b187">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b188">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b188">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b189">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b189">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b190">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b190">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b191">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b191">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntervalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b192"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b193"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b192"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b193"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b192">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b192">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b193">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b193">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
@@ -1608,63 +1608,63 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a time interval, e.g. in an audio recording</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b194"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b195"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b196"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b197"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b198"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b199"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b200"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b201"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b202"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b203"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b194"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b195"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b196"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b197"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b198"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b199"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b200"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b201"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b202"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b203"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b194">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b194">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b195">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b195">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b196">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b196">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b197">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b197">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b198">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b198">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b199">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b199">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b200">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b200">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b201">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b201">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b202">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b202">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b203">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b203">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1676,57 +1676,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a generic link object</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link Object</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b204"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b205"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b206"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b207"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b208"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b209"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b210"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b211"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b212"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b213"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b214"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b215"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b216"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b217"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b218"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b204"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b205"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b206"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b207"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b208"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b209"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b210"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b211"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b212"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b213"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b214"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b215"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b216"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b217"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b218"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b204">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b204">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b205">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b205">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b206">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b206">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b207">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b207">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b208">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b208">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b209">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b209">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b210">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b210">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b211">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b211">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkTo">
@@ -1741,7 +1741,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b212">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b212">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkToValue">
@@ -1756,32 +1756,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b213">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b213">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b214">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b214">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b215">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b215">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b216">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b216">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b217">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b217">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b218">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b218">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -1791,123 +1791,123 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A reification node that describes direct links between resources</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
 	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b219"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b220"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b221"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b222"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b223"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b224"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b225"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b226"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b227"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b228"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b229"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b219"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b220"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b221"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b222"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b223"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b224"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b225"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b226"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b227"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b228"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b229"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b219">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b219">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b220">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b220">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b221">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b221">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b222">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b222">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b223">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b223">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b224">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b224">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b225">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b225">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b226">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b226">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b227">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b227">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#object"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b228">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b228">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b229">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b229">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListNode">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a flat or hierarchical list</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b230"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b231"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b230"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b231"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b230">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b230">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b231">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b231">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b232"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b233"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b234"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b235"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b236"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b237"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b238"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b239"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b240"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b241"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b232"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b233"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b234"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b235"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b236"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b237"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b238"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b239"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b240"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b241"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b232">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b232">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b233">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b233">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b234">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b234">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b235">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b235">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b236">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b236">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b237">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b237">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#listValueAsListNode">
@@ -1919,7 +1919,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b238">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b238">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#listValueAsListNodeLabel">
@@ -1931,17 +1931,17 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b239">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b239">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b240">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b240">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b241">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b241">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1950,58 +1950,58 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a moving image file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b242"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b243"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b244"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b245"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b246"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b247"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b248"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b249"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b250"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b251"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b252"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b253"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b254"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b255"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b256"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b242"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b243"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b244"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b245"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b246"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b247"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b248"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b249"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b250"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b251"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b252"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b253"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b254"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b255"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b256"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b242">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b242">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b243">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b243">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b244">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b244">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b245">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b245">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b246">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b246">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b247">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b247">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b248">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b248">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b249">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b249">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimX">
@@ -2013,7 +2013,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b250">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b250">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimY">
@@ -2025,7 +2025,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b251">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b251">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDuration">
@@ -2037,7 +2037,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b252">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b252">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasFps">
@@ -2049,7 +2049,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b253">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b253">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasQualityLevel">
@@ -2061,17 +2061,17 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b254">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b254">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b255">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b255">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b256">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b256">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2081,51 +2081,51 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing moving image data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Movie)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b257"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b258"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b259"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b260"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b261"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b262"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b263"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b264"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b265"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b266"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b267"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b268"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b269"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b257"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b258"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b259"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b260"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b261"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b262"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b263"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b264"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b265"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b266"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b267"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b268"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b269"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b257">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b257">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b258">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b258">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b259">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b259">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b260">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b260">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b261">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b261">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b262">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b262">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b263">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b263">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasMovingImageFileValue">
@@ -2140,32 +2140,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b264">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b264">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b265">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b265">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b266">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b266">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b267">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b267">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b268">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b268">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b269">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b269">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -2177,50 +2177,50 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometric region of a resource. The geometry is represented currently as JSON string.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b270"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b271"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b272"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b273"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b274"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b275"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b276"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b277"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b278"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b279"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b280"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b281"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b282"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b283"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b284"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b285"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b286"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b270"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b271"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b272"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b273"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b274"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b275"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b276"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b277"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b278"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b279"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b280"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b281"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b282"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b283"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b284"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b285"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b286"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b270">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b270">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b271">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b271">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b272">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b272">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b273">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b273">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b274">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b274">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b275">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b275">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasColor">
@@ -2236,11 +2236,11 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b276">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b276">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b277">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b277">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasGeometry">
@@ -2255,32 +2255,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b278">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b278">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b279">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b279">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b280">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b280">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b281">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b281">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b282">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b282">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b283">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b283">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOf">
@@ -2295,7 +2295,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b284">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b284">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOfValue">
@@ -2310,42 +2310,42 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b285">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b285">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b286">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b286">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b287">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b287">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b288">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b288">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b289">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b289">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b290">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b290">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b291">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b291">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b292">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b292">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasFileValue">
@@ -2359,86 +2359,86 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b293">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b293">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b294">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b294">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b295">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b295">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b296">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b296">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b297">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b297">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b298">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b298">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b299">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b299">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b300">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b300">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b301">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b301">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b302">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b302">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b303">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b303">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b304">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b304">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b305">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b305">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b306">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b306">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b307">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b307">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b308">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b308">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b309">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b309">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b310">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b310">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b311">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b311">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -2447,35 +2447,35 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b312"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b313"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b314"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b315"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b316"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b317"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b318"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b319"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b320"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b312"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b313"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b314"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b315"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b316"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b317"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b318"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b319"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b320"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a knora-base value type in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b330"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b331"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b332"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b333"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b334"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b335"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b336"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b337"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b330"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b331"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b332"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b333"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b334"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b335"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b336"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b337"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b312">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b312">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b313">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b313">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -2485,7 +2485,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b314">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b314">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -2495,7 +2495,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b315">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b315">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -2505,7 +2505,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b316">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b316">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -2515,7 +2515,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b317">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b317">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -2525,7 +2525,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b318">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b318">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -2535,7 +2535,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b319">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b319">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -2546,7 +2546,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b320">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b320">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -2561,57 +2561,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b321"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b322"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b323"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b324"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b325"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b326"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b327"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b328"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b329"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b321"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b322"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b323"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b324"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b325"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b326"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b327"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b328"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b329"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b321">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b321">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b322">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b322">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b323">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b323">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b324">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b324">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b325">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b325">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b326">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b326">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b327">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b327">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b328">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b328">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b329">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b329">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -2619,51 +2619,51 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a standoff markup tag</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b401"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b402"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b403"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b404"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b405"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b406"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b407"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b408"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b401"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b402"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b403"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b404"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b405"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b406"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b407"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b408"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b330">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b330">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b331">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b331">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b332">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b332">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b333">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b333">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b334">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b334">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b335">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b335">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b336">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b336">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b337">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b337">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -2673,105 +2673,105 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b338"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b339"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b340"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b341"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b342"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b343"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b344"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b345"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b346"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b347"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b348"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b349"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b350"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b351"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b352"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b353"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b354"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b338"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b339"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b340"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b341"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b342"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b343"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b344"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b345"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b346"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b347"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b348"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b349"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b350"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b351"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b352"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b353"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b354"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b338">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b338">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b339">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b339">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b340">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b340">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b341">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b341">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b342">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b342">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b343">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b343">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b344">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b344">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b345">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b345">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b346">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b346">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b347">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b347">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b348">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b348">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b349">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b349">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b350">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b350">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b351">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b351">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b352">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b352">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b353">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b353">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b354">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b354">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -2781,57 +2781,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a decimal (floating point) value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b355"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b356"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b357"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b358"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b359"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b360"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b361"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b362"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b363"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b355"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b356"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b357"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b358"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b359"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b360"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b361"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b362"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b363"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b355">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b355">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b356">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b356">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b357">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b357">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b358">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b358">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b359">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b359">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b360">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b360">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b361">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b361">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b362">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b362">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b363">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b363">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -2841,57 +2841,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b364"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b365"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b366"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b367"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b368"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b369"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b370"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b371"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b372"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b364"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b365"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b366"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b367"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b368"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b369"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b370"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b371"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b372"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b364">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b364">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b365">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b365">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b366">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b366">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b367">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b367">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b368">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b368">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b369">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b369">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b370">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b370">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b371">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b371">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b372">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b372">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -2901,32 +2901,32 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an internal reference in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b373"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b374"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b375"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b376"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b377"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b378"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b379"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b380"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b381"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b373"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b374"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b375"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b376"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b377"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b378"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b379"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b380"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b381"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b373">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b373">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b374">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b374">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b375">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b375">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b376">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b376">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasInternalReference">
@@ -2935,27 +2935,27 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b377">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b377">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b378">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b378">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b379">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b379">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b380">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b380">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b381">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b381">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -2965,63 +2965,63 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an interval in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b382"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b383"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b384"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b385"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b386"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b387"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b388"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b389"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b390"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b391"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b382"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b383"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b384"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b385"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b386"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b387"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b388"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b389"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b390"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b391"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b382">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b382">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b383">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b383">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b384">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b384">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b385">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b385">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b386">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b386">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b387">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b387">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b388">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b388">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b389">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b389">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b390">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b390">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b391">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b391">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3030,32 +3030,32 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a reference to a Knora resource in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b392"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b393"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b394"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b395"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b396"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b397"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b398"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b399"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b400"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b392"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b393"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b394"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b395"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b396"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b397"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b398"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b399"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b400"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b392">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b392">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b393">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b393">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b394">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b394">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b395">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b395">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasLink">
@@ -3064,60 +3064,60 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b396">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b396">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b397">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b397">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b398">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b398">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b399">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b399">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b400">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b400">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b401">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b401">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b402">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b402">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b403">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b403">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b404">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b404">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b405">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b405">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b406">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b406">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b407">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b407">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b408">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b408">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
@@ -3126,61 +3126,61 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary URI in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b409"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b410"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b411"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b412"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b413"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b414"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b415"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b416"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b417"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b409"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b410"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b411"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b412"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b413"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b414"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b415"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b416"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b417"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#UriBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b480"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b480"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b409">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b409">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b410">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b410">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b411">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b411">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b412">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b412">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b413">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b413">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b414">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b414">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b415">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b415">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b416">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b416">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b417">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b417">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3197,56 +3197,56 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A file containing a two-dimensional still image</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b418"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b419"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b420"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b421"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b422"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b423"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b424"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b425"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b426"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b427"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b428"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b429"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b430"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b418"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b419"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b420"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b421"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b422"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b423"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b424"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b425"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b426"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b427"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b428"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b429"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b430"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b418">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b418">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b419">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b419">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b420">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b420">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b421">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b421">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b422">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b422">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b423">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b423">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b424">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b424">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b425">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b425">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimX">
@@ -3258,7 +3258,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b426">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b426">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimY">
@@ -3270,7 +3270,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b427">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b427">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasIIIFBaseUrl">
@@ -3282,17 +3282,17 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b428">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b428">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b429">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b429">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b430">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b430">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -3302,66 +3302,66 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can contain two-dimensional still image files</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Image)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b431"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b432"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b433"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b434"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b435"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b436"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b437"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b438"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b439"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b440"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b441"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b442"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b443"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b431"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b432"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b433"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b434"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b435"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b436"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b437"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b438"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b439"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b440"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b441"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b442"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b443"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b431">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b431">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b432">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b432">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b433">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b433">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b434">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b434">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b435">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b435">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b436">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b436">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b437">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b437">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b438">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b438">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b439">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b439">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b440">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b440">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue">
@@ -3376,17 +3376,17 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b441">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b441">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b442">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b442">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b443">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b443">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -3395,63 +3395,63 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A text file such as plain Unicode text, LaTeX, TEI/XML, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b444"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b445"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b446"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b447"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b448"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b449"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b450"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b451"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b452"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b453"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b444"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b445"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b446"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b447"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b448"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b449"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b450"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b451"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b452"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b453"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b444">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b444">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b445">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b445">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b446">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b446">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b447">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b447">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b448">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b448">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b449">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b449">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b450">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b450">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b451">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b451">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b452">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b452">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b453">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b453">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -3461,66 +3461,66 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing text files</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Text)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b454"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b455"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b456"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b457"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b458"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b459"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b460"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b461"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b462"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b463"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b464"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b465"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b466"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b454"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b455"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b456"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b457"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b458"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b459"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b460"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b461"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b462"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b463"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b464"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b465"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b466"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b454">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b454">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b455">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b455">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b456">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b456">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b457">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b457">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b458">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b458">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b459">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b459">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b460">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b460">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b461">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b461">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b462">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b462">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b463">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b463">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue">
@@ -3535,17 +3535,17 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b464">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b464">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b465">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b465">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b466">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b466">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -3553,46 +3553,46 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#TextValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b467"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b468"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b469"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b470"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b471"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b472"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b473"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b474"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b475"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b476"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b477"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b478"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b479"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b467"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b468"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b469"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b470"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b471"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b472"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b473"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b474"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b475"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b476"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b477"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b478"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b479"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b467">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b467">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b468">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b468">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b469">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b469">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b470">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b470">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b471">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b471">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b472">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b472">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsHtml">
@@ -3604,7 +3604,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b473">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b473">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsXml">
@@ -3616,7 +3616,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b474">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b474">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasLanguage">
@@ -3628,7 +3628,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b475">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b475">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMapping">
@@ -3640,7 +3640,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b476">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b476">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasStandoff">
@@ -3652,22 +3652,22 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b477">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b477">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b478">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b478">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b479">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b479">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b480">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b480">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
@@ -3676,57 +3676,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a URI</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b481"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b482"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b483"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b484"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b485"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b486"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b487"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b488"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b489"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b481"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b482"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b483"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b484"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b485"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b486"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b487"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b488"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b489"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b481">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b481">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b482">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b482">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b483">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b483">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b484">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b484">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b485">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b485">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b486">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b486">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b487">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b487">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b488">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b488">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b489">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b489">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -3735,7 +3735,7 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Knora user</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b490">
+		<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b490">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#username">
@@ -3747,35 +3747,35 @@
 		</owl:Restriction>
 	</rdfs:subClassOf>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b491">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b491">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b492">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b492">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b493">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b493">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b494">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b494">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b495">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b495">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b496">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b496">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b497">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b497">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b498">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b498">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
@@ -3784,80 +3784,80 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff.  The transformation's result is ecptected to be HTML.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff. The transformation's result is ecptected to be HTML.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#TextRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b499"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b500"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b501"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b502"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b503"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b504"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b505"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b506"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b507"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b508"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b509"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b510"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b511"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b499"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b500"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b501"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b502"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b503"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b504"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b505"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b506"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b507"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b508"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b509"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b510"/>
+	<rdfs:subClassOf rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b511"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b499">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b499">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b500">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b500">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b501">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b501">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b502">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b502">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b503">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b503">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b504">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b504">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b505">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b505">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b506">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b506">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b507">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b507">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b508">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b508">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b509">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b509">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b510">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b510">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b511">
+<owl:Restriction rdf:nodeID="genid-3e78a84904204b5dab5d4b015547dc8a-b511">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -3996,6 +3996,11 @@
 	<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the name of a mapping</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Name of a mapping (will be part of the mapping's Iri)</rdfs:label>
+</owl:DatatypeProperty>
+<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#newModificationDate">
+	<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#dateTimeStamp"/>
+	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Specifies the new modification date of a resource</rdfs:comment>
+	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">new modification date</rdfs:label>
 </owl:DatatypeProperty>
 <rdf:Property rdf:about="http://api.knora.org/ontology/knora-api/v2#objectType">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Specifies the required type of the objects of a property</rdfs:comment>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
@@ -2880,6 +2880,11 @@ knora-api:mappingHasName a owl:DatatypeProperty;
   rdfs:comment "Represents the name of a mapping";
   rdfs:label "Name of a mapping (will be part of the mapping's Iri)" .
 
+knora-api:newModificationDate a owl:DatatypeProperty;
+  knora-api:objectType xsd:dateTimeStamp;
+  rdfs:comment "Specifies the new modification date of a resource";
+  rdfs:label "new modification date" .
+
 knora-api:objectType a rdf:Property;
   rdfs:comment "Specifies the required type of the objects of a property";
   rdfs:label "Object type" .

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -427,11 +427,11 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(resourceIri.toSmartIri.isKnoraDataIri)
         }
 
-        "update the label and permissions of a resource" in {
-            val dateTimeStampBeforeUpdate = Instant.now
+        "update the metadata of a resource" in {
             val resourceIri = "http://rdfh.ch/0001/a-thing"
             val newLabel = "test thing with modified label"
             val newPermissions = "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:ProjectMember"
+            val newModificationDate = Instant.now.plus(java.time.Duration.ofDays(1))
 
             val jsonLDEntity =
                 s"""|{
@@ -439,6 +439,10 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
                    |  "@type" : "anything:Thing",
                    |  "rdfs:label" : "$newLabel",
                    |  "knora-api:hasPermissions" : "$newPermissions",
+                   |  "knora-api:newModificationDate" : {
+                   |    "@type" : "xsd:dateTimeStamp",
+                   |    "@value" : "$newModificationDate"
+                   |  },
                    |  "@context" : {
                    |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
                    |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
@@ -470,7 +474,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
                 validationFun = stringFormatter.toInstant
             )
 
-            assert(lastModificationDate.isAfter(dateTimeStampBeforeUpdate))
+            assert(lastModificationDate == newModificationDate)
         }
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -21,6 +21,7 @@ package org.knora.webapi.e2e.v2
 
 import java.io.File
 import java.net.URLEncoder
+import java.time.Instant
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.{Accept, BasicHttpCredentials}
@@ -33,7 +34,7 @@ import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.routing.RouteUtilV2
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.jsonld.{JsonLDConstants, JsonLDDocument, JsonLDUtil}
-import org.knora.webapi.util.{FileUtil, StringFormatter}
+import org.knora.webapi.util.{FileUtil, PermissionUtilADM, StringFormatter}
 
 import scala.concurrent.ExecutionContextExecutor
 
@@ -424,6 +425,52 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)
             val resourceIri: IRI = responseJsonDoc.body.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.validateAndEscapeIri)
             assert(resourceIri.toSmartIri.isKnoraDataIri)
+        }
+
+        "update the label and permissions of a resource" in {
+            val dateTimeStampBeforeUpdate = Instant.now
+            val resourceIri = "http://rdfh.ch/0001/a-thing"
+            val newLabel = "test thing with modified label"
+            val newPermissions = "CR knora-base:Creator|M knora-base:ProjectMember|V knora-base:ProjectMember"
+
+            val jsonLDEntity =
+                s"""|{
+                   |  "@id" : "$resourceIri",
+                   |  "@type" : "anything:Thing",
+                   |  "rdfs:label" : "$newLabel",
+                   |  "knora-api:hasPermissions" : "$newPermissions",
+                   |  "@context" : {
+                   |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                   |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+                   |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+                   |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+                   |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+                   |  }
+                   |}""".stripMargin
+
+            val updateRequest = Put(s"$baseApiUrl/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
+            val updateResponse: HttpResponse = singleAwaitingRequest(updateRequest)
+            val updateResponseAsString = responseToString(updateResponse)
+            assert(updateResponse.status == StatusCodes.OK, updateResponseAsString)
+
+            val previewRequest = Get(s"$baseApiUrl/v2/resourcespreview/${URLEncoder.encode(resourceIri, "UTF-8")}") ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
+            val previewResponse: HttpResponse = singleAwaitingRequest(previewRequest)
+            val previewResponseAsString = responseToString(previewResponse)
+            assert(previewResponse.status == StatusCodes.OK, previewResponseAsString)
+
+            val previewJsonLD = JsonLDUtil.parseJsonLD(previewResponseAsString)
+            val updatedLabel: String = previewJsonLD.requireString(OntologyConstants.Rdfs.Label)
+            assert(updatedLabel == newLabel)
+            val updatedPermissions: String = previewJsonLD.requireString(OntologyConstants.KnoraApiV2WithValueObjects.HasPermissions)
+            assert(PermissionUtilADM.parsePermissions(updatedPermissions) == PermissionUtilADM.parsePermissions(newPermissions))
+
+            val lastModificationDate: Instant = previewJsonLD.requireDatatypeValueInObject(
+                key = OntologyConstants.KnoraApiV2WithValueObjects.LastModificationDate,
+                expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
+                validationFun = stringFormatter.toInstant
+            )
+
+            assert(lastModificationDate.isAfter(dateTimeStampBeforeUpdate))
         }
     }
 }


### PR DESCRIPTION
This adds an API v2 route for updating the following resource metadata:

- [x] `rdfs:label`
- [x] permissions
- [x] last modification date

Also:

- [x] Add unit tests.
- [x] Add E2E tests.
- [x] Update docs.
- [x] Update release notes.

Resolves #1088.
Resolves #1015.
