### PR TITLE
Allow hasRepresentation in an ontology used in a bulk import

### DIFF
--- a/docs/src/paradox/00-release-notes/next.md
+++ b/docs/src/paradox/00-release-notes/next.md
@@ -4,9 +4,9 @@ Write any new release notes between releases into this file. They will be moved 
 at the time of the release, because only then we will know the next release number.
 
 Also, please change the **HINT** to the appropriate level:
- - MAJOR CHANGE, the changes introduced warrant a major number increase
- - MINOR CHANGE, the changes introduced warrant a minor number increase
- - BUGFIX CHANGE, the changes introduced warrant a bugfix number increase
+ - MAJOR: the changes introduced warrant a major number increase
+ - FEATURE: the changes introduced warrant a minor number increase
+ - FIX: the changes introduced warrant a bugfix number increase
 
 
 ## HINT => MAJOR CHANGE
@@ -18,3 +18,4 @@ Also, please change the **HINT** to the appropriate level:
 - FIX: Fix error-checking when updating cardinalities in ontology API (@github[#1142](#1142))
 - FEATURE: Allow setting resource creation date in bulk import (@github[#1151](#1151))
 - FEATURE: The `v2/authentication` route now also initiates cookie creation (the same as `v1/authentication`) (@github[#1159](#1159))
+- FIX: Allow hasRepresentation in an ontology used in a bulk import (@github[#1171](#1171))

--- a/webapi/_test_data/ontologies/anything-onto.ttl
+++ b/webapi/_test_data/ontologies/anything-onto.ttl
@@ -625,6 +625,21 @@
     rdfs:comment """Diese Resource-Klasse beschreibt ein unbedeutendes Ding"""@de .
 
 
+:ThingWithRepresentation rdf:type owl:Class ;
+  rdfs:subClassOf knora-base:Resource ;
+  rdfs:label "Thing with representation"@en ;
+  rdfs:comment "A thing with a representation"@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty knora-base:hasRepresentation ;
+    owl:minCardinality "0"^^xsd:nonNegativeInteger
+  ], [
+    a owl:Restriction ;
+    owl:onProperty knora-base:hasRepresentationValue ;
+    owl:minCardinality "0"^^xsd:nonNegativeInteger
+  ] .
+
+
 #################################################################
 #
 #    Standoff Classes

--- a/webapi/src/main/resources/knoraXmlImport.xsd
+++ b/webapi/src/main/resources/knoraXmlImport.xsd
@@ -46,6 +46,12 @@
         </xs:sequence>
     </xs:complexType>
 
+    <xs:complexType name="Representation_linkValueType">
+        <xs:sequence>
+            <xs:element name="Representation" type="linkValueType"/>
+        </xs:sequence>
+    </xs:complexType>
+
     <xs:element name="resources">
         <xs:complexType>
             <xs:sequence>


### PR DESCRIPTION
This bug is complicated to explain but easy to fix.

In the XML schemas that are used to check an API v1 bulk import, for each resource class that's used as the `objectClassConstraint` of a property, there needs to be an XML element type for elements representing links to resources of that class. For example, if you have a property `hasPerson` with an `objectClassConstraint` of `Person`, you get an automatically generated XML element type like this:

```xml
    <xs:complexType name="Person_linkValueType">
        <xs:sequence>
            <xs:element name="Person" type="knoraXmlImport:linkValueType"/>
        </xs:sequence>
    </xs:complexType>
```

These element types are generated for project-specific resource classes (in the Twirl template `xmlImport.scala.xml`), but element types for resource classes in `knora-base` are hard-coded in `knoraXmlImport.xsd`.

NIE-INE have an ontology that uses the property `knora-base:hasRepresentation`, whose `objectClassConstraint` is `Representation`. This property isn't actually useful in API v1, but NIE-INE have it in their ontology because they're planning to use API v2. The bug is that when we run XML schema validation, it can't find the type `Representation_linkValueType`, because I never thought to add it. So this PR adds it.

Fixes #1168.