### PR TITLE
Reject link value properties in Gravsearch queries in the simple schema

### DIFF
--- a/docs/src/paradox/00-release-notes/next.md
+++ b/docs/src/paradox/00-release-notes/next.md
@@ -12,3 +12,4 @@ Also, please change the "HINT" to the appropriate level:
 ## HINT => LEVEL
 
 - BUGFIX CHANGE: Triplestore connection error when using dockerComposeUp (@github[#1122](#1122))
+- BUGFIX CHANGE: Reject link value properties in Gravsearch queries in the simple schema (@github[#1145](#1145))

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -1121,18 +1121,26 @@ class OntologyResponderV2 extends Responder {
                         // Yes, so it's available.
                         acc
                     } else {
-                        // No. Is it among the properties removed from knora-base to create the requested schema?
+                        // No. See if it's available in the requested schema.
                         propertyIri.getOntologySchema.get match {
                             case apiV2Schema: ApiV2Schema =>
                                 val internalPropertyIri = propertyIri.toOntologySchema(InternalSchema)
-                                val knoraBasePropertiesToRemove = KnoraBaseTransformationRules.getTransformationRules(apiV2Schema).knoraBasePropertiesToRemove
 
-                                if (knoraBasePropertiesToRemove.contains(internalPropertyIri)) {
-                                    // Yes. Include it in the set of unavailable properties.
+                                // If it's a link value property and it's requested in the simple schema, it's unavailable.
+                                if (apiV2Schema == ApiV2Simple && isLinkValueProp(internalPropertyIri, cacheData)) {
                                     acc + propertyIri
                                 } else {
-                                    // No. It's available.
-                                    acc
+                                    // Is it among the properties removed from knora-base to create the requested schema?
+
+                                    val knoraBasePropertiesToRemove = KnoraBaseTransformationRules.getTransformationRules(apiV2Schema).knoraBasePropertiesToRemove
+
+                                    if (knoraBasePropertiesToRemove.contains(internalPropertyIri)) {
+                                        // Yes. Include it in the set of unavailable properties.
+                                        acc + propertyIri
+                                    } else {
+                                        // No. It's available.
+                                        acc
+                                    }
                                 }
 
                             case InternalSchema => acc

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -82,7 +82,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
         RdfDataObject(path = "_test_data/e2e.v2.SearchRouteV2R2RSpec/gravsearchtest1-data.ttl", name = "http://www.knora.org/data/0666/gravsearchtest1")
     )
 
-    "The Search v2 Endpoint" should { /*
+    "The Search v2 Endpoint" should {
         "perform a fulltext search for 'Narr'" in {
 
             Get("/v2/search/Narr") ~> searchPath ~> check {
@@ -7330,7 +7330,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             }
 
         }
-*/
+
         "reject a link value property in a query in the simple schema" in {
             val gravsearchQuery =
                 """
@@ -7351,8 +7351,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
             Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> addCredentials(BasicHttpCredentials(incunabulaUserEmail, password)) ~> searchPath ~> check {
 
-                println(responseAs[String])
-                assert(status == StatusCodes.BAD_REQUEST, response.toString)
+                assert(status == StatusCodes.NOT_FOUND, response.toString)
 
             }
         }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -82,7 +82,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
         RdfDataObject(path = "_test_data/e2e.v2.SearchRouteV2R2RSpec/gravsearchtest1-data.ttl", name = "http://www.knora.org/data/0666/gravsearchtest1")
     )
 
-    "The Search v2 Endpoint" should {
+    "The Search v2 Endpoint" should { /*
         "perform a fulltext search for 'Narr'" in {
 
             Get("/v2/search/Narr") ~> searchPath ~> check {
@@ -7329,6 +7329,32 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
             }
 
+        }
+*/
+        "reject a link value property in a query in the simple schema" in {
+            val gravsearchQuery =
+                """
+                  |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?book knora-api:isMainResource true .
+                  |    ?book incunabula:title ?title .
+                  |    ?page incunabula:partOfValue ?book .
+                  |} WHERE {
+                  |    ?book a incunabula:book .
+                  |    ?book incunabula:title ?title .
+                  |    ?page a incunabula:page .
+                  |    ?page incunabula:partOfValue ?book .
+                  |}
+                """.stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> addCredentials(BasicHttpCredentials(incunabulaUserEmail, password)) ~> searchPath ~> check {
+
+                println(responseAs[String])
+                assert(status == StatusCodes.BAD_REQUEST, response.toString)
+
+            }
         }
 
     }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -7351,7 +7351,9 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
             Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> addCredentials(BasicHttpCredentials(incunabulaUserEmail, password)) ~> searchPath ~> check {
 
-                assert(status == StatusCodes.NOT_FOUND, response.toString)
+                val responseStr = responseAs[String]
+                assert(status == StatusCodes.NOT_FOUND, responseStr)
+                assert(responseStr.contains("http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#partOfValue"))
 
             }
         }


### PR DESCRIPTION
If you try to use a link value property in a Gravsearch query in the simple schema, you get a confusing error message. This fix returns a better error message, saying that the property is not found.

Fixes #1138.