### PR TITLE
Fix processing of shared property in bulk import

### DIFF
--- a/docs/src/paradox/00-release-notes/next.md
+++ b/docs/src/paradox/00-release-notes/next.md
@@ -24,3 +24,4 @@ Also, please change the **HINT** to the appropriate level:
   https://docs.knora.org/paradox/03-apis/api-v2/knora-iris.html#iris-for-data
   must update them.
 - FIX: Set cookie domain to the value specified in `application.conf` with the setting `cookie-domain` (@github[#1169](#1169))
+- FIX: Fix processing of shared property in bulk import (@github[#1182](#1182))

--- a/webapi/_test_data/ontologies/example-ibox.ttl
+++ b/webapi/_test_data/ontologies/example-ibox.ttl
@@ -1,0 +1,37 @@
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix knora-base: <http://www.knora.org/ontology/knora-base#> .
+@prefix salsah-gui: <http://www.knora.org/ontology/salsah-gui#> .
+@prefix example-box:  <http://www.knora.org/ontology/shared/example-box#> .
+
+@base <http://www.knora.org/ontology/shared/example-ibox> .
+
+# An example of a shared ontology.
+
+@prefix : <http://www.knora.org/ontology/shared/example-ibox#> .
+
+<http://www.knora.org/ontology/shared/example-ibox> rdf:type owl:Ontology ;
+    rdfs:label "An example of a shared ontology that uses another shared ontology" ;
+    knora-base:attachedToProject <http://www.knora.org/ontology/knora-base#DefaultSharedOntologiesProject> ;
+    knora-base:lastModificationDate "2018-09-10T14:53:00.000Z"^^xsd:dateTimeStamp .
+
+:iBox rdf:type owl:Class ;
+
+      rdfs:subClassOf knora-base:Resource ,
+                      [
+                         rdf:type owl:Restriction ;
+                         owl:onProperty example-box:hasName ;
+                         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+                         salsah-gui:guiOrder "0"^^xsd:nonNegativeInteger
+                      ] ;
+
+      knora-base:resourceIcon "thing.png" ;
+
+      rdfs:label "shared thing"@en ;
+
+      rdfs:comment """A shared thing."""@en .
+

--- a/webapi/src/main/scala/org/knora/webapi/util/StringFormatter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/StringFormatter.scala
@@ -2067,7 +2067,13 @@ class StringFormatter private(val maybeSettings: Option[SettingsImpl], initForTe
             case PropertyFromOtherOntologyInXmlImportRegex(_, Optional(maybeProjectID), prefixLabel, localName) =>
                 maybeProjectID match {
                     case Some(projectID) =>
-                        Some(s"${OntologyConstants.KnoraInternal.InternalOntologyStart}/$projectID/$prefixLabel#$localName")
+                        // Is this ia shared ontology?
+                        // TODO: when multiple shared project ontologies are supported, this will need to be done differently.
+                        if (projectID == DefaultSharedOntologiesProjectCode) {
+                            Some(s"${OntologyConstants.KnoraInternal.InternalOntologyStart}/shared/$prefixLabel#$localName")
+                        } else {
+                            Some(s"${OntologyConstants.KnoraInternal.InternalOntologyStart}/$projectID/$prefixLabel#$localName")
+                        }
 
                     case None =>
                         if (prefixLabel == OntologyConstants.KnoraXmlImportV1.KnoraXmlImportNamespacePrefixLabel) {


### PR DESCRIPTION
Fixes #1175:

If a class definition in ontology A uses a property definition from shared ontology B, the property's XML label is not converted correctly to an internal property IRI when bulk import data is uploaded.
