### PR TITLE
Fix property names for incoming links

### DIFF
--- a/docs/src/paradox/00-release-notes/next.md
+++ b/docs/src/paradox/00-release-notes/next.md
@@ -11,4 +11,5 @@ Also, please change the "HINT" to the appropriate level:
 
 ## HINT => LEVEL
 
+- MAJOR CHANGE: Fix property names for incoming links (@github[#1144](#1144))
 - BUGFIX CHANGE: Triplestore connection error when using dockerComposeUp (@github[#1122](#1122))

--- a/docs/src/paradox/03-apis/api-v2/query-language.md
+++ b/docs/src/paradox/03-apis/api-v2/query-language.md
@@ -140,15 +140,15 @@ as explained under @ref:[CONSTRUCT Clause](#construct-clause).
 
 ## Virtual incoming Links
 
-Depending on the ontology design, a resource A points to B or vice versa. 
-For example, a page A is part of a book B using the property  `incunabula:partOf`. 
-If A is marked as the main resource, then B is nested as a dependent resource 
+Depending on the ontology design, a resource A points to B or vice versa.
+For example, a page A is part of a book B using the property  `incunabula:partOf`.
+If A is marked as the main resource, then B is nested as a dependent resource
 in its link value `incunabula:partOfValue`. But in case B is marked as the main resource,
-B does not have a link value pointing to A because in fact B is pointed to by A. 
+B does not have a link value pointing to A because in fact B is pointed to by A.
 Instead, B has a virtual property `knora-api:hasIncomingLink` containing A's link value:
 
 ```
-"knora-api:hasIncomingLink" : {
+"knora-api:hasIncomingLinkValue" : {
     "@id" : "http://rdfh.ch/A/values/xy",
     "@type" : "knora-api:LinkValue",
     "knora-api:linkValueHasSource" : {
@@ -163,7 +163,8 @@ Instead, B has a virtual property `knora-api:hasIncomingLink` containing A's lin
       }
     }
   },
-``` 
+```
+
 Note that the virtually inserted link value inverts the relation by using `knora-api:linkValueHasSource`.
 The source of the link is A and its target B is only represented by an Iri (`knora-api:linkValueHasTargetIri`)
 since B is the main resource. 

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -135,7 +135,7 @@ object OntologyConstants {
     /**
       * Ontology labels that are reserved for built-in ontologies.
       */
-    val BuiltInOntologyLabels = Set(
+    val BuiltInOntologyLabels: Set[String] = Set(
         KnoraBase.KnoraBaseOntologyLabel,
         KnoraApi.KnoraApiOntologyLabel,
         SalsahGui.SalsahGuiOntologyLabel,
@@ -224,7 +224,7 @@ object OntologyConstants {
 
         val ResourceProperty: IRI = KnoraBasePrefixExpansion + "resourceProperty"
         val HasValue: IRI = KnoraBasePrefixExpansion + "hasValue"
-        val HasIncomingLink: IRI = KnoraBasePrefixExpansion + "hasIncomingLink"
+        val HasIncomingLinkValue: IRI = KnoraBasePrefixExpansion + "hasIncomingLinkValue"
         val HasFileValue: IRI = KnoraBasePrefixExpansion + "hasFileValue"
         val HasStillImageFileValue: IRI = KnoraBasePrefixExpansion + "hasStillImageFileValue"
         val HasMovingImageFileValue: IRI = KnoraBasePrefixExpansion + "hasMovingImageFileValue"
@@ -769,7 +769,7 @@ object OntologyConstants {
         val ValueHas: IRI = KnoraApiV2PrefixExpansion + "valueHas"
         val HasLinkTo: IRI = KnoraApiV2PrefixExpansion + "hasLinkTo"
         val HasLinkToValue: IRI = KnoraApiV2PrefixExpansion + "hasLinkToValue"
-        val HasIncomingLink: IRI = KnoraApiV2PrefixExpansion + "hasIncomingLink"
+        val HasIncomingLinkValue: IRI = KnoraApiV2PrefixExpansion + "hasIncomingLinkValue"
 
         val IsPartOf: IRI = KnoraApiV2PrefixExpansion + "isPartOf"
         val IsPartOfValue: IRI = KnoraApiV2PrefixExpansion + "isPartOfValue"

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2SimpleTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2SimpleTransformationRules.scala
@@ -278,6 +278,29 @@ object KnoraApiV2SimpleTransformationRules extends KnoraBaseTransformationRules 
         )
     )
 
+    private val HasIncomingLink: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.KnoraApiV2Simple.HasIncomingLink,
+        propertyType = OntologyConstants.Owl.ObjectProperty,
+        subjectType = Some(OntologyConstants.KnoraApiV2Simple.Resource),
+        objectType = Some(OntologyConstants.KnoraApiV2Simple.Resource),
+        subPropertyOf = Set(OntologyConstants.KnoraApiV2Simple.HasLinkTo),
+        predicates = Seq(
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Label,
+                objectsWithLang = Map(
+                    LanguageCodes.DE -> "hat eingehenden Verweis",
+                    LanguageCodes.EN -> "has incoming link"
+                )
+            ),
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Comment,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "Indicates that this resource referred to by another resource"
+                )
+            )
+        )
+    )
+
     private val ResourceCardinalites = Map(
         OntologyConstants.KnoraApiV2Simple.HasIncomingLink -> Cardinality.MayHaveMany
     )
@@ -486,7 +509,8 @@ object KnoraApiV2SimpleTransformationRules extends KnoraBaseTransformationRules 
         HasValue,
         ResourceProperty,
         SubjectType,
-        ObjectType
+        ObjectType,
+        HasIncomingLink
     ).map {
         propertyInfo => propertyInfo.entityInfoContent.propertyIri -> propertyInfo
     }.toMap

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2WithValueObjectsTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2WithValueObjectsTransformationRules.scala
@@ -287,8 +287,8 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         objectType = Some(OntologyConstants.Xsd.String)
     )
 
-    private val HasIncomingLink: ReadPropertyInfoV2 = makeProperty(
-        propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.HasIncomingLink,
+    private val HasIncomingLinkValue: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.HasIncomingLinkValue,
         isResourceProp = true,
         propertyType = OntologyConstants.Owl.ObjectProperty,
         subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.Resource),
@@ -299,8 +299,8 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
                 objectsWithLang = Map(
-                    LanguageCodes.DE -> "hat eingehende Verweise",
-                    LanguageCodes.EN -> "has incoming links"
+                    LanguageCodes.DE -> "hat eingehenden Verweis",
+                    LanguageCodes.EN -> "has incoming link"
                 )
             ),
             makePredicate(
@@ -1157,7 +1157,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
     )
 
     private val ResourceCardinalities = Map(
-        OntologyConstants.KnoraApiV2WithValueObjects.HasIncomingLink -> Cardinality.MayHaveMany
+        OntologyConstants.KnoraApiV2WithValueObjects.HasIncomingLinkValue -> Cardinality.MayHaveMany
     )
 
     private val DateBaseCardinalities = Map(
@@ -1418,7 +1418,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         OntologyName,
         MappingHasName,
         ValueAsString,
-        HasIncomingLink,
+        HasIncomingLinkValue,
         SubjectType,
         ObjectType,
         TextValueHasStandoff,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -226,6 +226,7 @@ case class ReadResourceV2(resourceIri: IRI,
 
                     // In the simple schema, use link properties instead of link value properties.
                     val adaptedPropertyIri = if (targetSchema == ApiV2Simple) {
+                        // If all the property's values are link values, it's a link value property.
                         val isLinkProp = readValues.forall {
                             readValue =>
                                 readValue.valueContent match {
@@ -234,6 +235,7 @@ case class ReadResourceV2(resourceIri: IRI,
                                 }
                         }
 
+                        // If it's a link value property, use the corresponding link property.
                         if (isLinkProp) {
                             propertyIriInTargetSchema.fromLinkValuePropToLinkProp
                         } else {

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/GravsearchQueryChecker.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/GravsearchQueryChecker.scala
@@ -148,7 +148,7 @@ object GravsearchQueryChecker {
         OntologyConstants.KnoraApiV2WithValueObjects.IsInherited,
         OntologyConstants.KnoraApiV2WithValueObjects.OntologyName,
         OntologyConstants.KnoraApiV2WithValueObjects.MappingHasName,
-        OntologyConstants.KnoraApiV2WithValueObjects.HasIncomingLink,
+        OntologyConstants.KnoraApiV2WithValueObjects.HasIncomingLinkValue,
         OntologyConstants.KnoraApiV2WithValueObjects.DateValueHasStartYear,
         OntologyConstants.KnoraApiV2WithValueObjects.DateValueHasEndYear,
         OntologyConstants.KnoraApiV2WithValueObjects.DateValueHasStartMonth,

--- a/webapi/src/main/scala/org/knora/webapi/util/ConstructResponseUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/ConstructResponseUtilV2.scala
@@ -383,7 +383,7 @@ object ConstructResponseUtilV2 {
 
             if (incomingLinkAssertions.nonEmpty) {
                 // create a virtual property representing an incoming link
-                val incomingProps: (IRI, Seq[ValueRdfData]) = OntologyConstants.KnoraBase.HasIncomingLink -> incomingLinkAssertions.values.toSeq.flatten.map {
+                val incomingProps: (IRI, Seq[ValueRdfData]) = OntologyConstants.KnoraBase.HasIncomingLinkValue -> incomingLinkAssertions.values.toSeq.flatten.map {
                     linkValue: ValueRdfData =>
 
                         // get the source of the link value (it points to the resource that is currently processed)

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/boxOntologyWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/boxOntologyWithValueObjects.jsonld
@@ -49,7 +49,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/boxOntologyWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/boxOntologyWithValueObjects.rdf
@@ -20,81 +20,81 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shared thing.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shared thing</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b12"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b0">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b1">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b2">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b3">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b4">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b5">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b6">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b7">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b7">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b8">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b9">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b10">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b11">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-bc5f09fe4ec84b77b330a3892ff28d92-b12">
+<owl:Restriction rdf:nodeID="genid-9ad22ed3d3284b7a97757fd37e55015a-b12">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/boxOntologyWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/boxOntologyWithValueObjects.ttl
@@ -53,7 +53,7 @@ example-box:Box a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologyWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologyWithValueObjects.jsonld
@@ -48,7 +48,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -171,7 +171,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -534,7 +534,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -771,7 +771,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologyWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologyWithValueObjects.rdf
@@ -17,89 +17,89 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Randleistentyp</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Randleiste</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StillImageRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b15"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b0">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b1">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b2">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b3">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b4">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b5">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b6">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b7">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b7">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b8">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b9">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b10">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b11">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b12">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b12">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b13">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b13">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -117,7 +117,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b14">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b14">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -134,7 +134,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b15">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b15">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -157,92 +157,92 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diese Resource-Klasse beschreibt ein Buch</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Book</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b39"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b16">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b16">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b17">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b17">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b18">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b18">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b19">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b19">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b20">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b20">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b21">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b21">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b22">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b22">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b23">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b23">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b24">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b24">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b25">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b25">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b26">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b26">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b27">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b27">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b28">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b28">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
@@ -261,12 +261,12 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b29">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b29">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#description"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b30">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b30">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -285,7 +285,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b31">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b31">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -304,7 +304,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b32">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b32">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -322,7 +322,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b33">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b33">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -341,7 +341,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b34">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b34">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -358,7 +358,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b35">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b35">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -377,7 +377,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b36">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b36">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -395,7 +395,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b37">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b37">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -414,7 +414,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b38">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b38">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -433,7 +433,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b39">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b39">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -471,32 +471,32 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A page is a part of a book</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Page</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StillImageRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b62"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b63"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b66"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b68"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b71"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b74"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b77"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b79"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b63"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b81"/>
 </owl:Class>
 <owl:ObjectProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasLeftSidebandValue">
 	<knora-api:isEditable rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isEditable>
@@ -538,84 +538,84 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A fake resource class that only has optional properties</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sonstiges</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b51"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b55"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b40">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b40">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b41">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b41">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b42">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b42">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b43">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b43">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b44">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b44">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b45">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b45">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b46">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b46">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b47">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b47">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b48">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b48">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b49">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b49">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b50">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b50">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b51">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b51">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b52">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b52">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -630,7 +630,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b53">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b53">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -645,7 +645,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b54">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b54">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -661,7 +661,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b55">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b55">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -689,72 +689,72 @@
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Original filename</rdfs:label>
 	<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasValue"/>
 </owl:ObjectProperty>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b56">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b56">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b57">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b57">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b58">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b58">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b59">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b59">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b60">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b60">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b61">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b61">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b62">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b62">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b63">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b63">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b64">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b64">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b65">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b65">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b66">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b66">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b67">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b67">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b68">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b68">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b69">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b69">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -772,12 +772,12 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b70">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b70">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#description"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b71">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b71">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -794,7 +794,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b72">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b72">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -811,7 +811,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b73">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b73">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -829,12 +829,12 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b74">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b74">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#citation"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b75">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b75">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -853,32 +853,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b76">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b76">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#origname"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b77">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b77">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasLeftSideband"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b78">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b78">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasLeftSidebandValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b79">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b79">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasRightSideband"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b80">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b80">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasRightSidebandValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-1be1b9d316494e7d9c97c075762aa669-b81">
+<owl:Restriction rdf:nodeID="genid-1f1ea547b99f466ab0389878fa9d4e64-b81">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologyWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologyWithValueObjects.ttl
@@ -62,7 +62,7 @@ incunabula:Sideband a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -140,7 +140,7 @@ incunabula:book a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -376,7 +376,7 @@ incunabula:page a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -521,7 +521,7 @@ incunabula:misc a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaPageAndBookWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaPageAndBookWithValueObjects.jsonld
@@ -49,7 +49,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -228,7 +228,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaPageAndBookWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaPageAndBookWithValueObjects.rdf
@@ -18,147 +18,147 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diese Resource-Klasse beschreibt ein Buch</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Book</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b23"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b0">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b1">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b2">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b3">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b4">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b5">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b6">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b7">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b7">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b8">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b9">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b10">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b11">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b12">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b12">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#title"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b13">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b13">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#description"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b14">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b14">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasAuthor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b15">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b15">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#publisher"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b16">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b16">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#publoc"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b17">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b17">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#citation"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b18">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b18">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#pubdate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b19">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b19">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#location"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b20">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b20">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#url"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b21">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b21">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#physical_desc"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b22">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b22">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#note"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b23">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b23">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#book_comment"/>
@@ -170,159 +170,159 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A page is a part of a book</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Page</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StillImageRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b49"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b24">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b24">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b25">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b25">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b26">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b26">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b27">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b27">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b28">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b28">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b29">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b29">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b30">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b30">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b31">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b31">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b32">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b32">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b33">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b33">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b34">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b34">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b35">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b35">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b36">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b36">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b37">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b37">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#pagenum"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b38">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b38">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#description"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b39">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b39">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#partOf"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b40">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b40">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#partOfValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b41">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b41">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#seqnum"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b42">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b42">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#citation"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b43">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b43">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#page_comment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b44">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b44">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#origname"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b45">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b45">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasLeftSideband"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b46">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b46">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasLeftSidebandValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b47">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b47">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasRightSideband"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b48">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b48">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasRightSidebandValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-f5a8cb049e624257bd678622f59800d2-b49">
+<owl:Restriction rdf:nodeID="genid-13419255d919422f944c27c043ad90fe-b49">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#transcription"/>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaPageAndBookWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaPageAndBookWithValueObjects.ttl
@@ -95,7 +95,7 @@ incunabula:book a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -143,7 +143,7 @@ incunabula:page a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.jsonld
@@ -783,6 +783,20 @@
       "@id" : "knora-api:hasValue"
     }
   }, {
+    "@id" : "knora-api:hasIncomingLink",
+    "@type" : "owl:ObjectProperty",
+    "knora-api:objectType" : {
+      "@id" : "knora-api:Resource"
+    },
+    "knora-api:subjectType" : {
+      "@id" : "knora-api:Resource"
+    },
+    "rdfs:comment" : "Indicates that this resource referred to by another resource",
+    "rdfs:label" : "has incoming link",
+    "rdfs:subPropertyOf" : {
+      "@id" : "knora-api:hasLinkTo"
+    }
+  }, {
     "@id" : "knora-api:hasLinkTo",
     "@type" : "owl:ObjectProperty",
     "knora-api:objectType" : {

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.rdf
@@ -12,24 +12,24 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic class for representing annotations</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b6"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Resource">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents something in the world, or an abstract thing</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Resource</rdfs:label>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b68"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b71"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b0">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b0">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#creationDate">
@@ -39,7 +39,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b1">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b1">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasComment">
@@ -51,11 +51,19 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b2">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b2">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
+	<owl:onProperty>
+		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink">
+			<knora-api:objectType rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
+			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Indicates that this resource referred to by another resource</rdfs:comment>
+			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has incoming link</rdfs:label>
+			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasLinkTo"/>
+		</owl:ObjectProperty>
+	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b3">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b3">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo">
@@ -67,7 +75,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b4">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b4">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#isAnnotationOf">
@@ -78,7 +86,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b5">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b5">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate">
@@ -86,7 +94,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b6">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b6">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -94,29 +102,29 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containing audio data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Audio)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b12"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Representation">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can store one or more files</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b62"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b63"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b63"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b66"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b7">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b7">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b8">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b8">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasAudioFile">
@@ -128,19 +136,19 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b9">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b9">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b10">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b10">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b11">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b11">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b12">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b12">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -148,10 +156,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Color literal</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b13">
+		<rdfs:Datatype rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b13">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b14">
+				<rdf:Description rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b14">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">#([0-9a-fA-F]{3}){1,2}</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -162,18 +170,18 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containg 3D data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (3D)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b20"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b15">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b15">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b16">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b16">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasDDDFile">
@@ -185,19 +193,19 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b17">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b17">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b18">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b18">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b19">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b19">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b20">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b20">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -205,10 +213,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date as a period with different possible precisions.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date literal</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b21">
+		<rdfs:Datatype rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b21">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b22">
+				<rdf:Description rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b22">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(GREGORIAN|JULIAN):\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?(:\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?)?</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -218,18 +226,18 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#DocumentRepresentation">
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Document)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b28"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b23">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b23">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b24">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b24">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasDocumentFile">
@@ -241,19 +249,19 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b25">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b25">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b26">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b26">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b27">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b27">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b28">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b28">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -266,34 +274,34 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b34"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b29">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b29">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b30">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b30">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b31">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b31">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b32">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b32">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b33">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b33">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b34">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b34">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -306,10 +314,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Geoname code.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Geoname code</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b35">
+		<rdfs:Datatype rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b35">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b36">
+				<rdf:Description rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b36">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">\d{1,8}</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -320,10 +328,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an interval.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interprivate val literal</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b37">
+		<rdfs:Datatype rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b37">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b38">
+				<rdf:Description rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b38">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">\d+(\.\d+)?,\d+(\.\d+)?</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -335,27 +343,27 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a generic link object</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link Object</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b45"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b39">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b39">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b40">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b40">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b41">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b41">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b42">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b42">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasLinkTo">
@@ -367,15 +375,15 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b43">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b43">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b44">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b44">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b45">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b45">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -383,22 +391,22 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing moving image data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Movie)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b51"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b46">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b46">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b47">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b47">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b48">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b48">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasMovingImageFile">
@@ -410,15 +418,15 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b49">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b49">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b50">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b50">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b51">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b51">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -427,21 +435,21 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometric region of a resource. The geometry is represented currently as JSON string.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b60"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b52">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b52">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b53">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b53">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasColor">
@@ -453,11 +461,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b54">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b54">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b55">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b55">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasGeometry">
@@ -469,15 +477,15 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b56">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b56">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b57">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b57">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b58">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b58">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#isRegionOf">
@@ -489,19 +497,19 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b59">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b59">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b60">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b60">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b61">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b61">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b62">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b62">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasFile">
@@ -513,39 +521,39 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b63">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b63">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b64">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b64">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b65">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b65">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b66">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b66">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b67">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b67">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b68">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b68">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b69">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b69">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b70">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b70">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b71">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b71">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -553,26 +561,26 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can contain two-dimensional still image files</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Image)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b74"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b77"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b72">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b72">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b73">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b73">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b74">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b74">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b75">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b75">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasStillImageFile">
@@ -584,11 +592,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b76">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b76">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b77">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b77">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -596,26 +604,26 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing text files</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Text)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b79"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b81"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b83"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b78">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b78">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b79">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b79">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b80">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b80">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b81">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b81">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasTextFile">
@@ -627,11 +635,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b82">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b82">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b83">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b83">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -639,34 +647,34 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff.  The transformation's result is ecptected to be HTML.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff. The transformation's result is ecptected to be HTML.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#TextRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b84"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b85"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b86"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b87"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b89"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b85"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b86"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b87"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b88"/>
+	<rdfs:subClassOf rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b89"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b84">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b84">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b85">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b85">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b86">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b86">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b87">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b87">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasTextFile"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b88">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b88">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6b4345773f254131a7938ecb2b808fe5-b89">
+<owl:Restriction rdf:nodeID="genid-f1c5d53c2931436b83962d489e95b543-b89">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.ttl
@@ -65,6 +65,13 @@ knora-api:hasComment a owl:DatatypeProperty;
   rdfs:label "Comment";
   rdfs:subPropertyOf knora-api:hasValue .
 
+knora-api:hasIncomingLink a owl:ObjectProperty;
+  knora-api:objectType knora-api:Resource;
+  knora-api:subjectType knora-api:Resource;
+  rdfs:comment "Indicates that this resource referred to by another resource";
+  rdfs:label "has incoming link";
+  rdfs:subPropertyOf knora-api:hasLinkTo .
+
 knora-api:hasStandoffLinkTo a owl:ObjectProperty;
   knora-api:objectType knora-api:Resource;
   knora-api:subjectType knora-api:Resource;

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
@@ -54,7 +54,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -249,7 +249,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -596,7 +596,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -1045,7 +1045,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -1219,7 +1219,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -1642,7 +1642,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -2031,7 +2031,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -2150,7 +2150,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -2261,7 +2261,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -2346,7 +2346,7 @@
       "@type" : "owl:Restriction",
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -3363,7 +3363,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -3540,7 +3540,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -3889,7 +3889,7 @@
       "knora-api:isInherited" : true,
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
-        "@id" : "knora-api:hasIncomingLink"
+        "@id" : "knora-api:hasIncomingLinkValue"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -4363,7 +4363,7 @@
       "@id" : "knora-api:hasValue"
     }
   }, {
-    "@id" : "knora-api:hasIncomingLink",
+    "@id" : "knora-api:hasIncomingLinkValue",
     "@type" : "owl:ObjectProperty",
     "knora-api:isLinkValueProperty" : true,
     "knora-api:isResourceProperty" : true,
@@ -4374,7 +4374,7 @@
       "@id" : "knora-api:Resource"
     },
     "rdfs:comment" : "Indicates that this resource referred to by another resource",
-    "rdfs:label" : "has incoming links",
+    "rdfs:label" : "has incoming link",
     "rdfs:subPropertyOf" : {
       "@id" : "knora-api:hasLinkToValue"
     }

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
@@ -17,40 +17,40 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic class for representing annotations</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b14"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Resource">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents something in the world, or an abstract thing</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Resource</rdfs:label>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b300"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b301"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b302"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b303"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b304"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b305"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b306"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b307"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b308"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b309"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b310"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b311"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b300"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b301"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b302"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b303"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b304"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b305"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b306"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b307"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b308"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b309"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b310"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b311"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b0">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -61,7 +61,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b1">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -72,7 +72,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b2">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -83,7 +83,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b3">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -93,7 +93,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b4">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -103,7 +103,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b5">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b5">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasComment">
@@ -118,22 +118,22 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b6">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
-		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink">
+		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue">
 			<knora-api:isLinkValueProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isLinkValueProperty>
 			<knora-api:isResourceProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceProperty>
 			<knora-api:objectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#LinkValue"/>
 			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
 			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Indicates that this resource referred to by another resource</rdfs:comment>
-			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has incoming links</rdfs:label>
+			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has incoming link</rdfs:label>
 			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasLinkToValue"/>
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b7">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b7">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -142,7 +142,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b8">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -157,7 +157,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b9">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -172,7 +172,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b10">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b10">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOf">
@@ -186,7 +186,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b11">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b11">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOfValue">
@@ -199,7 +199,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b12">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b12">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -209,7 +209,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b13">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b13">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -218,7 +218,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b14">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b14">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -227,38 +227,38 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an audio file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b25"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#FileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b141"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b142"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b143"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b144"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b145"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b146"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b147"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b148"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b149"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b150"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b141"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b142"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b143"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b144"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b145"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b146"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b147"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b148"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b149"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b150"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b15">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b15">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b16">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b16">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#audioFileValueHasDuration">
@@ -270,17 +270,17 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b17">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b17">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b18">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b18">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b19">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b19">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -293,7 +293,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b20">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b20">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -306,17 +306,17 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b21">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b21">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b22">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b22">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b23">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b23">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -327,7 +327,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b24">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b24">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -338,7 +338,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b25">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b25">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -355,65 +355,65 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containing audio data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Audio)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b38"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Representation">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can store one or more files</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b287"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b288"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b289"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b290"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b291"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b292"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b293"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b294"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b295"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b296"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b297"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b298"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b299"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b287"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b288"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b289"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b290"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b291"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b292"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b293"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b294"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b295"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b296"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b297"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b298"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b299"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b26">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b26">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b27">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b27">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b28">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b28">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b29">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b29">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b30">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b30">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b31">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b31">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasAudioFileValue">
@@ -428,47 +428,47 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b32">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b32">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b33">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b33">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b34">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b34">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b35">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b35">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b36">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b36">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b37">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b37">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b38">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b38">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#BooleanBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b39"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b39">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b39">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean">
@@ -485,70 +485,70 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b48"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Value">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The base class of classes representing Knora values</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b491"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b492"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b493"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b494"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b495"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b496"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b497"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b498"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b491"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b492"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b493"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b494"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b495"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b496"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b497"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b498"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b40">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b40">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b41">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b41">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b42">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b42">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b43">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b43">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b44">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b44">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b45">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b45">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b46">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b46">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b47">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b47">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b48">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b48">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -556,7 +556,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ColorBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b49">
+		<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b49">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor">
@@ -575,57 +575,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in HTML format, e.g. "#33eeff"</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b51"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b58"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b50">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b50">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b51">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b51">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b52">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b52">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b53">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b53">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b54">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b54">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b55">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b55">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b56">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b56">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b57">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b57">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b58">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b58">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -634,63 +634,63 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This represents some 3D-object with mesh data, point cloud, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b62"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b63"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b66"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b63"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b68"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b59">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b59">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b60">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b60">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b61">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b61">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b62">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b62">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b63">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b63">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b64">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b64">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b65">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b65">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b66">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b66">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b67">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b67">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b68">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b68">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -700,46 +700,46 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containg 3D data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (3D)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b71"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b74"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b77"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b79"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b81"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b69">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b69">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b70">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b70">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b71">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b71">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b72">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b72">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b73">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b73">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b74">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b74">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDDDFileValue">
@@ -754,54 +754,54 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b75">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b75">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b76">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b76">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b77">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b77">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b78">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b78">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b79">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b79">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b80">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b80">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b81">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b81">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DateBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b83"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b84"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b85"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b86"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b87"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b89"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b90"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b85"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b86"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b87"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b88"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b89"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b90"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b82">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b82">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar">
@@ -813,7 +813,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b83">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b83">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay">
@@ -825,7 +825,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b84">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b84">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra">
@@ -837,7 +837,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b85">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b85">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth">
@@ -849,7 +849,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b86">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b86">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear">
@@ -861,7 +861,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b87">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b87">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay">
@@ -873,7 +873,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b88">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b88">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra">
@@ -885,7 +885,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b89">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b89">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth">
@@ -897,7 +897,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b90">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b90">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear">
@@ -914,105 +914,105 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Knora date value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b91"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b92"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b93"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b94"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b95"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b96"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b97"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b98"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b99"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b100"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b101"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b102"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b103"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b104"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b105"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b106"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b107"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b91"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b92"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b93"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b94"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b95"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b96"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b97"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b98"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b99"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b100"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b101"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b102"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b103"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b104"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b105"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b106"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b107"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b91">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b91">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b92">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b92">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b93">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b93">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b94">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b94">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b95">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b95">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b96">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b96">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b97">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b97">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b98">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b98">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b99">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b99">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b100">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b100">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b101">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b101">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b102">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b102">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b103">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b103">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b104">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b104">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b105">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b105">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b106">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b106">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b107">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b107">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1020,7 +1020,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DecimalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b108">
+		<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b108">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal">
@@ -1039,57 +1039,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary-precision decimal value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b109"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b110"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b111"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b112"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b113"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b114"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b115"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b116"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b117"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b109"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b110"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b111"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b112"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b113"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b114"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b115"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b116"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b117"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b109">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b109">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b110">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b110">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b111">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b111">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b112">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b112">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b113">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b113">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b114">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b114">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b115">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b115">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b116">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b116">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b117">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b117">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1097,63 +1097,63 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DocumentFileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b118"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b119"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b120"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b121"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b122"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b123"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b124"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b125"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b126"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b127"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b118"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b119"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b120"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b121"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b122"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b123"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b124"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b125"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b126"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b127"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b118">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b118">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b119">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b119">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b120">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b120">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b121">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b121">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b122">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b122">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b123">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b123">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b124">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b124">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b125">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b125">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b126">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b126">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b127">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b127">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1162,46 +1162,46 @@
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Document)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b128"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b129"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b130"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b131"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b132"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b133"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b134"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b135"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b136"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b137"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b138"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b139"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b140"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b128"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b129"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b130"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b131"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b132"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b133"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b134"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b135"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b136"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b137"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b138"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b139"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b140"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b128">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b128">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b129">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b129">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b130">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b130">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b131">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b131">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b132">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b132">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b133">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b133">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDocumentFileValue">
@@ -1216,85 +1216,85 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b134">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b134">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b135">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b135">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b136">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b136">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b137">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b137">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b138">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b138">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b139">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b139">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b140">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b140">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b141">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b141">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b142">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b142">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b143">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b143">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b144">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b144">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b145">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b145">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b146">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b146">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b147">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b147">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b148">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b148">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b149">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b149">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b150">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b150">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1304,80 +1304,80 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b151"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b152"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b153"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b154"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b155"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b156"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b157"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b158"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b159"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b160"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b161"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b162"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b163"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b151"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b152"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b153"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b154"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b155"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b156"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b157"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b158"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b159"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b160"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b161"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b162"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b163"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b151">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b151">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b152">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b152">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b153">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b153">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b154">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b154">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b155">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b155">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b156">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b156">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b157">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b157">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b158">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b158">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b159">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b159">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b160">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b160">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b161">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b161">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b162">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b162">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b163">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b163">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -1386,32 +1386,32 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometrical objects as JSON string</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b164"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b165"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b166"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b167"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b168"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b169"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b170"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b171"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b172"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b164"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b165"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b166"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b167"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b168"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b169"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b170"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b171"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b172"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b164">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b164">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b165">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b165">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b166">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b166">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b167">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b167">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geometryValueAsGeometry">
@@ -1423,27 +1423,27 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b168">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b168">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b169">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b169">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b170">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b170">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b171">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b171">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b172">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b172">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1451,32 +1451,32 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#GeonameValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b173"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b174"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b175"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b176"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b177"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b178"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b179"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b180"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b181"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b173"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b174"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b175"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b176"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b177"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b178"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b179"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b180"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b181"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b173">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b173">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b174">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b174">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b175">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b175">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b176">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b176">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geonameValueAsGeonameCode">
@@ -1488,27 +1488,27 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b177">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b177">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b178">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b178">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b179">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b179">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b180">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b180">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b181">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b181">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1516,7 +1516,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b182">
+		<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b182">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intValueAsInt">
@@ -1535,71 +1535,71 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b183"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b184"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b185"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b186"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b187"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b188"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b189"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b190"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b191"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b183"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b184"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b185"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b186"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b187"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b188"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b189"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b190"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b191"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b183">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b183">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b184">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b184">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b185">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b185">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b186">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b186">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b187">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b187">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b188">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b188">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b189">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b189">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b190">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b190">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b191">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b191">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntervalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b192"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b193"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b192"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b193"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b192">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b192">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b193">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b193">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
@@ -1608,63 +1608,63 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a time interval, e.g. in an audio recording</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b194"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b195"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b196"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b197"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b198"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b199"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b200"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b201"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b202"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b203"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b194"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b195"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b196"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b197"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b198"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b199"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b200"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b201"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b202"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b203"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b194">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b194">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b195">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b195">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b196">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b196">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b197">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b197">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b198">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b198">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b199">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b199">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b200">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b200">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b201">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b201">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b202">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b202">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b203">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b203">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1676,57 +1676,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a generic link object</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link Object</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b204"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b205"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b206"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b207"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b208"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b209"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b210"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b211"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b212"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b213"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b214"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b215"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b216"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b217"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b218"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b204"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b205"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b206"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b207"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b208"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b209"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b210"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b211"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b212"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b213"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b214"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b215"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b216"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b217"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b218"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b204">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b204">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b205">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b205">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b206">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b206">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b207">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b207">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b208">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b208">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b209">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b209">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b210">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b210">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b211">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b211">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkTo">
@@ -1741,7 +1741,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b212">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b212">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkToValue">
@@ -1756,32 +1756,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b213">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b213">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b214">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b214">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b215">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b215">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b216">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b216">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b217">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b217">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b218">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b218">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -1791,123 +1791,123 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A reification node that describes direct links between resources</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
 	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b219"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b220"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b221"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b222"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b223"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b224"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b225"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b226"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b227"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b228"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b229"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b219"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b220"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b221"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b222"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b223"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b224"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b225"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b226"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b227"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b228"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b229"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b219">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b219">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b220">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b220">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b221">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b221">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b222">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b222">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b223">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b223">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b224">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b224">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b225">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b225">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b226">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b226">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b227">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b227">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#object"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b228">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b228">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b229">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b229">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListNode">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a flat or hierarchical list</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b230"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b231"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b230"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b231"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b230">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b230">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b231">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b231">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b232"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b233"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b234"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b235"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b236"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b237"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b238"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b239"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b240"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b241"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b232"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b233"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b234"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b235"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b236"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b237"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b238"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b239"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b240"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b241"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b232">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b232">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b233">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b233">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b234">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b234">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b235">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b235">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b236">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b236">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b237">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b237">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#listValueAsListNode">
@@ -1919,7 +1919,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b238">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b238">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#listValueAsListNodeLabel">
@@ -1931,17 +1931,17 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b239">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b239">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b240">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b240">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b241">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b241">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1950,58 +1950,58 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a moving image file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b242"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b243"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b244"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b245"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b246"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b247"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b248"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b249"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b250"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b251"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b252"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b253"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b254"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b255"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b256"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b242"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b243"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b244"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b245"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b246"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b247"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b248"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b249"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b250"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b251"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b252"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b253"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b254"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b255"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b256"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b242">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b242">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b243">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b243">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b244">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b244">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b245">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b245">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b246">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b246">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b247">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b247">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b248">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b248">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b249">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b249">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimX">
@@ -2013,7 +2013,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b250">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b250">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimY">
@@ -2025,7 +2025,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b251">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b251">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDuration">
@@ -2037,7 +2037,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b252">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b252">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasFps">
@@ -2049,7 +2049,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b253">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b253">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasQualityLevel">
@@ -2061,17 +2061,17 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b254">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b254">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b255">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b255">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b256">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b256">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2081,51 +2081,51 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing moving image data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Movie)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b257"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b258"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b259"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b260"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b261"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b262"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b263"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b264"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b265"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b266"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b267"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b268"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b269"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b257"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b258"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b259"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b260"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b261"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b262"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b263"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b264"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b265"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b266"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b267"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b268"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b269"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b257">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b257">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b258">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b258">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b259">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b259">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b260">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b260">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b261">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b261">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b262">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b262">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b263">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b263">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasMovingImageFileValue">
@@ -2140,32 +2140,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b264">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b264">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b265">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b265">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b266">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b266">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b267">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b267">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b268">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b268">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b269">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b269">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -2177,50 +2177,50 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometric region of a resource. The geometry is represented currently as JSON string.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b270"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b271"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b272"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b273"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b274"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b275"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b276"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b277"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b278"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b279"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b280"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b281"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b282"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b283"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b284"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b285"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b286"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b270"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b271"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b272"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b273"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b274"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b275"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b276"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b277"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b278"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b279"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b280"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b281"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b282"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b283"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b284"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b285"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b286"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b270">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b270">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b271">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b271">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b272">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b272">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b273">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b273">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b274">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b274">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b275">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b275">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasColor">
@@ -2236,11 +2236,11 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b276">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b276">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b277">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b277">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasGeometry">
@@ -2255,32 +2255,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b278">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b278">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b279">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b279">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b280">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b280">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b281">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b281">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b282">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b282">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b283">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b283">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOf">
@@ -2295,7 +2295,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b284">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b284">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOfValue">
@@ -2310,42 +2310,42 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b285">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b285">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b286">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b286">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b287">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b287">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b288">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b288">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b289">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b289">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b290">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b290">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b291">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b291">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b292">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b292">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasFileValue">
@@ -2359,86 +2359,86 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b293">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b293">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b294">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b294">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b295">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b295">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b296">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b296">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b297">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b297">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b298">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b298">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b299">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b299">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b300">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b300">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b301">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b301">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b302">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b302">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b303">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b303">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b304">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b304">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b305">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b305">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b306">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b306">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b307">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b307">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b308">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b308">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b309">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b309">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b310">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b310">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b311">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b311">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -2447,35 +2447,35 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b312"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b313"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b314"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b315"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b316"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b317"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b318"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b319"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b320"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b312"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b313"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b314"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b315"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b316"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b317"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b318"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b319"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b320"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a knora-base value type in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b330"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b331"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b332"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b333"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b334"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b335"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b336"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b337"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b330"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b331"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b332"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b333"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b334"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b335"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b336"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b337"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b312">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b312">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b313">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b313">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -2485,7 +2485,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b314">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b314">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -2495,7 +2495,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b315">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b315">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -2505,7 +2505,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b316">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b316">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -2515,7 +2515,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b317">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b317">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -2525,7 +2525,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b318">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b318">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -2535,7 +2535,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b319">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b319">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -2546,7 +2546,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b320">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b320">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -2561,57 +2561,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b321"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b322"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b323"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b324"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b325"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b326"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b327"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b328"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b329"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b321"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b322"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b323"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b324"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b325"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b326"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b327"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b328"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b329"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b321">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b321">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b322">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b322">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b323">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b323">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b324">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b324">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b325">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b325">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b326">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b326">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b327">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b327">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b328">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b328">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b329">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b329">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -2619,51 +2619,51 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a standoff markup tag</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b401"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b402"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b403"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b404"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b405"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b406"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b407"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b408"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b401"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b402"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b403"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b404"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b405"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b406"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b407"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b408"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b330">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b330">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b331">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b331">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b332">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b332">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b333">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b333">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b334">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b334">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b335">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b335">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b336">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b336">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b337">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b337">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -2673,105 +2673,105 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b338"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b339"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b340"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b341"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b342"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b343"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b344"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b345"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b346"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b347"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b348"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b349"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b350"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b351"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b352"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b353"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b354"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b338"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b339"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b340"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b341"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b342"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b343"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b344"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b345"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b346"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b347"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b348"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b349"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b350"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b351"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b352"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b353"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b354"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b338">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b338">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b339">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b339">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b340">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b340">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b341">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b341">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b342">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b342">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b343">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b343">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b344">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b344">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b345">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b345">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b346">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b346">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b347">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b347">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b348">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b348">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b349">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b349">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b350">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b350">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b351">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b351">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b352">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b352">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b353">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b353">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b354">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b354">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -2781,57 +2781,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a decimal (floating point) value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b355"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b356"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b357"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b358"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b359"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b360"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b361"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b362"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b363"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b355"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b356"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b357"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b358"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b359"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b360"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b361"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b362"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b363"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b355">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b355">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b356">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b356">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b357">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b357">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b358">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b358">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b359">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b359">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b360">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b360">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b361">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b361">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b362">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b362">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b363">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b363">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -2841,57 +2841,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b364"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b365"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b366"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b367"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b368"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b369"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b370"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b371"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b372"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b364"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b365"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b366"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b367"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b368"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b369"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b370"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b371"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b372"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b364">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b364">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b365">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b365">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b366">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b366">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b367">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b367">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b368">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b368">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b369">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b369">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b370">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b370">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b371">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b371">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b372">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b372">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -2901,32 +2901,32 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an internal reference in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b373"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b374"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b375"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b376"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b377"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b378"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b379"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b380"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b381"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b373"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b374"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b375"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b376"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b377"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b378"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b379"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b380"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b381"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b373">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b373">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b374">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b374">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b375">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b375">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b376">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b376">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasInternalReference">
@@ -2935,27 +2935,27 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b377">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b377">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b378">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b378">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b379">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b379">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b380">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b380">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b381">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b381">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -2965,63 +2965,63 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an interval in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b382"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b383"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b384"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b385"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b386"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b387"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b388"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b389"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b390"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b391"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b382"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b383"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b384"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b385"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b386"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b387"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b388"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b389"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b390"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b391"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b382">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b382">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b383">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b383">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b384">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b384">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b385">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b385">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b386">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b386">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b387">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b387">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b388">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b388">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b389">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b389">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b390">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b390">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b391">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b391">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3030,32 +3030,32 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a reference to a Knora resource in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b392"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b393"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b394"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b395"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b396"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b397"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b398"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b399"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b400"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b392"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b393"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b394"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b395"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b396"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b397"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b398"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b399"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b400"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b392">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b392">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b393">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b393">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b394">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b394">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b395">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b395">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasLink">
@@ -3064,60 +3064,60 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b396">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b396">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b397">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b397">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b398">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b398">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b399">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b399">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b400">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b400">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b401">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b401">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b402">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b402">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b403">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b403">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b404">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b404">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b405">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b405">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b406">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b406">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b407">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b407">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b408">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b408">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
@@ -3126,61 +3126,61 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary URI in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b409"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b410"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b411"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b412"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b413"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b414"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b415"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b416"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b417"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b409"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b410"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b411"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b412"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b413"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b414"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b415"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b416"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b417"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#UriBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b480"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b480"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b409">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b409">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b410">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b410">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b411">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b411">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b412">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b412">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b413">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b413">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b414">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b414">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b415">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b415">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b416">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b416">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b417">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b417">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3197,56 +3197,56 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A file containing a two-dimensional still image</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b418"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b419"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b420"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b421"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b422"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b423"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b424"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b425"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b426"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b427"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b428"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b429"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b430"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b418"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b419"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b420"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b421"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b422"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b423"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b424"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b425"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b426"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b427"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b428"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b429"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b430"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b418">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b418">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b419">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b419">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b420">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b420">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b421">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b421">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b422">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b422">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b423">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b423">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b424">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b424">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b425">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b425">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimX">
@@ -3258,7 +3258,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b426">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b426">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimY">
@@ -3270,7 +3270,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b427">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b427">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasIIIFBaseUrl">
@@ -3282,17 +3282,17 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b428">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b428">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b429">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b429">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b430">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b430">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -3302,66 +3302,66 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can contain two-dimensional still image files</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Image)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b431"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b432"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b433"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b434"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b435"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b436"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b437"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b438"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b439"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b440"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b441"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b442"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b443"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b431"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b432"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b433"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b434"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b435"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b436"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b437"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b438"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b439"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b440"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b441"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b442"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b443"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b431">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b431">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b432">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b432">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b433">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b433">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b434">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b434">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b435">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b435">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b436">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b436">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b437">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b437">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b438">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b438">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b439">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b439">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b440">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b440">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue">
@@ -3376,17 +3376,17 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b441">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b441">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b442">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b442">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b443">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b443">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -3395,63 +3395,63 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A text file such as plain Unicode text, LaTeX, TEI/XML, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b444"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b445"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b446"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b447"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b448"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b449"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b450"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b451"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b452"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b453"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b444"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b445"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b446"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b447"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b448"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b449"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b450"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b451"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b452"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b453"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b444">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b444">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b445">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b445">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b446">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b446">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b447">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b447">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b448">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b448">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b449">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b449">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b450">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b450">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b451">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b451">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b452">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b452">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b453">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b453">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -3461,66 +3461,66 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing text files</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Text)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b454"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b455"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b456"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b457"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b458"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b459"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b460"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b461"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b462"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b463"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b464"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b465"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b466"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b454"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b455"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b456"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b457"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b458"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b459"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b460"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b461"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b462"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b463"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b464"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b465"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b466"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b454">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b454">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b455">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b455">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b456">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b456">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b457">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b457">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b458">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b458">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b459">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b459">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b460">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b460">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b461">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b461">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b462">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b462">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b463">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b463">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue">
@@ -3535,17 +3535,17 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b464">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b464">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b465">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b465">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b466">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b466">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -3553,46 +3553,46 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#TextValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b467"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b468"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b469"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b470"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b471"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b472"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b473"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b474"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b475"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b476"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b477"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b478"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b479"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b467"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b468"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b469"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b470"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b471"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b472"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b473"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b474"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b475"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b476"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b477"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b478"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b479"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b467">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b467">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b468">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b468">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b469">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b469">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b470">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b470">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b471">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b471">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b472">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b472">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsHtml">
@@ -3604,7 +3604,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b473">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b473">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsXml">
@@ -3616,7 +3616,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b474">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b474">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasLanguage">
@@ -3628,7 +3628,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b475">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b475">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMapping">
@@ -3640,7 +3640,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b476">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b476">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasStandoff">
@@ -3652,22 +3652,22 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b477">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b477">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b478">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b478">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b479">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b479">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b480">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b480">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
@@ -3676,57 +3676,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a URI</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b481"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b482"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b483"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b484"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b485"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b486"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b487"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b488"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b489"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b481"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b482"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b483"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b484"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b485"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b486"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b487"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b488"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b489"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b481">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b481">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b482">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b482">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b483">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b483">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b484">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b484">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b485">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b485">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b486">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b486">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b487">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b487">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b488">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b488">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b489">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b489">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -3735,7 +3735,7 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Knora user</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b490">
+		<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b490">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#username">
@@ -3747,35 +3747,35 @@
 		</owl:Restriction>
 	</rdfs:subClassOf>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b491">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b491">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b492">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b492">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b493">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b493">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b494">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b494">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b495">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b495">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b496">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b496">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b497">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b497">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b498">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b498">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
@@ -3784,80 +3784,80 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff.  The transformation's result is ecptected to be HTML.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff. The transformation's result is ecptected to be HTML.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#TextRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b499"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b500"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b501"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b502"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b503"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b504"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b505"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b506"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b507"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b508"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b509"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b510"/>
-	<rdfs:subClassOf rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b511"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b499"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b500"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b501"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b502"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b503"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b504"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b505"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b506"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b507"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b508"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b509"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b510"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b511"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b499">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b499">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b500">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b500">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b501">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b501">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b502">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b502">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b503">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b503">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b504">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b504">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLink"/>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b505">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b505">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b506">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b506">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b507">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b507">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b508">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b508">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b509">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b509">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b510">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b510">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-5ef328d4f14d44e7892f191ce83fbabe-b511">
+<owl:Restriction rdf:nodeID="genid-5fb04d725cd84e16a32d0d5548b0912f-b511">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
@@ -59,7 +59,7 @@ knora-api:Annotation a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -95,7 +95,7 @@ knora-api:Resource a owl:Class;
       owl:onProperty knora-api:deleteDate
     ], [ a owl:Restriction;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasPermissions
@@ -149,13 +149,13 @@ knora-api:hasComment a owl:ObjectProperty;
   rdfs:label "Comment";
   rdfs:subPropertyOf knora-api:hasValue .
 
-knora-api:hasIncomingLink a owl:ObjectProperty;
+knora-api:hasIncomingLinkValue a owl:ObjectProperty;
   knora-api:isLinkValueProperty true;
   knora-api:isResourceProperty true;
   knora-api:objectType knora-api:LinkValue;
   knora-api:subjectType knora-api:Resource;
   rdfs:comment "Indicates that this resource referred to by another resource";
-  rdfs:label "has incoming links";
+  rdfs:label "has incoming link";
   rdfs:subPropertyOf knora-api:hasLinkToValue .
 
 knora-api:hasPermissions a owl:DatatypeProperty;
@@ -360,7 +360,7 @@ knora-api:AudioRepresentation a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -417,7 +417,7 @@ knora-api:Representation a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -668,7 +668,7 @@ knora-api:DDDRepresentation a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -998,7 +998,7 @@ knora-api:DocumentRepresentation a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -1065,7 +1065,7 @@ knora-api:ForbiddenResource a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -1325,7 +1325,7 @@ knora-api:LinkObj a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       owl:minCardinality 1;
       owl:onProperty knora-api:hasLinkTo
@@ -1612,7 +1612,7 @@ knora-api:MovingImageRepresentation a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       owl:minCardinality 1;
       owl:onProperty knora-api:hasMovingImageFileValue
@@ -1690,7 +1690,7 @@ knora-api:Region a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -2398,7 +2398,7 @@ knora-api:StillImageRepresentation a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -2510,7 +2510,7 @@ knora-api:TextRepresentation a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
@@ -2716,7 +2716,7 @@ knora-api:XSLTransformation a owl:Class;
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
+      owl:onProperty knora-api:hasIncomingLinkValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/standoffOntologyWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/standoffOntologyWithValueObjects.rdf
@@ -16,64 +16,64 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a section that is quoted from another source in a text</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b7"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents structural markup information in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b163"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b164"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b165"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b166"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b167"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b168"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b169"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b170"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b163"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b164"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b165"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b166"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b167"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b168"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b169"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b170"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b0">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b1">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b2">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b3">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b4">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b5">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b6">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b7">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b7">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -82,64 +82,64 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents bold text in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffVisualTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b15"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/standoff/v2#StandoffVisualTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents visual markup information in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b235"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b236"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b237"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b238"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b239"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b240"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b241"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b242"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b235"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b236"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b237"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b238"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b239"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b240"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b241"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b242"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b8">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b9">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b10">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b11">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b12">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b12">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b13">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b13">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b14">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b14">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b15">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b15">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -148,51 +148,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a linebreak</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b23"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b16">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b16">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b17">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b17">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b18">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b18">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b19">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b19">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b20">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b20">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b21">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b21">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b22">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b22">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b23">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b23">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -201,51 +201,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the title of a work in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b31"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b24">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b24">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b25">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b25">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b26">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b26">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b27">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b27">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b28">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b28">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b29">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b29">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b30">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b30">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b31">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b31">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -254,51 +254,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a section of computer source code in a text</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b39"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b32">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b32">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b33">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b33">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b34">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b34">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b35">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b35">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b36">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b36">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b37">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b37">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b38">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b38">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b39">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b39">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -307,51 +307,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a header of level 1 in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b47"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b40">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b40">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b41">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b41">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b42">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b42">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b43">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b43">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b44">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b44">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b45">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b45">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b46">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b46">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b47">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b47">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -360,51 +360,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a header of level 2 in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b51"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b55"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b48">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b48">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b49">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b49">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b50">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b50">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b51">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b51">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b52">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b52">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b53">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b53">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b54">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b54">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b55">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b55">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -413,51 +413,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a header of level 3 in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b62"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b63"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b63"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b56">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b56">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b57">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b57">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b58">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b58">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b59">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b59">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b60">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b60">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b61">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b61">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b62">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b62">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b63">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b63">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -466,51 +466,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a header of level 4 in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b66"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b68"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b71"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b64">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b64">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b65">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b65">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b66">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b66">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b67">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b67">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b68">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b68">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b69">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b69">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b70">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b70">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b71">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b71">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -519,51 +519,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a header of level 5 in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b74"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b77"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b79"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b72">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b72">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b73">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b73">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b74">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b74">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b75">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b75">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b76">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b76">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b77">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b77">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b78">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b78">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b79">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b79">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -572,51 +572,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a header of level 6 in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b81"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b83"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b84"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b85"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b86"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b87"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b85"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b86"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b87"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b80">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b80">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b81">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b81">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b82">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b82">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b83">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b83">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b84">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b84">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b85">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b85">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b86">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b86">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b87">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b87">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -625,63 +625,63 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a hyperlink in a text</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffUriTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b89"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b90"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b91"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b92"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b93"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b94"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b95"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b96"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b97"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b88"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b89"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b90"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b91"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b92"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b93"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b94"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b95"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b96"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b97"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b88">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b88">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b89">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b89">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b90">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b90">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b91">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b91">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b92">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b92">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b93">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b93">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b94">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b94">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b95">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b95">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b96">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b96">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b97">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b97">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/standoff/v2#standoffHyperlinkTagHasTarget">
@@ -695,51 +695,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents italics in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffVisualTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b98"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b99"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b100"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b101"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b102"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b103"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b104"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b105"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b98"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b99"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b100"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b101"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b102"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b103"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b104"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b105"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b98">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b98">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b99">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b99">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b100">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b100">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b101">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b101">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b102">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b102">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b103">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b103">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b104">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b104">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b105">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b105">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -748,51 +748,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a line to seperate content in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffVisualTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b106"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b107"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b108"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b109"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b110"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b111"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b112"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b113"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b106"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b107"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b108"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b109"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b110"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b111"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b112"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b113"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b106">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b106">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b107">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b107">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b108">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b108">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b109">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b109">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b110">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b110">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b111">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b111">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b112">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b112">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b113">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b113">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -801,51 +801,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a list element in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b114"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b115"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b116"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b117"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b118"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b119"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b120"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b121"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b114"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b115"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b116"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b117"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b118"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b119"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b120"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b121"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b114">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b114">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b115">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b115">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b116">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b116">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b117">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b117">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b118">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b118">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b119">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b119">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b120">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b120">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b121">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b121">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -854,51 +854,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an ordered list in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b122"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b123"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b124"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b125"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b126"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b127"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b128"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b129"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b122"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b123"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b124"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b125"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b126"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b127"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b128"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b129"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b122">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b122">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b123">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b123">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b124">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b124">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b125">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b125">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b126">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b126">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b127">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b127">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b128">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b128">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b129">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b129">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -907,51 +907,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a paragraph in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b130"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b131"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b132"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b133"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b134"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b135"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b136"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b137"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b130"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b131"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b132"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b133"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b134"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b135"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b136"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b137"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b130">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b130">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b131">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b131">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b132">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b132">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b133">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b133">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b134">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b134">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b135">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b135">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b136">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b136">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b137">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b137">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -960,51 +960,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a preformatted content in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffVisualTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b138"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b139"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b140"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b141"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b142"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b143"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b144"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b145"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b138"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b139"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b140"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b141"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b142"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b143"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b144"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b145"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b138">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b138">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b139">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b139">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b140">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b140">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b141">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b141">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b142">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b142">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b143">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b143">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b144">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b144">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b145">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b145">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -1013,57 +1013,57 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the root node if the TextValue has been created from XML</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b146"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b147"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b148"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b149"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b150"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b151"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b152"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b153"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b154"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b146"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b147"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b148"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b149"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b150"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b151"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b152"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b153"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b154"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b146">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b146">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b147">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b147">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b148">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b148">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b149">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b149">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b150">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b150">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b151">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b151">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b152">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b152">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b153">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b153">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b154">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b154">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/standoff/v2#standoffRootTagHasDocumentType">
@@ -1077,91 +1077,91 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents struck text in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffVisualTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b155"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b156"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b157"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b158"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b159"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b160"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b161"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b162"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b155"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b156"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b157"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b158"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b159"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b160"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b161"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b162"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b155">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b155">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b156">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b156">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b157">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b157">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b158">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b158">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b159">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b159">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b160">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b160">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b161">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b161">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b162">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b162">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b163">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b163">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b164">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b164">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b165">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b165">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b166">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b166">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b167">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b167">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b168">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b168">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b169">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b169">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b170">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b170">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -1170,51 +1170,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents subscript in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffVisualTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b171"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b172"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b173"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b174"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b175"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b176"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b177"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b178"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b171"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b172"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b173"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b174"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b175"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b176"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b177"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b178"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b171">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b171">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b172">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b172">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b173">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b173">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b174">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b174">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b175">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b175">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b176">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b176">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b177">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b177">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b178">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b178">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -1223,51 +1223,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents superscript in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffVisualTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b179"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b180"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b181"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b182"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b183"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b184"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b185"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b186"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b179"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b180"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b181"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b182"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b183"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b184"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b185"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b186"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b179">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b179">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b180">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b180">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b181">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b181">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b182">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b182">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b183">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b183">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b184">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b184">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b185">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b185">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b186">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b186">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -1276,51 +1276,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a table body in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b187"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b188"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b189"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b190"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b191"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b192"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b193"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b194"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b187"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b188"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b189"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b190"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b191"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b192"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b193"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b194"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b187">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b187">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b188">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b188">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b189">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b189">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b190">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b190">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b191">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b191">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b192">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b192">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b193">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b193">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b194">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b194">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -1329,51 +1329,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a cell in a table</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b195"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b196"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b197"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b198"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b199"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b200"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b201"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b202"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b195"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b196"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b197"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b198"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b199"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b200"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b201"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b202"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b195">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b195">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b196">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b196">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b197">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b197">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b198">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b198">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b199">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b199">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b200">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b200">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b201">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b201">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b202">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b202">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -1382,51 +1382,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a row in a table</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b203"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b204"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b205"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b206"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b207"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b208"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b209"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b210"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b203"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b204"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b205"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b206"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b207"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b208"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b209"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b210"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b203">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b203">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b204">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b204">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b205">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b205">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b206">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b206">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b207">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b207">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b208">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b208">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b209">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b209">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b210">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b210">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -1435,51 +1435,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a table in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b211"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b212"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b213"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b214"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b215"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b216"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b217"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b218"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b211"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b212"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b213"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b214"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b215"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b216"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b217"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b218"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b211">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b211">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b212">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b212">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b213">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b213">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b214">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b214">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b215">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b215">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b216">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b216">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b217">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b217">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b218">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b218">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -1488,51 +1488,51 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents underlined text in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffVisualTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b219"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b220"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b221"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b222"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b223"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b224"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b225"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b226"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b219"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b220"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b221"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b222"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b223"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b224"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b225"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b226"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b219">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b219">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b220">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b220">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b221">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b221">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b222">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b222">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b223">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b223">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b224">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b224">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b225">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b225">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b226">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b226">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -1541,91 +1541,91 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an unordered list in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/standoff/v2#StandoffStructuralTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b227"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b228"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b229"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b230"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b231"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b232"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b233"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b234"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b227"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b228"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b229"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b230"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b231"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b232"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b233"/>
+	<rdfs:subClassOf rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b234"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b227">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b227">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b228">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b228">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b229">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b229">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b230">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b230">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b231">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b231">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b232">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b232">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b233">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b233">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b234">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b234">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b235">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b235">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b236">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b236">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b237">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b237">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b238">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b238">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b239">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b239">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b240">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b240">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b241">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b241">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c65419054b0f41ecb86511cd9bad4c4e-b242">
+<owl:Restriction rdf:nodeID="genid-e57d98f837e741a99e4e79d79166441f-b242">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>

--- a/webapi/src/test/resources/test-data/searchR2RV2/ProjectsWithOptionalPersonOrBiblio.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ProjectsWithOptionalPersonOrBiblio.jsonld
@@ -27,7 +27,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2018-06-06T12:08:56.890Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/0666/xY8O4uSeQb-MDC4VtvQGdw/values/XktHkAazSZWzBA3x0sYFuQ",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {
@@ -77,7 +77,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2018-06-06T12:08:56.619Z"
     },
-    "knora-api:hasIncomingLink" : [ {
+    "knora-api:hasIncomingLinkValue" : [ {
       "@id" : "http://rdfh.ch/0666/wopH6GHOSpCyASdrsNqg_A/values/UKYA3eNMQK6OWmPjxVAbsA",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {

--- a/webapi/src/test/resources/test-data/searchR2RV2/bookWithIncomingPagesOnlyLink.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/bookWithIncomingPagesOnlyLink.jsonld
@@ -28,7 +28,7 @@
     "@type" : "xsd:dateTimeStamp",
     "@value" : "2016-03-02T15:05:43Z"
   },
-  "knora-api:hasIncomingLink" : {
+  "knora-api:hasIncomingLinkValue" : {
     "@id" : "http://rdfh.ch/50e7460a7203/values/8bdc04c8-b765-44c8-adb3-5ab536dcd051",
     "@type" : "knora-api:LinkValue",
     "knora-api:attachedToUser" : {

--- a/webapi/src/test/resources/test-data/searchR2RV2/bookWithIncomingPagesWithAllRequestedProps.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/bookWithIncomingPagesWithAllRequestedProps.jsonld
@@ -28,7 +28,7 @@
     "@type" : "xsd:dateTimeStamp",
     "@value" : "2016-03-02T15:05:43Z"
   },
-  "knora-api:hasIncomingLink" : {
+  "knora-api:hasIncomingLinkValue" : {
     "@id" : "http://rdfh.ch/50e7460a7203/values/8bdc04c8-b765-44c8-adb3-5ab536dcd051",
     "@type" : "knora-api:LinkValue",
     "knora-api:attachedToUser" : {

--- a/webapi/src/test/resources/test-data/searchR2RV2/booksWithPage100.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/booksWithPage100.jsonld
@@ -12,7 +12,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2016-03-02T15:05:18Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/0da887734b01/values/2296545c-978c-4e4f-9d7c-995e3db08aff",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {
@@ -71,7 +71,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2016-03-02T15:05:21Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/1ea3ff007e01/values/8afe8739-c7d1-4692-b9ad-d79b75ef70ad",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {
@@ -130,7 +130,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2016-03-02T15:05:15Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/700b6b7e1201/values/8b2f3364-4a6e-4697-9c6e-abd70145bde9",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {
@@ -189,7 +189,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2016-03-02T15:05:39Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/52b8c76d3d03/values/12ab7013-49bc-4f7c-b034-7d5e4793c078",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {
@@ -248,7 +248,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2016-03-02T15:05:34Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/7a5c3424ca02/values/ab9c5350-cf68-4417-9ee2-04615ab50cd5",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {
@@ -307,7 +307,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2016-03-02T15:05:43Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/7f2296af8803/values/61ef4c38-d115-4872-9d4d-2fa925d90050",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {
@@ -366,7 +366,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2016-03-02T15:05:24Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/87528201cc01/values/51d70510-b5f5-469a-bd8c-a12b69a4647c",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {
@@ -425,7 +425,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2016-03-02T15:05:30Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/87dc8d1f4102/values/10d81c78-9647-433f-ab75-48ea7639eee2",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {
@@ -484,7 +484,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2016-03-02T15:05:47Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/aaf6ddfecd03/values/5eddf8d1-faaa-4ea6-b5ac-3a9069b6968c",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {
@@ -543,7 +543,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2016-03-02T15:05:10Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/b9466d1a17/values/404dbb1a-dff4-4d43-ad3e-1837c40110ab",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {
@@ -602,7 +602,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2016-03-02T15:05:51Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/c34970561804/values/509fc2c3-9707-4e97-b861-ac59dd1770a4",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {
@@ -661,7 +661,7 @@
       "@type" : "xsd:dateTimeStamp",
       "@value" : "2016-03-02T15:05:23Z"
     },
-    "knora-api:hasIncomingLink" : {
+    "knora-api:hasIncomingLinkValue" : {
       "@id" : "http://rdfh.ch/b85e520aae01/values/df4fd6a1-8383-4e60-a49e-a3e98b456963",
       "@type" : "knora-api:LinkValue",
       "knora-api:attachedToUser" : {

--- a/webapi/src/test/resources/test-data/searchR2RV2/incomingPagesForBook.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/incomingPagesForBook.jsonld
@@ -28,7 +28,7 @@
     "@type" : "xsd:dateTimeStamp",
     "@value" : "2016-03-02T15:05:47Z"
   },
-  "knora-api:hasIncomingLink" : [ {
+  "knora-api:hasIncomingLinkValue" : [ {
     "@id" : "http://rdfh.ch/05c7acceb703/values/ad6b1ac8-7727-4893-9a30-4de4666b4780",
     "@type" : "knora-api:LinkValue",
     "knora-api:attachedToUser" : {


### PR DESCRIPTION
- [x] In the API v2 complex schema, rename `hasIncomingLink` to `hasIncomingLinkValue`, because the name of a link value property must end in `Value`. Also rename the corresponding virtual property in `knora-base`.
- [x] In the API v2 simple schema, add the definition of `hasIncomingLink` to the `knora-api` ontology.
- [x] Update docs.
- [x] Update release notes.

Corresponding PR in `Knora-ui`: https://github.com/dhlab-basel/Knora-ui/pull/148

Fixes #1135.