### PR TITLE
Fix error-checking when updating cardinalities in ontology API

### DIFF
--- a/docs/src/paradox/00-release-notes/next.md
+++ b/docs/src/paradox/00-release-notes/next.md
@@ -12,3 +12,4 @@ Also, please change the "HINT" to the appropriate level:
 ## HINT => LEVEL
 
 - BUGFIX CHANGE: Triplestore connection error when using dockerComposeUp (@github[#1122](#1122))
+- BUGFIX CHANGE: Fix error-checking when updating cardinalities in ontology API (@github[#1142](#1142))

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -2368,10 +2368,8 @@ class OntologyResponderV2 extends Responder {
 
                 ontology = cacheData.ontologies(internalOntologyIri)
 
-                existingReadClassInfo: ReadClassInfoV2 = ontology.classes.getOrElse(internalClassIri,
-                    throw BadRequestException(s"Class ${changeCardinalitiesRequest.classInfoContent.classIri} does not exist"))
-
-                existingClassDef: ClassInfoContentV2 = existingReadClassInfo.entityInfoContent
+                existingClassDef: ClassInfoContentV2 = ontology.classes.getOrElse(internalClassIri,
+                    throw BadRequestException(s"Class ${changeCardinalitiesRequest.classInfoContent.classIri} does not exist")).entityInfoContent
 
                 // Check that the class isn't used in data, and that it has no subclasses.
 
@@ -2396,8 +2394,7 @@ class OntologyResponderV2 extends Responder {
                 (newInternalClassDefWithLinkValueProps, cardinalitiesForClassWithInheritance) = checkCardinalitiesBeforeAdding(
                     internalClassDef = newInternalClassDef,
                     allBaseClassIris = allBaseClassIris,
-                    cacheData = cacheData,
-                    existingLinkPropsToKeep = existingReadClassInfo.linkProperties
+                    cacheData = cacheData
                 )
 
                 // Check that the class definition doesn't refer to any non-shared ontologies in other projects.


### PR DESCRIPTION
When adding cardinalities to a class definition, we don't allow the client to submit link value properties. Instead, they're supposed to submit link properties, and we generate the corresponding link value properties automatically. The bug fixed here is that if the class already contains a link value property, the error-checking mistakenly thinks that it's from the input being processed.

Fixes #1137.