### PR TITLE
Allow setting resource creation date in bulk import

### DIFF
--- a/docs/src/paradox/00-release-notes/next.md
+++ b/docs/src/paradox/00-release-notes/next.md
@@ -15,3 +15,4 @@ Also, please change the "HINT" to the appropriate level:
 - MINOR CHANGE: Update resource metadata in API v2 (@github[#1131](#1131))
 - BUGFIX CHANGE: Reject link value properties in Gravsearch queries in the simple schema (@github[#1145](#1145))
 - BUGFIX CHANGE: Fix error-checking when updating cardinalities in ontology API (@github[#1142](#1142))
+- MINOR CHANGE: Allow setting resource creation date in bulk import (@github[#1151](#1151))

--- a/docs/src/paradox/03-apis/api-v1/adding-resources.md
+++ b/docs/src/paradox/03-apis/api-v1/adding-resources.md
@@ -236,7 +236,7 @@ script. The resulting XML import document could look like this:
         <knoraXmlImport:label>Math Intelligencer</knoraXmlImport:label>
         <p0801-biblio:hasName knoraType="richtext_value">Math Intelligencer</p0801-biblio:hasName>
     </p0801-biblio:Journal>
-    <p0801-biblio:JournalArticle id="strings_in_the_16th_and_17th_centuries">
+    <p0801-biblio:JournalArticle id="strings_in_the_16th_and_17th_centuries" creationDate="2019-01-09T15:45:54Z">
         <knoraXmlImport:label>Strings in the 16th and 17th Centuries</knoraXmlImport:label>
         <p0801-biblio:p0801-beol__comment knoraType="richtext_value" mapping_id="http://rdfh.ch/standoff/mappings/StandardMapping">
             <text xmlns="">The most <strong>interesting</strong> article in <a class="salsah-link" href="ref:math_intelligencer">Math Intelligencer</a>.</text>
@@ -285,6 +285,11 @@ This illustrates several aspects of XML imports:
     [NCName](https://www.w3.org/TR/REC-xml-names/#NT-NCName), and must
     be unique within the file. These IDs are used only during the
     import, and will not be stored in the triplestore.
+
+  - Each resource can optionally have a `creationDate` attribute, which
+    can be an [xsd:dateTime](https://www.w3.org/TR/xmlschema11-2/#dateTime)
+    or an [xsd:dateTimeStamp](https://www.w3.org/TR/xmlschema11-2/#dateTimeStamp).
+    If `creationDate` is not supplied, the current time is used.
 
   - The first child element of each resource must be a
     `knoraXmlImport:label`, which will be stored as the resource's

--- a/docs/src/paradox/03-apis/api-v2/editing-resources.md
+++ b/docs/src/paradox/03-apis/api-v2/editing-resources.md
@@ -137,7 +137,9 @@ For example, here is a request to create a resource with various value types:
 }
 ```
 
-Permissions for the new resource can be given by adding `knora-api:hasPermissions`. For example:
+Permissions for the new resource can be given by adding `knora-api:hasPermissions`, and a custom creation date
+can be specified by adding `knora-api:creationDate`
+(an [xsd:dateTimeStamp](https://www.w3.org/TR/xmlschema11-2/#dateTimeStamp)). For example:
 
 ```jsonld
 {
@@ -150,7 +152,11 @@ Permissions for the new resource can be given by adding `knora-api:hasPermission
     "@id" : "http://rdfh.ch/projects/0001"
   },
   "rdfs:label" : "test thing",
-  "knora-api:hasPermissions" : "CR knora-base:Creator|V http://rdfh.ch/groups/0001/thing-searcher"
+  "knora-api:hasPermissions" : "CR knora-base:Creator|V http://rdfh.ch/groups/0001/thing-searcher",
+  "knora-api:creationDate" : {
+    "@type" : "xsd:dateTimeStamp",
+    "@value" : "2019-01-09T15:45:54.502951Z"
+  }
   "@context" : {
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -113,7 +113,7 @@ object Dependencies {
         val rdf4jRuntime           = "org.eclipse.rdf4j"                        % "rdf4j-runtime"            % "2.3.2"
         val scallop                = "org.rogach"                              %% "scallop"                  % "2.0.5"
         val gwtServlet             = "com.google.gwt"                           % "gwt-servlet"              % "2.8.0"
-        val saxonHE                = "net.sf.saxon"                             % "Saxon-HE"                 % "9.7.0-14"
+        val saxonHE                = "net.sf.saxon"                             % "Saxon-HE"                 % "9.9.0-2"
 
         val scalaXml               = "org.scala-lang.modules"                  %% "scala-xml"                % "1.1.1"
         val scalaArm               = "com.jsuereth"                             % "scala-arm_2.12"           % "2.0"

--- a/webapi/src/main/resources/knoraXmlImport.xsd
+++ b/webapi/src/main/resources/knoraXmlImport.xsd
@@ -24,6 +24,7 @@
 
     <xs:complexType name="resourceType">
         <xs:attribute name="id" use="required" type="xs:NCName"/>
+        <xs:attribute name="creation_date" use="optional" type="xs:dateTimeStamp"/>
     </xs:complexType>
 
     <xs:element name="file">

--- a/webapi/src/main/resources/knoraXmlImport.xsd
+++ b/webapi/src/main/resources/knoraXmlImport.xsd
@@ -24,7 +24,7 @@
 
     <xs:complexType name="resourceType">
         <xs:attribute name="id" use="required" type="xs:NCName"/>
-        <xs:attribute name="creation_date" use="optional" type="xs:dateTimeStamp"/>
+        <xs:attribute name="creationDate" use="optional" type="xs:dateTime"/>
     </xs:complexType>
 
     <xs:element name="file">

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/resourcemessages/ResourceMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/resourcemessages/ResourceMessagesV1.scala
@@ -19,6 +19,7 @@
 
 package org.knora.webapi.messages.v1.responder.resourcemessages
 
+import java.time.Instant
 import java.util.UUID
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
@@ -57,17 +58,19 @@ case class CreateResourceApiRequestV1(restype_id: IRI,
 /**
   * Used internally to represent a request to create a resource from an XML import.
   *
-  * @param restype_id the IRI of the resource class.
-  * @param label      the resource's label.
-  * @param client_id  the client's unique ID for the resource.
-  * @param properties the resource's properties.
-  * @param file       a file on disk that should be attached to the resource.
+  * @param restype_id   the IRI of the resource class.
+  * @param label        the resource's label.
+  * @param client_id    the client's unique ID for the resource.
+  * @param properties   the resource's properties.
+  * @param file         a file on disk that should be attached to the resource.
+  * @param creationDate the creation date that should be attached to the resource.
   */
 case class CreateResourceFromXmlImportRequestV1(restype_id: IRI,
                                                 client_id: String,
                                                 label: String,
                                                 properties: Map[IRI, Seq[CreateResourceValueV1]],
-                                                file: Option[ReadFileV1] = None)
+                                                file: Option[ReadFileV1] = None,
+                                                creationDate: Option[Instant])
 
 /**
   * Represents a property value to be created.
@@ -219,12 +222,14 @@ case class ResourceCreateRequestV1(resourceTypeIri: IRI,
   * @param label            the rdfs:label of the resource.
   * @param values           the properties to add: type and value(s): a Map of propertyIris to ApiValueV1.
   * @param file             a file on disk that should be stored by Sipi and should be attached to the resource.
+  * @param creationDate     the creation date that should be attached to the resource.
   */
 case class OneOfMultipleResourceCreateRequestV1(resourceTypeIri: IRI,
                                                 clientResourceID: String,
                                                 label: String,
                                                 values: Map[IRI, Seq[CreateValueV1WithComment]],
-                                                file: Option[SipiResponderConversionPathRequestV1] = None)
+                                                file: Option[SipiResponderConversionPathRequestV1] = None,
+                                                creationDate: Option[Instant])
 
 /**
   * Requests the creation of multiple new resources.
@@ -949,15 +954,15 @@ object ResourceV1JsonProtocol extends SprayJsonSupport with DefaultJsonProtocol 
                         "label" -> propertyV1.label.toJson,
                         "attributes" -> propertyV1.attributes.toJson,
                         "occurrence" -> propertyV1.occurrence.toJson) ++
-                            // Don't generate JSON for these lists if they're empty.
-                            list2JsonOption("values", propertyV1.values, () => propertyV1.values.toJson) ++
-                            list2JsonOption("value_ids", propertyV1.value_ids, () => propertyV1.value_ids.toJson) ++
-                            list2JsonOption("comments", propertyV1.comments, () => propertyV1.comments.toJson) ++
-                            list2JsonOption("value_restype", propertyV1.value_restype, () => propertyV1.value_restype.toJson) ++
-                            list2JsonOption("value_iconsrcs", propertyV1.value_iconsrcs, () => propertyV1.value_iconsrcs.toJson) ++
-                            list2JsonOption("value_firstprops", propertyV1.value_firstprops, () => propertyV1.value_firstprops.toJson) ++
-                            list2JsonOption("value_rights", propertyV1.value_rights, () => propertyV1.value_rights.toJson) ++
-                            list2JsonOption("locations", propertyV1.locations, () => propertyV1.locations.toJson)
+                        // Don't generate JSON for these lists if they're empty.
+                        list2JsonOption("values", propertyV1.values, () => propertyV1.values.toJson) ++
+                        list2JsonOption("value_ids", propertyV1.value_ids, () => propertyV1.value_ids.toJson) ++
+                        list2JsonOption("comments", propertyV1.comments, () => propertyV1.comments.toJson) ++
+                        list2JsonOption("value_restype", propertyV1.value_restype, () => propertyV1.value_restype.toJson) ++
+                        list2JsonOption("value_iconsrcs", propertyV1.value_iconsrcs, () => propertyV1.value_iconsrcs.toJson) ++
+                        list2JsonOption("value_firstprops", propertyV1.value_firstprops, () => propertyV1.value_firstprops.toJson) ++
+                        list2JsonOption("value_rights", propertyV1.value_rights, () => propertyV1.value_rights.toJson) ++
+                        list2JsonOption("locations", propertyV1.locations, () => propertyV1.locations.toJson)
                     (propertyV1.pid, JsObject(fields))
             }(breakOut)
 
@@ -993,8 +998,8 @@ object ResourceV1JsonProtocol extends SprayJsonSupport with DefaultJsonProtocol 
                         "guielement" -> propertyGetV1.guielement.toJson,
                         "is_annotation" -> propertyGetV1.is_annotation.toJson,
                         "attributes" -> propertyGetV1.attributes.toJson) ++
-                            // Don't generate JSON for these lists if they're empty.
-                            list2JsonOption("values", propertyGetV1.values, () => propertyGetV1.values.toJson)
+                        // Don't generate JSON for these lists if they're empty.
+                        list2JsonOption("values", propertyGetV1.values, () => propertyGetV1.values.toJson)
                     (propertyGetV1.pid, JsObject(fields))
             }(breakOut)
 
@@ -1081,8 +1086,8 @@ object ResourceV1JsonProtocol extends SprayJsonSupport with DefaultJsonProtocol 
                         "guielement" -> propertyGetV1.guielement.toJson,
                         "is_annotation" -> propertyGetV1.is_annotation.toJson,
                         "attributes" -> propertyGetV1.attributes.toJson) ++
-                            // Don't generate JSON for these lists if they're empty.
-                            list2JsonOption("values", propertyGetV1.values, () => propertyGetV1.values.toJson)
+                        // Don't generate JSON for these lists if they're empty.
+                        list2JsonOption("values", propertyGetV1.values, () => propertyGetV1.values.toJson)
                     (propertyGetV1.pid, JsObject(fields))
             }(breakOut)
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/valuemessages/ValueMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/valuemessages/ValueMessagesV1.scala
@@ -20,6 +20,7 @@
 package org.knora.webapi.messages.v1.responder.valuemessages
 
 import java.io.File
+import java.time.Instant
 import java.util.UUID
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
@@ -392,7 +393,7 @@ case class CreateValueV1WithComment(updateValueV1: UpdateValueV1, comment: Optio
   * @param values                           the values to be added, with optional comments.
   * @param clientResourceIDsToResourceIris  a map of client resource IDs (which may appear in standoff link tags
   *                                         in values) to the IRIs that will be used for those resources.
-  * @param currentTime                      an xsd:dateTimeStamp that will be attached to the values.
+  * @param creationDate                     an xsd:dateTimeStamp that will be attached to the values.
   * @param userProfile                      the user that is creating the values.
   */
 case class GenerateSparqlToCreateMultipleValuesRequestV1(projectIri: IRI,
@@ -401,7 +402,7 @@ case class GenerateSparqlToCreateMultipleValuesRequestV1(projectIri: IRI,
                                                          defaultPropertyAccessPermissions: Map[IRI, String],
                                                          values: Map[IRI, Seq[CreateValueV1WithComment]],
                                                          clientResourceIDsToResourceIris: Map[String, IRI],
-                                                         currentTime: String,
+                                                         creationDate: Instant,
                                                          userProfile: UserADM,
                                                          apiRequestID: UUID) extends ValuesResponderRequestV1
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -326,7 +326,8 @@ case class CreateResourceV2(resourceIri: IRI,
                             label: String,
                             values: Map[SmartIri, Seq[CreateValueInNewResourceV2]],
                             projectADM: ProjectADM,
-                            permissions: Option[String] = None) extends ResourceV2 {
+                            permissions: Option[String] = None,
+                            creationDate: Option[Instant] = None) extends ResourceV2 {
     lazy val flatValues: Iterable[CreateValueInNewResourceV2] = values.values.flatten
 
     /**
@@ -399,7 +400,14 @@ object CreateResourceRequestV2 extends KnoraJsonLDRequestReaderV2[CreateResource
             projectIri: SmartIri = jsonLDDocument.requireIriInObject(OntologyConstants.KnoraApiV2WithValueObjects.AttachedToProject, stringFormatter.toSmartIriWithErr)
 
             // Get the resource's permissions.
-            maybePermissions = jsonLDDocument.maybeStringWithValidation(OntologyConstants.KnoraApiV2WithValueObjects.HasPermissions, stringFormatter.toSparqlEncodedString)
+            permissions = jsonLDDocument.maybeStringWithValidation(OntologyConstants.KnoraApiV2WithValueObjects.HasPermissions, stringFormatter.toSparqlEncodedString)
+
+            // Get the resource's creation date.
+            creationDate: Option[Instant] = jsonLDDocument.maybeDatatypeValueInObject(
+                key = OntologyConstants.KnoraApiV2WithValueObjects.CreationDate,
+                expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
+                validationFun = stringFormatter.toInstant
+            )
 
             // Get the resource's values.
 
@@ -409,7 +417,8 @@ object CreateResourceRequestV2 extends KnoraJsonLDRequestReaderV2[CreateResource
                     JsonLDConstants.TYPE,
                     OntologyConstants.Rdfs.Label,
                     OntologyConstants.KnoraApiV2WithValueObjects.AttachedToProject,
-                    OntologyConstants.KnoraApiV2WithValueObjects.HasPermissions
+                    OntologyConstants.KnoraApiV2WithValueObjects.HasPermissions,
+                    OntologyConstants.KnoraApiV2WithValueObjects.CreationDate
                 )
 
             valueFutures: Map[SmartIri, Seq[Future[CreateValueInNewResourceV2]]] = propertyIriStrs.map {
@@ -467,7 +476,8 @@ object CreateResourceRequestV2 extends KnoraJsonLDRequestReaderV2[CreateResource
                 label = label,
                 values = values,
                 projectADM = projectInfoResponse.project,
-                permissions = maybePermissions
+                permissions = permissions,
+                creationDate = creationDate
             ),
             requestingUser = requestingUser,
             apiRequestID = apiRequestID

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -289,12 +289,12 @@ case class DeleteValueRequestV2(resourceIri: IRI,
   *
   * @param resourceIri    the IRI of the resource in which values are to be created.
   * @param values         a map of property IRIs to the values to be added for each property.
-  * @param currentTime    an xsd:dateTimeStamp that will be attached to the values.
+  * @param creationDate   an xsd:dateTimeStamp that will be attached to the values.
   * @param requestingUser the user that is creating the values.
   */
 case class GenerateSparqlToCreateMultipleValuesRequestV2(resourceIri: IRI,
                                                          values: Map[SmartIri, Seq[GenerateSparqlForValueInNewResourceV2]],
-                                                         currentTime: Instant,
+                                                         creationDate: Instant,
                                                          requestingUser: UserADM) extends ValuesResponderRequestV2 {
     lazy val flatValues: Iterable[GenerateSparqlForValueInNewResourceV2] = values.values.flatten
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ResourcesResponderV1.scala
@@ -758,9 +758,9 @@ class ResourcesResponderV1 extends Responder {
         /**
           * Represents a still image file value belonging to a source object (e.g., an image representation of a page).
           *
-          * @param id            the file value IRI
+          * @param id             the file value IRI
           * @param permissionCode the current user's permission code on the file value.
-          * @param image         a [[StillImageFileValueV1]]
+          * @param image          a [[StillImageFileValueV1]]
           */
         case class StillImageFileValue(id: IRI,
                                        permissionCode: Option[Int],
@@ -1181,10 +1181,11 @@ class ResourcesResponderV1 extends Responder {
                             val valueOrders = row.rowMap("valueOrders").split(StringFormatter.INFORMATION_SEPARATOR_ONE).map(_.toInt)
 
                             val guiOrders: Array[Int] = properties.map {
-                                propertyIri => cardinalities(propertyIri).guiOrder match {
-                                    case Some(order) => order
-                                    case None => -1
-                                }
+                                propertyIri =>
+                                    cardinalities(propertyIri).guiOrder match {
+                                        case Some(order) => order
+                                        case None => -1
+                                    }
                             }
 
                             // create a list of three tuples, sort it by guiOrder and valueOrder and return only string values
@@ -1378,11 +1379,10 @@ class ResourcesResponderV1 extends Responder {
 
             defaultPropertyAccessPermissionsMap: Map[IRI, Map[IRI, String]] = new ErrorHandlingMap(defaultPropertyAccessPermissions.toMap, { key: IRI => s"No default property access permissions found for resource class $key" })
 
-            // Make a timestamp for the new resources and their values.
-            currentTime: String = Instant.now.toString
-
             resourceCreationFutures: Seq[Future[SparqlTemplateResourceToCreate]] = resourcesToCreate.map {
                 resourceCreateRequest: OneOfMultipleResourceCreateRequestV1 =>
+                    val creationDate: Instant = resourceCreateRequest.creationDate.getOrElse(Instant.now)
+
                     for {
                         // Check user's PermissionProfile (part of UserADM) to see if the user has the permission to
                         // create a new resource in the given project.
@@ -1436,7 +1436,7 @@ class ResourcesResponderV1 extends Responder {
                             defaultPropertyAccessPermissions = defaultPropertyAccessPermissionsMap(resourceCreateRequest.resourceTypeIri),
                             values = resourceValuesWithLinkTargetIris,
                             clientResourceIDsToResourceIris = clientResourceIDsToResourceIris,
-                            currentTime = currentTime,
+                            creationDate = creationDate,
                             fileValues = fileValues,
                             userProfile = userProfile,
                             apiRequestID = apiRequestID
@@ -1447,7 +1447,8 @@ class ResourcesResponderV1 extends Responder {
                         permissions = defaultObjectAccessPermissions,
                         sparqlForValues = generateSparqlForValuesResponse.insertSparql,
                         resourceClassIri = resourceCreateRequest.resourceTypeIri,
-                        resourceLabel = resourceCreateRequest.label
+                        resourceLabel = resourceCreateRequest.label,
+                        resourceCreationDate = creationDate
                     )
             }
 
@@ -1459,8 +1460,7 @@ class ResourcesResponderV1 extends Responder {
                 resourcesToCreate = sparqlTemplateResourcesToCreate,
                 projectIri = projectIri,
                 namedGraph = namedGraph,
-                creatorIri = userIri,
-                currentTime = currentTime
+                creatorIri = userIri
             )
 
             // Do the update.
@@ -1654,7 +1654,7 @@ class ResourcesResponderV1 extends Responder {
                                              values: Map[IRI, Seq[CreateValueV1WithComment]],
                                              fileValues: Option[(IRI, Vector[CreateValueV1WithComment])],
                                              clientResourceIDsToResourceIris: Map[String, IRI],
-                                             currentTime: String,
+                                             creationDate: Instant,
                                              userProfile: UserADM,
                                              apiRequestID: UUID): Future[GenerateSparqlToCreateMultipleValuesResponseV1] = {
         for {
@@ -1666,7 +1666,7 @@ class ResourcesResponderV1 extends Responder {
                 defaultPropertyAccessPermissions = defaultPropertyAccessPermissions,
                 values = values ++ fileValues,
                 clientResourceIDsToResourceIris = clientResourceIDsToResourceIris,
-                currentTime = currentTime,
+                creationDate = creationDate,
                 userProfile = userProfile,
                 apiRequestID = apiRequestID
             ))
@@ -1680,19 +1680,18 @@ class ResourcesResponderV1 extends Responder {
       *
       * @param resourcesToCreate Collection of the resources to be created .
       * @param projectIri        IRI of the project .
-      * @param creatorIri        the creator of the resources to be created.
       * @param namedGraph        the named graph the resources belongs to.
+      * @param creatorIri        the creator of the resources to be created.
       * @return a [String] returns a Sparql query for creating the resources and their values .
       */
-    def generateSparqlForNewResources(resourcesToCreate: Seq[SparqlTemplateResourceToCreate], projectIri: IRI, namedGraph: IRI, creatorIri: IRI, currentTime: String): String = {
+    def generateSparqlForNewResources(resourcesToCreate: Seq[SparqlTemplateResourceToCreate], projectIri: IRI, namedGraph: IRI, creatorIri: IRI): String = {
         // Generate SPARQL for creating the resources, and include the SPARQL for creating the values of every resource.
         queries.sparql.v1.txt.createNewResources(
             dataNamedGraph = namedGraph,
             triplestore = settings.triplestoreType,
             resourcesToCreate = resourcesToCreate,
             projectIri = projectIri,
-            creatorIri = creatorIri,
-            currentTime = currentTime
+            creatorIri = creatorIri
         ).toString()
     }
 
@@ -1711,8 +1710,6 @@ class ResourcesResponderV1 extends Responder {
                               createNewResourceSparql: String,
                               generateSparqlForValuesResponse: GenerateSparqlToCreateMultipleValuesResponseV1,
                               userProfile: UserADM): Future[ResourceCreateResponseV1] = {
-        val userProfileV1 = userProfile.asUserProfileV1
-
         // Verify that the resource was created.
         for {
             createdResourcesSparql <- Future(queries.sparql.v1.txt.getCreatedResource(
@@ -1833,7 +1830,7 @@ class ResourcesResponderV1 extends Responder {
             // Everything looks OK, so we can create the resource and its values.
 
             // Make a timestamp for the resource and its values.
-            currentTime: String = Instant.now.toString
+            creationDate: Instant = Instant.now
 
             generateSparqlForValuesResponse: GenerateSparqlToCreateMultipleValuesResponseV1 <- generateSparqlForValuesOfNewResource(
                 projectIri = projectIri,
@@ -1843,25 +1840,27 @@ class ResourcesResponderV1 extends Responder {
                 values = values,
                 fileValues = fileValues,
                 clientResourceIDsToResourceIris = Map.empty[String, IRI],
-                currentTime = currentTime,
+                creationDate = creationDate,
                 userProfile = userProfile,
                 apiRequestID = apiRequestID
             )
 
-            resourcesToCreate: Seq[SparqlTemplateResourceToCreate] = Seq(SparqlTemplateResourceToCreate(
-                resourceIri = resourceIri,
-                permissions = defaultResourceClassAccessPermissions,
-                sparqlForValues = generateSparqlForValuesResponse.insertSparql,
-                resourceClassIri = resourceClassIri,
-                resourceLabel = label)
+            resourcesToCreate: Seq[SparqlTemplateResourceToCreate] = Seq(
+                SparqlTemplateResourceToCreate(
+                    resourceIri = resourceIri,
+                    permissions = defaultResourceClassAccessPermissions,
+                    sparqlForValues = generateSparqlForValuesResponse.insertSparql,
+                    resourceClassIri = resourceClassIri,
+                    resourceLabel = label,
+                    resourceCreationDate = creationDate
+                )
             )
 
             createNewResourceSparql = generateSparqlForNewResources(
                 resourcesToCreate = resourcesToCreate,
                 projectIri = projectIri,
                 namedGraph = namedGraph,
-                creatorIri = creatorIri,
-                currentTime = currentTime
+                creatorIri = creatorIri
             )
 
             // Do the update.
@@ -1888,7 +1887,13 @@ class ResourcesResponderV1 extends Responder {
       * @param apiRequestID          the ID of this API request.
       * @return a [[ResourceCreateResponseV1]] informing the client about the new resource.
       */
-    private def createNewResource(resourceClassIri: IRI, label: String, values: Map[IRI, Seq[CreateValueV1WithComment]], sipiConversionRequest: Option[SipiResponderConversionRequestV1] = None, projectIri: IRI, userProfile: UserADM, apiRequestID: UUID): Future[ResourceCreateResponseV1] = {
+    private def createNewResource(resourceClassIri: IRI,
+                                  label: String,
+                                  values: Map[IRI, Seq[CreateValueV1WithComment]],
+                                  sipiConversionRequest: Option[SipiResponderConversionRequestV1] = None,
+                                  projectIri: IRI,
+                                  userProfile: UserADM,
+                                  apiRequestID: UUID): Future[ResourceCreateResponseV1] = {
         val userProfileV1 = userProfile.asUserProfileV1
 
         val resultFuture = for {
@@ -1944,16 +1949,18 @@ class ResourcesResponderV1 extends Responder {
             result: ResourceCreateResponseV1 <- IriLocker.runWithIriLock(
                 apiRequestID,
                 resourceIri,
-                () => createResourceAndCheck(resourceClassIri,
-                    resourceProjectIri,
-                    label,
-                    resourceIri,
-                    values,
-                    sipiConversionRequest,
+                () => createResourceAndCheck(
+                    resourceClassIri = resourceClassIri,
+                    projectIri = resourceProjectIri,
+                    label = label,
+                    resourceIri = resourceIri,
+                    values = values,
+                    sipiConversionRequest = sipiConversionRequest,
                     creatorIri = userIri,
-                    namedGraph,
-                    userProfile,
-                    apiRequestID)
+                    namedGraph = namedGraph,
+                    userProfile = userProfile,
+                    apiRequestID = apiRequestID
+                )
             )
         } yield result
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v1/ValuesResponderV1.scala
@@ -389,7 +389,7 @@ class ValuesResponderV1 extends Responder {
                 standoffLinkInsertSparql: String = queries.sparql.v1.txt.generateInsertStatementsForStandoffLinks(
                     resourceIri = createMultipleValuesRequest.resourceIri,
                     linkUpdates = standoffLinkUpdates,
-                    currentTime = createMultipleValuesRequest.currentTime
+                    creationDate = createMultipleValuesRequest.creationDate
                 ).toString()
 
                 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -462,7 +462,7 @@ class ValuesResponderV1 extends Responder {
                                         queries.sparql.v1.txt.generateInsertStatementsForCreateLink(
                                             resourceIri = createMultipleValuesRequest.resourceIri,
                                             linkUpdate = sparqlTemplateLinkUpdate,
-                                            currentTime = createMultipleValuesRequest.currentTime,
+                                            creationDate = createMultipleValuesRequest.creationDate,
                                             maybeComment = valueToCreate.createValueV1WithComment.comment,
                                             maybeValueHasOrder = Some(valueToCreate.valueHasOrder)
                                         ).toString()
@@ -510,7 +510,7 @@ class ValuesResponderV1 extends Responder {
                                             maybeComment = valueToCreate.createValueV1WithComment.comment,
                                             valueCreator = userIri,
                                             valuePermissions = defaultPropertyAccessPermissions,
-                                            currentTime = createMultipleValuesRequest.currentTime,
+                                            creationDate = createMultipleValuesRequest.creationDate,
                                             maybeValueHasOrder = Some(valueToCreate.valueHasOrder)
                                         ).toString()
                                 }
@@ -730,7 +730,7 @@ class ValuesResponderV1 extends Responder {
             // If a temporary file was created, ensure that it's deleted, regardless of whether the request succeeded or failed.
             resultFuture.andThen {
                 case _ => changeFileValueRequest.file match {
-                    case (conversionPathRequest: SipiResponderConversionPathRequestV1) =>
+                    case conversionPathRequest: SipiResponderConversionPathRequestV1 =>
                         // a tmp file has been created by the resources route (non GUI-case), delete it
                         FileUtil.deleteFileFromTmpLocation(conversionPathRequest.source, log)
                     case _ => ()
@@ -2018,7 +2018,7 @@ class ValuesResponderV1 extends Responder {
                 userProfile = userProfile
             )
 
-            currentTime: String = Instant.now.toString
+            currentTime: Instant = Instant.now
 
             // Generate a SPARQL update string.
             sparqlUpdate = queries.sparql.v1.txt.createLink(
@@ -2026,7 +2026,7 @@ class ValuesResponderV1 extends Responder {
                 triplestore = settings.triplestoreType,
                 resourceIri = resourceIri,
                 linkUpdate = sparqlTemplateLinkUpdate,
-                currentTime = currentTime,
+                creationDate = currentTime,
                 maybeComment = comment
             ).toString()
 
@@ -2065,7 +2065,7 @@ class ValuesResponderV1 extends Responder {
                                                  userProfile: UserADM): Future[UnverifiedValueV1] = {
         // Generate an IRI for the new value.
         val newValueIri = knoraIdUtil.makeRandomValueIri(resourceIri)
-        val currentTime: String = Instant.now.toString
+        val creationDate: Instant = Instant.now
 
         for {
             // If we're creating a text value, update direct links and LinkValues for any resource references in standoff.
@@ -2106,7 +2106,7 @@ class ValuesResponderV1 extends Responder {
                 maybeComment = comment,
                 valueCreator = valueCreator,
                 valuePermissions = valuePermissions,
-                currentTime = currentTime
+                creationDate = creationDate
             ).toString()
 
             /*

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -137,7 +137,7 @@ class ResourcesResponderV2 extends ResponderWithStandoffV2 {
                 defaultPropertyPermissions: Map[SmartIri, String] = defaultPropertyPermissionsMap(internalCreateResource.resourceClassIri)
 
                 // Make a timestamp for the resource and its values.
-                currentTime: Instant = Instant.now
+                creationDate: Instant = internalCreateResource.creationDate.getOrElse(Instant.now)
 
                 // Do the remaining pre-update checks and make a ResourceReadyToCreate describing the SPARQL
                 // for creating the resource.
@@ -148,7 +148,7 @@ class ResourcesResponderV2 extends ResponderWithStandoffV2 {
                     clientResourceIDs = Map.empty[IRI, String],
                     defaultResourcePermissions = defaultResourcePermissions,
                     defaultPropertyPermissions = defaultPropertyPermissions,
-                    currentTime = currentTime,
+                    creationDate = creationDate,
                     requestingUser = createResourceRequestV2.requestingUser
                 )
 
@@ -161,8 +161,7 @@ class ResourcesResponderV2 extends ResponderWithStandoffV2 {
                     triplestore = settings.triplestoreType,
                     resourcesToCreate = Seq(resourceReadyToCreate.sparqlTemplateResourceToCreate),
                     projectIri = createResourceRequestV2.createResource.projectADM.id,
-                    creatorIri = createResourceRequestV2.requestingUser.id,
-                    currentTime = currentTime
+                    creatorIri = createResourceRequestV2.requestingUser.id
                 ).toString()
 
                 // Do the update.
@@ -248,7 +247,7 @@ class ResourcesResponderV2 extends ResponderWithStandoffV2 {
       * @param defaultResourcePermissions the default permissions to be given to the resource, if it does not have custom permissions.
       * @param defaultPropertyPermissions the default permissions to be given to the resource's values, if they do not
       *                                   have custom permissions. This is a map of property IRIs to permission strings.
-      * @param currentTime                the timestamp to be attached to the resource and its values.
+      * @param creationDate               the timestamp to be attached to the resource and its values.
       * @param requestingUser             the user making the request.
       * @return a [[ResourceReadyToCreate]].
       */
@@ -258,7 +257,7 @@ class ResourcesResponderV2 extends ResponderWithStandoffV2 {
                                               clientResourceIDs: Map[IRI, String],
                                               defaultResourcePermissions: String,
                                               defaultPropertyPermissions: Map[SmartIri, String],
-                                              currentTime: Instant,
+                                              creationDate: Instant,
                                               requestingUser: UserADM): Future[ResourceReadyToCreate] = {
         val resourceIDForErrorMsg: String = clientResourceIDs.get(internalCreateResource.resourceIri).map(resourceID => s"In resource '$resourceID': ").getOrElse("")
 
@@ -327,7 +326,7 @@ class ResourcesResponderV2 extends ResponderWithStandoffV2 {
                 GenerateSparqlToCreateMultipleValuesRequestV2(
                     resourceIri = internalCreateResource.resourceIri,
                     values = valuesWithValidatedPermissions,
-                    currentTime = currentTime,
+                    currentTime = creationDate,
                     requestingUser = requestingUser)
                 ).mapTo[GenerateSparqlToCreateMultipleValuesResponseV2]
         } yield ResourceReadyToCreate(
@@ -336,7 +335,8 @@ class ResourcesResponderV2 extends ResponderWithStandoffV2 {
                 permissions = resourcePermissions,
                 sparqlForValues = sparqlForValuesResponse.insertSparql,
                 resourceClassIri = internalCreateResource.resourceClassIri.toString,
-                resourceLabel = internalCreateResource.label
+                resourceLabel = internalCreateResource.label,
+                resourceCreationDate = creationDate
             ),
             values = sparqlForValuesResponse.unverifiedValues
         )

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -444,9 +444,9 @@ class ResourcesResponderV2 extends ResponderWithStandoffV2 {
                 GenerateSparqlToCreateMultipleValuesRequestV2(
                     resourceIri = internalCreateResource.resourceIri,
                     values = valuesWithValidatedPermissions,
-                    currentTime = creationDate,
-                    requestingUser = requestingUser)
-                ).mapTo[GenerateSparqlToCreateMultipleValuesResponseV2]
+                    creationDate = creationDate,
+                    requestingUser = requestingUser
+                )).mapTo[GenerateSparqlToCreateMultipleValuesResponseV2]
         } yield ResourceReadyToCreate(
             sparqlTemplateResourceToCreate = SparqlTemplateResourceToCreate(
                 resourceIri = internalCreateResource.resourceIri,

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -378,7 +378,7 @@ class ValuesResponderV2 extends Responder {
                 linkUpdates = standoffLinkUpdates,
                 valueCreator = valueCreator,
                 valuePermissions = valuePermissions,
-                currentTime = currentTime
+                creationDate = currentTime
             ).toString()
 
             /*
@@ -433,7 +433,7 @@ class ValuesResponderV2 extends Responder {
                 triplestore = settings.triplestoreType,
                 resourceIri = resourceInfo.resourceIri,
                 linkUpdate = sparqlTemplateLinkUpdate,
-                currentTime = currentTime,
+                creationDate = currentTime,
                 maybeComment = linkValueContent.comment
             ).toString()
 
@@ -482,7 +482,7 @@ class ValuesResponderV2 extends Responder {
                                 propertyIri = propertyIri,
                                 valueToCreate = valueToCreate,
                                 valueHasOrder = valueHasOrder,
-                                currentTime = createMultipleValuesRequest.currentTime,
+                                creationDate = createMultipleValuesRequest.creationDate,
                                 requestingUser = createMultipleValuesRequest.requestingUser
                             )
                     }
@@ -508,7 +508,7 @@ class ValuesResponderV2 extends Responder {
       * @param propertyIri    the IRI of the property that will point to the value.
       * @param valueToCreate  the value to be created.
       * @param valueHasOrder  the value's `knora-base:valueHasOrder`.
-      * @param currentTime    the timestamp to be used as the value creation time.
+      * @param creationDate    the timestamp to be used as the value creation time.
       * @param requestingUser the user making the request.
       * @return a [[InsertSparqlWithUnverifiedValue]] containing the generated SPARQL and an [[UnverifiedValueV2]].
       */
@@ -516,7 +516,7 @@ class ValuesResponderV2 extends Responder {
                                                         propertyIri: SmartIri,
                                                         valueToCreate: GenerateSparqlForValueInNewResourceV2,
                                                         valueHasOrder: Int,
-                                                        currentTime: Instant,
+                                                        creationDate: Instant,
                                                         requestingUser: UserADM): InsertSparqlWithUnverifiedValue = {
         // Make an IRI for the new value.
         val newValueIri = knoraIdUtil.makeRandomValueIri(resourceIri)
@@ -547,7 +547,7 @@ class ValuesResponderV2 extends Responder {
                 queries.sparql.v2.txt.generateInsertStatementsForCreateLink(
                     resourceIri = resourceIri,
                     linkUpdate = sparqlTemplateLinkUpdate,
-                    currentTime = currentTime,
+                    creationDate = creationDate,
                     maybeComment = valueToCreate.valueContent.comment,
                     maybeValueHasOrder = Some(valueHasOrder)
                 ).toString()
@@ -562,7 +562,7 @@ class ValuesResponderV2 extends Responder {
                     linkUpdates = Seq.empty[SparqlTemplateLinkUpdate], // This is empty because we have to generate SPARQL for standoff links separately.
                     valueCreator = requestingUser.id,
                     valuePermissions = valueToCreate.permissions,
-                    currentTime = currentTime,
+                    creationDate = creationDate,
                     maybeValueHasOrder = Some(valueHasOrder)
                 ).toString()
         }
@@ -636,7 +636,7 @@ class ValuesResponderV2 extends Responder {
         queries.sparql.v2.txt.generateInsertStatementsForStandoffLinks(
             resourceIri = createMultipleValuesRequest.resourceIri,
             linkUpdates = standoffLinkUpdates,
-            currentTime = createMultipleValuesRequest.currentTime
+            creationDate = createMultipleValuesRequest.creationDate
         ).toString()
     }
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/ResourcesRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/ResourcesRouteV1.scala
@@ -23,6 +23,7 @@ package org.knora.webapi.routing.v1
 import java.io._
 import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
+import java.time.Instant
 import java.util.UUID
 
 import akka.actor.ActorSystem
@@ -309,7 +310,8 @@ object ResourcesRouteV1 extends Authenticator {
                             source = fileToRead.file,
                             userProfile = userProfile.asUserProfileV1
                         )
-                }
+                },
+                creationDate = resourceRequest.creationDate
             )
         }
 
@@ -673,6 +675,9 @@ object ResourcesRouteV1 extends Authenticator {
                     // Get the client's unique ID for the resource.
                     val clientIDForResource: String = (resourceNode \ "@id").toString
 
+                    // Get the optional resource creation date.
+                    val creationDate: Option[Instant] = resourceNode.attribute("creationDate").map(creationDateNode => stringFormatter.toInstant(creationDateNode.text, throw BadRequestException(s"Invalid resource creation date: ${creationDateNode.text}")))
+
                     // Convert the XML element's label and namespace to an internal resource class IRI.
 
                     val elementNamespace: String = resourceNode.getNamespace(resourceNode.prefix)
@@ -771,7 +776,8 @@ object ResourcesRouteV1 extends Authenticator {
                         client_id = clientIDForResource,
                         label = resourceLabel,
                         properties = groupedPropertiesWithValues,
-                        file = file
+                        file = file,
+                        creationDate = creationDate
                     )
                 })
         }

--- a/webapi/src/main/scala/org/knora/webapi/twirl/SparqlTemplateResourceToCreate.scala
+++ b/webapi/src/main/scala/org/knora/webapi/twirl/SparqlTemplateResourceToCreate.scala
@@ -20,20 +20,24 @@
 
 package org.knora.webapi.twirl
 
+import java.time.Instant
+
 import org.knora.webapi._
 
 /**
   * Represents a resource to be created with its index, label, IRI, permissions, and SPARQL for creating its values
   *
-  * @param resourceIri                     the IRI of the resource to be created.
-  * @param permissions                     the permissions user has for creating the new resource.
-  * @param sparqlForValues the SPARQL for creating the values of the resource.
-  * @param resourceClassIri                the type of the resource to be created.
-  * @param resourceLabel                   the label of the resource.
+  * @param resourceIri          the IRI of the resource to be created.
+  * @param permissions          the permissions user has for creating the new resource.
+  * @param sparqlForValues      the SPARQL for creating the values of the resource.
+  * @param resourceClassIri     the type of the resource to be created.
+  * @param resourceLabel        the label of the resource.
+  * @param resourceCreationDate the creation date that should be attached to the resource.
   */
 
 case class SparqlTemplateResourceToCreate(resourceIri: IRI,
                                           permissions: String,
                                           sparqlForValues: String,
                                           resourceClassIri: IRI,
-                                          resourceLabel: String)
+                                          resourceLabel: String,
+                                          resourceCreationDate: Instant)

--- a/webapi/src/main/twirl/queries/sparql/v1/createLink.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/createLink.scala.txt
@@ -17,6 +17,7 @@
  * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
  *@
 
+@import java.time.Instant
 @import org.knora.webapi._
 @import org.knora.webapi.twirl.SparqlTemplateLinkUpdate
 @import org.knora.webapi.messages.v1.responder.valuemessages._
@@ -28,6 +29,7 @@
  * @param triplestore       the name of the triplestore being used.
  * @param resourceIri       the resource that is the source of the link.
  * @param linkUpdate        a [[LinkUpdate]] object describing the link to insert.
+ * @param creationDate      an xsd:dateTimeStamp to be attached to the link value.
  * @param maybeComment      an optional comment on the link.
  *
  * To find out whether the update succeeded, the application must query the link.
@@ -36,7 +38,7 @@
   triplestore: String,
   resourceIri: IRI,
   linkUpdate: SparqlTemplateLinkUpdate,
-  currentTime: String,
+  creationDate: Instant,
   maybeComment: Option[String])
 
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -53,12 +55,12 @@ DELETE {
 } INSERT {
     GRAPH ?dataNamedGraph {
         @* Update the link source's last modification date. *@
-        ?resource knora-base:lastModificationDate "@currentTime"^^xsd:dateTimeStamp .
+        ?resource knora-base:lastModificationDate "@creationDate"^^xsd:dateTimeStamp .
 
         @{
             queries.sparql.v1.txt.generateInsertStatementsForCreateLink(resourceIri = resourceIri,
                                                                         linkUpdate = linkUpdate,
-                                                                        currentTime = currentTime,
+                                                                        creationDate = creationDate,
                                                                         maybeComment = maybeComment,
                                                                         maybeValueHasOrder = None)
         }

--- a/webapi/src/main/twirl/queries/sparql/v1/createNewResources.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/createNewResources.scala.txt
@@ -17,6 +17,7 @@
  * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
  *@
 
+@import java.time.Instant
 @import org.knora.webapi.IRI
 @import org.knora.webapi.messages.v1.responder.valuemessages._
 @import org.knora.webapi.twirl.SparqlTemplateResourceToCreate
@@ -30,14 +31,12 @@
  * @param resourcesToCreate a collection of resources to be created.
  * @param projectIri        the IRI of the project in which the resources are to be created.
  * @param creatorIri        the IRI of the creator of the resources.
- * @param currentTime       an xsd:dateTimeStamp that will be attached to the resources.
  *@
 @(dataNamedGraph: IRI,
   triplestore: String,
   resourcesToCreate: Seq[SparqlTemplateResourceToCreate],
   projectIri: IRI,
-  creatorIri: IRI,
-  currentTime: String)
+  creatorIri: IRI)
 
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -54,7 +53,7 @@ INSERT DATA {
                 knora-base:attachedToProject <@projectIri> ;
                 rdfs:label """@res.resourceLabel""" ;
  				knora-base:hasPermissions "@res.permissions" ;
-                knora-base:creationDate "@currentTime"^^xsd:dateTimeStamp .
+                knora-base:creationDate "@res.resourceCreationDate"^^xsd:dateTimeStamp .
 
             @res.sparqlForValues
         }

--- a/webapi/src/main/twirl/queries/sparql/v1/createValue.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/createValue.scala.txt
@@ -17,6 +17,7 @@
  * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
  *@
 
+@import java.time.Instant
 @import org.knora.webapi._
 @import org.knora.webapi.twirl.SparqlTemplateLinkUpdate
 @import org.knora.webapi.messages.v1.responder.valuemessages._
@@ -37,7 +38,7 @@
  * @param maybeComment an optional comment on the value.
  * @param valueCreator the IRI of the user who created the value.
  * @param valuePermissions the permissions that should be attached to the value.
- * @param currentTime an xsd:dateTimeStamp representing the current time.
+ * @param creationDate an xsd:dateTimeStamp to be attached to the value.
  *
  * The generated WHERE clause does some consistency checks. If these fail, the operation will do nothing.
  * To find out whether the update succeeded, the application must query the property's version history.
@@ -53,7 +54,7 @@
   maybeComment: Option[String],
   valueCreator: IRI,
   valuePermissions: String,
-  currentTime: String)
+  creationDate: Instant)
 
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -85,7 +86,7 @@ DELETE {
     }
 } INSERT {
     GRAPH ?dataNamedGraph {
-        ?resource knora-base:lastModificationDate "@currentTime"^^xsd:dateTimeStamp .
+        ?resource knora-base:lastModificationDate "@creationDate"^^xsd:dateTimeStamp .
 
         @{
             queries.sparql.v1.txt.generateInsertStatementsForCreateValue(resourceIri = resourceIri,
@@ -96,7 +97,7 @@ DELETE {
                                                                          maybeComment = maybeComment,
                                                                          valueCreator = valueCreator,
                                                                          valuePermissions = valuePermissions,
-                                                                         currentTime = currentTime,
+                                                                         creationDate = creationDate,
                                                                          maybeValueHasOrder = None)
         }
     }

--- a/webapi/src/main/twirl/queries/sparql/v1/generateInsertStatementsForCreateLink.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/generateInsertStatementsForCreateLink.scala.txt
@@ -17,6 +17,7 @@
  * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
  *@
 
+@import java.time.Instant
 @import org.knora.webapi._
 @import org.knora.webapi.twirl.SparqlTemplateLinkUpdate
 @import org.knora.webapi.messages.v1.responder.valuemessages._
@@ -28,13 +29,13 @@
  *
  * @param resourceIri     the IRI of the resource.
  * @param linkUpdate a [[LinkUpdate]] object describing the link to insert.
- * @param currentTime an xsd:dateTimeStamp representing the current time.
+ * @param creationDate an xsd:dateTimeStamp to be attached to the link value.
  * @param maybeComment an optional comment on the link.
  * @param the knora-base:valueHasOrder of the new value. If not provided, the SPARQL variable ?nextOrder will be used.
  *@
 @(resourceIri: IRI,
   linkUpdate: SparqlTemplateLinkUpdate,
-  currentTime: String,
+  creationDate: Instant,
   maybeComment: Option[String],
   maybeValueHasOrder: Option[Int])
 
@@ -72,7 +73,7 @@
                 }
             }
             knora-base:isDeleted false ;
-            knora-base:valueCreationDate "@currentTime"^^xsd:dateTimeStamp ;
+            knora-base:valueCreationDate "@creationDate"^^xsd:dateTimeStamp ;
             knora-base:attachedToUser <@linkUpdate.newLinkValueCreator> ;
             knora-base:hasPermissions "@linkUpdate.newLinkValuePermissions"^^xsd:string .
 

--- a/webapi/src/main/twirl/queries/sparql/v1/generateInsertStatementsForCreateValue.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/generateInsertStatementsForCreateValue.scala.txt
@@ -17,6 +17,7 @@
  * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
  *@
 
+@import java.time.Instant
 @import org.knora.webapi._
 @import org.knora.webapi.twirl.SparqlTemplateLinkUpdate
 @import org.knora.webapi.messages.v1.responder.valuemessages._
@@ -34,7 +35,7 @@
  * @param maybeComment an optional comment on the value.
  * @param valueCreator the IRI of the user who created the value.
  * @param valuePermissions the permissions that should be attached to the value.
- * @param currentTime an xsd:dateTimeStamp representing the current time.
+ * @param creationDate an xsd:dateTimeStamp to be attached to the value.
  * @param the knora-base:valueHasOrder of the new value. If not provided, the SPARQL variable ?nextOrder will be used.
  *@
 @(resourceIri: IRI,
@@ -45,7 +46,7 @@
   maybeComment: Option[String],
   valueCreator: IRI,
   valuePermissions: String,
-  currentTime: String,
+  creationDate: Instant,
   maybeValueHasOrder: Option[Int])
 
         # Value: @newValueIri
@@ -237,13 +238,13 @@
                     knora-base:valueHasOrder ?nextOrder ;
                 }
             }
-            knora-base:valueCreationDate "@currentTime"^^xsd:dateTimeStamp .
+            knora-base:valueCreationDate "@creationDate"^^xsd:dateTimeStamp .
 
         @* Insert direct links and LinkValues for resource references. *@
         @{
             queries.sparql.v1.txt.generateInsertStatementsForStandoffLinks(resourceIri = resourceIri,
                                                                            linkUpdates = linkUpdates,
-                                                                           currentTime = currentTime)
+                                                                           creationDate = creationDate)
         }
 
         @* Attach the value to the resource. *@

--- a/webapi/src/main/twirl/queries/sparql/v1/generateInsertStatementsForStandoffLinks.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/generateInsertStatementsForStandoffLinks.scala.txt
@@ -17,6 +17,7 @@
  * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
  *@
 
+@import java.time.Instant
 @import org.knora.webapi._
 @import org.knora.webapi.twirl.SparqlTemplateLinkUpdate
 @import org.knora.webapi.messages.v1.responder.valuemessages._
@@ -30,11 +31,11 @@
  * @param the IRI of the resource in which values are being created.
  * @param linkUpdates a list of [[LinkUpdate]] objects describing links and LinkValues that need to be
  *        updated for resource references in Standoff text values.
- * @param currentTime an xsd:dateTimeStamp representing the current time.
+ * @param creationDate an xsd:dateTimeStamp to be attached to the link values.
  *@
 @(resourceIri: IRI,
   linkUpdates: Seq[SparqlTemplateLinkUpdate],
-  currentTime: String)
+  creationDate: Instant)
 
         @for((linkUpdate, linkValueIndex) <- linkUpdates.zipWithIndex) {
             @* Insert a direct link for the resource reference if necessary. *@
@@ -50,7 +51,7 @@
                 knora-base:valueHasString "@linkUpdate.linkTargetIri" ;
                 knora-base:valueHasRefCount @linkUpdate.newReferenceCount ;
                 knora-base:isDeleted false ;
-                knora-base:valueCreationDate "@currentTime"^^xsd:dateTimeStamp .
+                knora-base:valueCreationDate "@creationDate"^^xsd:dateTimeStamp .
 
             <@linkUpdate.newLinkValueIri> knora-base:attachedToUser <@linkUpdate.newLinkValueCreator> ;
                 knora-base:hasPermissions "@linkUpdate.newLinkValuePermissions" .

--- a/webapi/src/main/twirl/queries/sparql/v2/createLink.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/createLink.scala.txt
@@ -29,6 +29,7 @@
  * @param triplestore       the name of the triplestore being used.
  * @param resourceIri       the resource that is the source of the link.
  * @param linkUpdate        a [[LinkUpdate]] object describing the link to insert.
+ * @param creationDate      an xsd:dateTimeStamp that will be attached to the link value.
  * @param maybeComment      an optional comment on the link.
  *
  * To find out whether the update succeeded, the application must query the link.
@@ -37,7 +38,7 @@
   triplestore: String,
   resourceIri: IRI,
   linkUpdate: SparqlTemplateLinkUpdate,
-  currentTime: Instant,
+  creationDate: Instant,
   maybeComment: Option[String])
 
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -54,12 +55,12 @@ DELETE {
 } INSERT {
     GRAPH ?dataNamedGraph {
         @* Update the link source's last modification date. *@
-        ?resource knora-base:lastModificationDate "@currentTime"^^xsd:dateTimeStamp .
+        ?resource knora-base:lastModificationDate "@creationDate"^^xsd:dateTimeStamp .
 
         @{
             queries.sparql.v2.txt.generateInsertStatementsForCreateLink(resourceIri = resourceIri,
                                                                         linkUpdate = linkUpdate,
-                                                                        currentTime = currentTime,
+                                                                        creationDate = creationDate,
                                                                         maybeComment = maybeComment,
                                                                         maybeValueHasOrder = None)
         }

--- a/webapi/src/main/twirl/queries/sparql/v2/createNewResources.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/createNewResources.scala.txt
@@ -30,14 +30,12 @@
  * @param resourcesToCreate a collection of resources to be created.
  * @param projectIri        the IRI of the project in which the resources are to be created.
  * @param creatorIri        the IRI of the creator of the resources.
- * @param currentTime       an xsd:dateTimeStamp that will be attached to the resources.
  *@
 @(dataNamedGraph: IRI,
   triplestore: String,
   resourcesToCreate: Seq[SparqlTemplateResourceToCreate],
   projectIri: IRI,
-  creatorIri: IRI,
-  currentTime: Instant)
+  creatorIri: IRI)
 
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -54,7 +52,7 @@ INSERT DATA {
                 knora-base:attachedToProject <@projectIri> ;
                 rdfs:label """@res.resourceLabel""" ;
  				knora-base:hasPermissions "@res.permissions" ;
-                knora-base:creationDate "@currentTime"^^xsd:dateTimeStamp .
+                knora-base:creationDate "@res.resourceCreationDate"^^xsd:dateTimeStamp .
 
             @res.sparqlForValues
         }

--- a/webapi/src/main/twirl/queries/sparql/v2/createValue.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/createValue.scala.txt
@@ -38,7 +38,7 @@
  *        updated for resource references in Standoff text values.
  * @param valueCreator the IRI of the user who created the value.
  * @param valuePermissions the permissions that should be attached to the value.
- * @param currentTime an xsd:dateTimeStamp representing the current time.
+ * @param creationDate an xsd:dateTimeStamp that should be attached to the value.
  *
  * The generated WHERE clause does some consistency checks. If these fail, the operation will do nothing.
  * To find out whether the update succeeded, the application must query the property's version history.
@@ -53,7 +53,7 @@
   linkUpdates: Seq[SparqlTemplateLinkUpdate],
   valueCreator: IRI,
   valuePermissions: String,
-  currentTime: Instant)
+  creationDate: Instant)
 
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -85,7 +85,7 @@ DELETE {
     }
 } INSERT {
     GRAPH ?dataNamedGraph {
-        ?resource knora-base:lastModificationDate "@currentTime"^^xsd:dateTimeStamp .
+        ?resource knora-base:lastModificationDate "@creationDate"^^xsd:dateTimeStamp .
 
         @{
             queries.sparql.v2.txt.generateInsertStatementsForCreateValue(resourceIri = resourceIri,
@@ -95,7 +95,7 @@ DELETE {
                                                                          linkUpdates = linkUpdates,
                                                                          valueCreator = valueCreator,
                                                                          valuePermissions = valuePermissions,
-                                                                         currentTime = currentTime,
+                                                                         creationDate = creationDate,
                                                                          maybeValueHasOrder = None)
         }
     }

--- a/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForCreateLink.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForCreateLink.scala.txt
@@ -29,13 +29,13 @@
  *
  * @param resourceIri     the IRI of the resource.
  * @param linkUpdate a [[LinkUpdate]] object describing the link to insert.
- * @param currentTime an xsd:dateTimeStamp representing the current time.
+ * @param creationDate an xsd:dateTimeStamp that will be attached to the link value.
  * @param maybeComment an optional comment on the link.
  * @param the knora-base:valueHasOrder of the new value. If not provided, the SPARQL variable ?nextOrder will be used.
  *@
 @(resourceIri: IRI,
   linkUpdate: SparqlTemplateLinkUpdate,
-  currentTime: Instant,
+  creationDate: Instant,
   maybeComment: Option[String],
   maybeValueHasOrder: Option[Int])
 
@@ -73,7 +73,7 @@
                 }
             }
             knora-base:isDeleted false ;
-            knora-base:valueCreationDate "@currentTime"^^xsd:dateTimeStamp ;
+            knora-base:valueCreationDate "@creationDate"^^xsd:dateTimeStamp ;
             knora-base:attachedToUser <@linkUpdate.newLinkValueCreator> ;
             knora-base:hasPermissions "@linkUpdate.newLinkValuePermissions"^^xsd:string .
 

--- a/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForCreateValue.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForCreateValue.scala.txt
@@ -37,7 +37,7 @@
  *        are being created separately.
  * @param valueCreator the IRI of the user who created the value.
  * @param valuePermissions the permissions that should be attached to the value.
- * @param currentTime an xsd:dateTimeStamp representing the current time.
+ * @param creationDate an xsd:dateTimeStamp that will be attached to the value.
  * @param the knora-base:valueHasOrder of the new value. If not provided, the SPARQL variable ?nextOrder will be used.
  *@
 @(resourceIri: IRI,
@@ -47,7 +47,7 @@
   linkUpdates: Seq[SparqlTemplateLinkUpdate],
   valueCreator: IRI,
   valuePermissions: String,
-  currentTime: Instant,
+  creationDate: Instant,
   maybeValueHasOrder: Option[Int])
 
         # Value: @newValueIri
@@ -83,13 +83,13 @@
                     knora-base:valueHasOrder ?nextOrder ;
                 }
             }
-            knora-base:valueCreationDate "@currentTime"^^xsd:dateTimeStamp .
+            knora-base:valueCreationDate "@creationDate"^^xsd:dateTimeStamp .
 
         @* Insert direct links and LinkValues for resource references. *@
         @{
             queries.sparql.v2.txt.generateInsertStatementsForStandoffLinks(resourceIri = resourceIri,
                                                                            linkUpdates = linkUpdates,
-                                                                           currentTime = currentTime)
+                                                                           creationDate = creationDate)
         }
 
         @* Attach the value to the resource. *@

--- a/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForStandoffLinks.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForStandoffLinks.scala.txt
@@ -31,11 +31,11 @@
  * @param the IRI of the resource in which values are being created.
  * @param linkUpdates a list of [[LinkUpdate]] objects describing links and LinkValues that need to be
  *        updated for resource references in Standoff text values.
- * @param currentTime an xsd:dateTimeStamp representing the current time.
+ * @param creationDate an xsd:dateTimeStamp that will be attached to the link values.
  *@
 @(resourceIri: IRI,
   linkUpdates: Seq[SparqlTemplateLinkUpdate],
-  currentTime: Instant)
+  creationDate: Instant)
 
         @for((linkUpdate, linkValueIndex) <- linkUpdates.zipWithIndex) {
             @* Insert a direct link for the resource reference if necessary. *@
@@ -51,7 +51,7 @@
                 knora-base:valueHasString "@linkUpdate.linkTargetIri" ;
                 knora-base:valueHasRefCount @linkUpdate.newReferenceCount ;
                 knora-base:isDeleted false ;
-                knora-base:valueCreationDate "@currentTime"^^xsd:dateTimeStamp .
+                knora-base:valueCreationDate "@creationDate"^^xsd:dateTimeStamp .
 
             <@linkUpdate.newLinkValueIri> knora-base:attachedToUser <@linkUpdate.newLinkValueCreator> ;
                 knora-base:hasPermissions "@linkUpdate.newLinkValuePermissions" .

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -21,6 +21,7 @@ package org.knora.webapi.e2e.v2
 
 import java.io.File
 import java.net.URLEncoder
+import java.time.Instant
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.{Accept, BasicHttpCredentials}
@@ -414,6 +415,49 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)
             val resourceIri: IRI = responseJsonDoc.body.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.validateAndEscapeIri)
             assert(resourceIri.toSmartIri.isKnoraDataIri)
+        }
+
+        "create a resource with a custom creation date" in {
+            val creationDate: Instant = Instant.parse("2019-01-09T15:45:54.502951Z")
+
+            val jsonLDEntity =
+                s"""{
+                  |  "@type" : "anything:Thing",
+                  |  "knora-api:attachedToProject" : {
+                  |    "@id" : "http://rdfh.ch/projects/0001"
+                  |  },
+                  |  "anything:hasBoolean" : {
+                  |    "@type" : "knora-api:BooleanValue",
+                  |    "knora-api:booleanValueAsBoolean" : true
+                  |  },
+                  |  "rdfs:label" : "test thing",
+                  |  "knora-api:creationDate" : {
+                  |    "@type" : "xsd:dateTimeStamp",
+                  |    "@value" : "$creationDate"
+                  |  },
+                  |  "@context" : {
+                  |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                  |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+                  |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+                  |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+                  |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+                  |  }
+                  |}""".stripMargin
+
+            val request = Post(s"$baseApiUrl/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
+            val response: HttpResponse = singleAwaitingRequest(request)
+            assert(response.status == StatusCodes.OK, response.toString)
+            val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)
+            val resourceIri: IRI = responseJsonDoc.body.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.validateAndEscapeIri)
+            assert(resourceIri.toSmartIri.isKnoraDataIri)
+
+            val savedCreationDate: Instant = responseJsonDoc.body.requireDatatypeValueInObject(
+                key = OntologyConstants.KnoraApiV2WithValueObjects.CreationDate,
+                expectedDatatype = OntologyConstants.Xsd.DateTimeStamp.toSmartIri,
+                validationFun = stringFormatter.toInstant
+            )
+
+            assert(savedCreationDate == creationDate)
         }
 
         "create a resource containing escaped text" in {


### PR DESCRIPTION
- [x] Allow each resource in an API v1 bulk import to specify its creation date.
- [x] Allow API v2 resource creation to specify a creation date.
- [x] Add tests.
- [x] Update docs and release notes.

Resolves #1089.