### PR TITLE
Allow ARK resolver protocol and hostname to be configured

### DIFF
--- a/docs/src/paradox/04-deployment/configuration.md
+++ b/docs/src/paradox/04-deployment/configuration.md
@@ -49,10 +49,12 @@ The relevant sections for tuning are:
 | app.jwt-secret-key                       | KNORA_WEBAPI_JWT_SECRET_KEY                       | super-secret-key     |
 | app.jwt-longevity                        | KNORA_WEBAPI_JWT_LONGEVITY                        | 30 days              |
 | app.cookie-domain                        | KNORA_WEBAPI_COOKIE_DOMAIN                        | localhost            |
+| app.ark.resolver                         | KNORA_WEBAPI_ARK_RESOLVER_URL                     | http://0.0.0.0:3336  |
+| app.ark.assigned-number                  | KNORA_WEBAPI_ARK_NAAN                             | 72163                |
 | app.knora-api.internal-host              | KNORA_WEBAPI_KNORA_API_INTERNAL_HOST              | 0.0.0.0              |
 | app.knora-api.internal-port              | KNORA_WEBAPI_KNORA_API_INTERNAL_PORT              | 3333                 |
 | app.knora-api.external-protocol          | KNORA_WEBAPI_KNORA_API_EXTERNAL_PROTOCOL          | http                 |
-| app.knora-api.external-host              | KNORA_WEBAPI_KNORA_API_EXTERNAL_HOST              | 0.0.0.0            |
+| app.knora-api.external-host              | KNORA_WEBAPI_KNORA_API_EXTERNAL_HOST              | 0.0.0.0              |
 | app.knora-api.external-port              | KNORA_WEBAPI_KNORA_API_EXTERNAL_PORT              | 3333                 |
 | app.sipi.internal-protocol               | KNORA_WEBAPI_SIPI_INTERNAL_PROTOCOL               | http                 |
 | app.sipi.internal-host                   | KNORA_WEBAPI_SIPI_INTERNAL_HOST                   | localhost            |

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -299,7 +299,9 @@ app {
 
     ark {
         resolver = "http://0.0.0.0:3336"
+        resolver = ${?KNORA_WEBAPI_ARK_RESOLVER_URL}
         assigned-number = 72163
+        assigned-number = ${?KNORA_WEBAPI_ARK_NAAN}
     }
 
     salsah1 {

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -298,7 +298,7 @@ app {
     }
 
     ark {
-        host = "ark.dasch.swiss"
+        resolver = "http://0.0.0.0:3336"
         assigned-number = 72163
     }
 

--- a/webapi/src/main/scala/org/knora/webapi/Settings.scala
+++ b/webapi/src/main/scala/org/knora/webapi/Settings.scala
@@ -111,7 +111,7 @@ class SettingsImpl(config: Config) extends Extension {
     val sipiMoveFileRouteV2: String = config.getString("app.sipi.v2.move-file-route")
     val sipiDeleteTempFileRouteV2: String = config.getString("app.sipi.v2.delete-temp-file-route")
 
-    val arkResolverHost: String = config.getString("app.ark.host")
+    val arkResolver: String = config.getString("app.ark.resolver")
     val arkAssignedNumber: Int = config.getInt("app.ark.assigned-number")
 
     val caches: Vector[KnoraCacheConfig] = config.getList("app.caches").iterator.asScala.map {

--- a/webapi/src/main/scala/org/knora/webapi/util/StringFormatter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/StringFormatter.scala
@@ -578,11 +578,11 @@ class StringFormatter private(val maybeSettings: Option[SettingsImpl], initForTe
         maybeSettings.map(_.externalKnoraApiHostPort)
     }
 
-    // The host that the ARK resolver is running on.
-    private val arkResolverHost: Option[String] = if (initForTest) {
-        Some("ark.dasch.swiss")
+    // The protocol and host that the ARK resolver is running on.
+    private val arkResolver: Option[String] = if (initForTest) {
+        Some("http://0.0.0.0:3336")
     } else {
-        maybeSettings.map(_.arkResolverHost)
+        maybeSettings.map(_.arkResolver)
     }
 
     // The DaSCH's ARK assigned number.
@@ -2179,7 +2179,7 @@ class StringFormatter private(val maybeSettings: Option[SettingsImpl], initForTe
       * @return an ARK URL that can be resolved to obtain the resource.
       */
     private def makeArkUrl(projectID: String, resourceID: String, maybeTimestamp: Option[Instant] = None): String = {
-        val (host: String, assignedNumber: Int) = (arkResolverHost, arkAssignedNumber) match {
+        val (resolver: String, assignedNumber: Int) = (arkResolver, arkAssignedNumber) match {
             case (Some(definedHost: String), Some(definedAssignedNumber: Int)) => (definedHost, definedAssignedNumber)
             case _ => throw AssertionException(s"StringFormatter has not been initialised with system settings")
         }
@@ -2200,7 +2200,7 @@ class StringFormatter private(val maybeSettings: Option[SettingsImpl], initForTe
         // Escape '-' as '=' in the resource ID and check digit, because '-' can be ignored in ARK URLs.
         val escapedResourceIDWithCheckDigit = resourceIDWithCheckDigit.replace('-', '=')
 
-        val arkUrlWithoutTimestamp = s"http://$host/ark:/$assignedNumber/$ArkVersion/$projectID/$escapedResourceIDWithCheckDigit"
+        val arkUrlWithoutTimestamp = s"$resolver/ark:/$assignedNumber/$ArkVersion/$projectID/$escapedResourceIDWithCheckDigit"
 
         maybeTimestamp match {
             case Some(timestamp) =>

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLand.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLand.jsonld
@@ -210,7 +210,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLand.rdf
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLand.rdf
@@ -30,7 +30,7 @@
 	<incunabula:title rdf:resource="http://rdfh.ch/0803/2a6221216701/values/942b620f9105"/>
 	<incunabula:title rdf:resource="http://rdfh.ch/0803/2a6221216701/values/5755b5489105"/>
 	<incunabula:url rdf:resource="http://rdfh.ch/0803/2a6221216701/values/f89173afca2704"/>
-	<knora-api:arkUrl rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W</knora-api:arkUrl>
+	<knora-api:arkUrl rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W</knora-api:arkUrl>
 	<knora-api:attachedToProject rdf:resource="http://rdfh.ch/projects/0803"/>
 	<knora-api:attachedToUser rdf:resource="http://rdfh.ch/users/91e19f1e01"/>
 	<knora-api:creationDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTimeStamp">2016-03-02T15:05:21Z</knora-api:creationDate>

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLand.ttl
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLand.ttl
@@ -22,7 +22,7 @@
   incunabula:title <http://rdfh.ch/0803/2a6221216701/values/5755b5489105>, <http://rdfh.ch/0803/2a6221216701/values/942b620f9105>,
     <http://rdfh.ch/0803/2a6221216701/values/d1010fd69005>;
   incunabula:url <http://rdfh.ch/0803/2a6221216701/values/f89173afca2704>;
-  knora-api:arkUrl "http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W"^^xsd:anyURI;
+  knora-api:arkUrl "http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W"^^xsd:anyURI;
   knora-api:attachedToProject <http://rdfh.ch/projects/0803>;
   knora-api:attachedToUser <http://rdfh.ch/users/91e19f1e01>;
   knora-api:creationDate "2016-03-02T15:05:21Z"^^xsd:dateTimeStamp;

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLandPreview.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLandPreview.jsonld
@@ -3,7 +3,7 @@
   "@type" : "incunabula:book",
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLandSimple.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLandSimple.jsonld
@@ -16,7 +16,7 @@
   "incunabula:url" : "http://aleph.unibas.ch/F/?local_base=DSV01&con_lng=GER&func=find-b&find_code=SYS&request=002610320",
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W"
   },
   "rdfs:label" : "Reise ins Heilige Land",
   "@context" : {

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLandSimple.rdf
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLandSimple.rdf
@@ -30,7 +30,7 @@
 	<incunabula:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reysen und wanderschafften durch das Gelobte Land</incunabula:title>
 	<incunabula:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Itinerarius</incunabula:title>
 	<incunabula:url rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://aleph.unibas.ch/F/?local_base=DSV01&amp;con_lng=GER&amp;func=find-b&amp;find_code=SYS&amp;request=002610320</incunabula:url>
-	<knora-api:arkUrl rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W</knora-api:arkUrl>
+	<knora-api:arkUrl rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W</knora-api:arkUrl>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reise ins Heilige Land</rdfs:label>
 </incunabula:book>
 

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLandSimple.ttl
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLandSimple.ttl
@@ -18,5 +18,5 @@
   incunabula:publoc "Basel";
   incunabula:title "Itinerarius", "Reise ins Heilige Land", "Reysen und wanderschafften durch das Gelobte Land";
   incunabula:url "http://aleph.unibas.ch/F/?local_base=DSV01&con_lng=GER&func=find-b&find_code=SYS&request=002610320";
-  knora-api:arkUrl "http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W"^^xsd:anyURI;
+  knora-api:arkUrl "http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W"^^xsd:anyURI;
   rdfs:label "Reise ins Heilige Land" .

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLandSimplePreview.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLandSimplePreview.jsonld
@@ -3,7 +3,7 @@
   "@type" : "incunabula:book",
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W"
   },
   "rdfs:label" : "Reise ins Heilige Land",
   "@context" : {

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithBCEDate.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithBCEDate.jsonld
@@ -21,7 +21,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/thing_with_BCE_dateb"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_BCE_dateb"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithBCEDate2.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithBCEDate2.jsonld
@@ -21,7 +21,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/thing_with_BCE_date2S"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_BCE_date2S"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithLinkComplex.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithLinkComplex.jsonld
@@ -13,7 +13,7 @@
       "@type" : "anything:Thing",
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/LOV=6aLYQFW15jwdyS51YwF"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/LOV=6aLYQFW15jwdyS51YwF"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0001"
@@ -31,7 +31,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/0C=0L1kORryKzJAJxxRyRQY"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/0C=0L1kORryKzJAJxxRyRQY"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithLinkSimple.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithLinkSimple.jsonld
@@ -6,7 +6,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/0C=0L1kORryKzJAJxxRyRQY"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/0C=0L1kORryKzJAJxxRyRQY"
   },
   "rdfs:label" : "Sierra",
   "@context" : {

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithTextLangComplex.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithTextLangComplex.jsonld
@@ -13,7 +13,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/a=thing=with=text=valuesLanguageB"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thing=with=text=valuesLanguageB"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithTextLangSimple.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithTextLangSimple.jsonld
@@ -7,7 +7,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/a=thing=with=text=valuesLanguageB"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thing=with=text=valuesLanguageB"
   },
   "rdfs:label" : "ein verdammtes Ding mit einer Sprache",
   "@context" : {

--- a/webapi/src/test/resources/test-data/searchR2RV2/BooksNotPublishedOnDate.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/BooksNotPublishedOnDate.jsonld
@@ -31,7 +31,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/cf0892760104a"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/cf0892760104a"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -89,7 +89,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -139,7 +139,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c3f913666f0"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c3f913666f0"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -181,7 +181,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1967a9933401n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1967a9933401n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -223,7 +223,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/41d01bd9fb0"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/41d01bd9fb0"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -265,7 +265,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/9311a421b501n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/9311a421b501n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -315,7 +315,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -361,7 +361,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/3341c4984004k"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/3341c4984004k"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -407,7 +407,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/939baf3f2a02L"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/939baf3f2a02L"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -449,7 +449,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/21abac2162A"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/21abac2162A"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -491,7 +491,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c5058f3a5"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -541,7 +541,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/e41ab5695cN"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/e41ab5695cN"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -583,7 +583,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/861b5644b302T"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/861b5644b302T"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -629,7 +629,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/5e77e98d2603U"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/5e77e98d2603U"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -675,7 +675,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/6fad5b8c1e03q"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/6fad5b8c1e03q"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -729,7 +729,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -771,7 +771,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/9935159f67u"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/9935159f67u"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/BooksPublishedAfterDate.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/BooksPublishedAfterDate.jsonld
@@ -26,7 +26,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/9935159f67u"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/9935159f67u"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/BooksPublishedAfterOrOnDate.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/BooksPublishedAfterOrOnDate.jsonld
@@ -27,7 +27,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/de6d83112e04o"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/de6d83112e04o"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -81,7 +81,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/8be1b7cf7103G"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/8be1b7cf7103G"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -135,7 +135,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -177,7 +177,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/9935159f67u"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/9935159f67u"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/BooksPublishedBeforeDate.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/BooksPublishedBeforeDate.jsonld
@@ -31,7 +31,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/cf0892760104a"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/cf0892760104a"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -89,7 +89,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -139,7 +139,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c3f913666f0"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c3f913666f0"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -181,7 +181,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1967a9933401n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1967a9933401n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -223,7 +223,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/41d01bd9fb0"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/41d01bd9fb0"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -265,7 +265,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/9311a421b501n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/9311a421b501n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -315,7 +315,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -361,7 +361,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/3341c4984004k"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/3341c4984004k"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -407,7 +407,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/939baf3f2a02L"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/939baf3f2a02L"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -449,7 +449,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/21abac2162A"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/21abac2162A"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -491,7 +491,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c5058f3a5"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -541,7 +541,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/e41ab5695cN"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/e41ab5695cN"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -583,7 +583,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/861b5644b302T"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/861b5644b302T"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -629,7 +629,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/5e77e98d2603U"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/5e77e98d2603U"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -675,7 +675,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/6fad5b8c1e03q"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/6fad5b8c1e03q"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/BooksPublishedBeforeOrOnDate.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/BooksPublishedBeforeOrOnDate.jsonld
@@ -31,7 +31,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/cf0892760104a"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/cf0892760104a"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -73,7 +73,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/de6d83112e04o"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/de6d83112e04o"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -131,7 +131,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -181,7 +181,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c3f913666f0"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c3f913666f0"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -223,7 +223,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1967a9933401n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1967a9933401n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -265,7 +265,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/41d01bd9fb0"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/41d01bd9fb0"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -307,7 +307,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/9311a421b501n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/9311a421b501n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -357,7 +357,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -403,7 +403,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/3341c4984004k"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/3341c4984004k"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -449,7 +449,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/939baf3f2a02L"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/939baf3f2a02L"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -491,7 +491,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/21abac2162A"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/21abac2162A"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -533,7 +533,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c5058f3a5"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -583,7 +583,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/e41ab5695cN"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/e41ab5695cN"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -625,7 +625,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/861b5644b302T"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/861b5644b302T"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -671,7 +671,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/5e77e98d2603U"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/5e77e98d2603U"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -717,7 +717,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/6fad5b8c1e03q"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/6fad5b8c1e03q"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -771,7 +771,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/8be1b7cf7103G"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/8be1b7cf7103G"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -825,7 +825,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/BooksPublishedBetweenDates.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/BooksPublishedBetweenDates.jsonld
@@ -35,7 +35,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c3f913666f0"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c3f913666f0"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -77,7 +77,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1967a9933401n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1967a9933401n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -119,7 +119,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/41d01bd9fb0"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/41d01bd9fb0"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -161,7 +161,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/9311a421b501n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/9311a421b501n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -211,7 +211,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/BooksPublishedOnDate.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/BooksPublishedOnDate.jsonld
@@ -27,7 +27,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/de6d83112e04o"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/de6d83112e04o"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -81,7 +81,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/8be1b7cf7103G"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/8be1b7cf7103G"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/BooksWithTitleContainingZeit.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/BooksWithTitleContainingZeit.jsonld
@@ -13,7 +13,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c5058f3a5"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -41,7 +41,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/BooksWithTitleContainingZeitgloecklein.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/BooksWithTitleContainingZeitgloecklein.jsonld
@@ -13,7 +13,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c5058f3a5"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -41,7 +41,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/DingeFulltextSearch.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/DingeFulltextSearch.jsonld
@@ -26,7 +26,7 @@
   } ],
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/a=thing=with=text=valuesv"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thing=with=text=valuesv"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/DingeFulltextSearchSimple.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/DingeFulltextSearchSimple.jsonld
@@ -4,7 +4,7 @@
   "anything:hasText" : [ "Ich liebe die Dinge, sie sind alles für mich.", "Na ja, die Dinge sind OK." ],
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/a=thing=with=text=valuesv"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thing=with=text=valuesv"
   },
   "rdfs:label" : "Ein Ding für jemanden, dem die Dinge gefallen",
   "@context" : {

--- a/webapi/src/test/resources/test-data/searchR2RV2/IncomingLinksForBook.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/IncomingLinksForBook.jsonld
@@ -3,7 +3,7 @@
   "@type" : "knora-api:LinkObj",
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/881405205304a"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/881405205304a"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0803"
@@ -27,7 +27,7 @@
       "@type" : "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book",
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/8be1b7cf7103G"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/8be1b7cf7103G"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/LanguageFulltextSearch.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/LanguageFulltextSearch.jsonld
@@ -13,7 +13,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/a=thing=with=text=valuesLanguageB"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thing=with=text=valuesLanguageB"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/LinkObjectsToBooks.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/LinkObjectsToBooks.jsonld
@@ -4,7 +4,7 @@
     "@type" : "knora-api:LinkObj",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/881405205304a"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/881405205304a"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -28,7 +28,7 @@
         "@type" : "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/8be1b7cf7103G"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/8be1b7cf7103G"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -55,7 +55,7 @@
         "@type" : "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/5e77e98d2603U"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/5e77e98d2603U"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -78,7 +78,7 @@
     "@type" : "knora-api:LinkObj",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ab79ffa43935M"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ab79ffa43935M"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -102,7 +102,7 @@
         "@type" : "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c5058f3a5"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -125,7 +125,7 @@
     "@type" : "knora-api:LinkObj",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/cb1a74e3e2f6X"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/cb1a74e3e2f6X"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -149,7 +149,7 @@
         "@type" : "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/21abac2162A"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/21abac2162A"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -176,7 +176,7 @@
         "@type" : "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/e41ab5695cN"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/e41ab5695cN"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -203,7 +203,7 @@
         "@type" : "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c5058f3a5"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/NarrFulltextSearch.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/NarrFulltextSearch.jsonld
@@ -13,7 +13,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/00505cf0a803D"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/00505cf0a803D"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -41,7 +41,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/00c650d23303L"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/00c650d23303L"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -69,7 +69,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/02abe871e903L"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/02abe871e903L"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -97,7 +97,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/04416f64ef03="
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/04416f64ef03="
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -125,7 +125,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/04f25db73f03q"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/04f25db73f03q"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -153,7 +153,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/05c7acceb703v"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/05c7acceb703v"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -181,7 +181,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/075d33c1bd03V"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/075d33c1bd03V"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -209,7 +209,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/0b8940a6c903u"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/0b8940a6c903u"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -237,7 +237,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/0d1fc798cf03K"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/0d1fc798cf03K"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -265,7 +265,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/0d5ac1099503s"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/0d5ac1099503s"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -293,7 +293,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/0fb54d8bd503g"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/0fb54d8bd503g"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -321,7 +321,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/0ff047fc9a03X"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/0ff047fc9a03X"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -349,7 +349,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/114bd47ddb03G"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/114bd47ddb03G"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -377,7 +377,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/14dd8cbc3403w"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/14dd8cbc3403w"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -405,7 +405,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/167313af3a03e"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/167313af3a03e"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -433,7 +433,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1b746fabbe03v"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1b746fabbe03v"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -461,7 +461,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1baf691c8403U"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1baf691c8403U"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -489,7 +489,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1d0af69dc4039"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1d0af69dc4039"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -517,7 +517,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1fa07c90ca03h"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1fa07c90ca03h"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -545,7 +545,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1fdb760190032"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1fdb760190032"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -573,7 +573,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/21360383d003A"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/21360383d003A"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -601,7 +601,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2171fdf39503q"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2171fdf39503q"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -629,7 +629,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/230784e69b03z"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/230784e69b03z"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -657,7 +657,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/23427e5761032"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/23427e5761032"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -685,7 +685,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/23cc8975d603o"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/23cc8975d603o"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/NotZeitgloeckleinExtendedSearch.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/NotZeitgloeckleinExtendedSearch.jsonld
@@ -13,7 +13,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1967a9933401n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1967a9933401n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -41,7 +41,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/21abac2162A"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/21abac2162A"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -85,7 +85,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -113,7 +113,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/3341c4984004k"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/3341c4984004k"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -141,7 +141,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/41d01bd9fb0"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/41d01bd9fb0"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -169,7 +169,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/5e77e98d2603U"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/5e77e98d2603U"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -197,7 +197,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/6fad5b8c1e03q"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/6fad5b8c1e03q"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -225,7 +225,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/861b5644b302T"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/861b5644b302T"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -261,7 +261,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/8be1b7cf7103G"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/8be1b7cf7103G"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -289,7 +289,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/9311a421b501n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/9311a421b501n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -317,7 +317,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/939baf3f2a02L"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/939baf3f2a02L"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -345,7 +345,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/9935159f67u"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/9935159f67u"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -381,7 +381,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -417,7 +417,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c3f913666f0"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c3f913666f0"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -445,7 +445,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/cf0892760104a"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/cf0892760104a"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -473,7 +473,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/de6d83112e04o"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/de6d83112e04o"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -509,7 +509,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/e41ab5695cN"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/e41ab5695cN"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -537,7 +537,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/PageWithSeqnum10OnlySeqnuminAnswer.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/PageWithSeqnum10OnlySeqnuminAnswer.jsonld
@@ -12,7 +12,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/68ef9568b903O"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/68ef9568b903O"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/PageWithSeqnum10WithSeqnumAndLinkValueInAnswer.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/PageWithSeqnum10WithSeqnumAndLinkValueInAnswer.jsonld
@@ -13,7 +13,7 @@
       "@type" : "incunabula:book",
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"
@@ -40,7 +40,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/68ef9568b903O"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/68ef9568b903O"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/PagesOfNarrenschiffOrderedBySeqnum.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/PagesOfNarrenschiffOrderedBySeqnum.jsonld
@@ -14,7 +14,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -41,7 +41,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/7bbb8e59b703A"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/7bbb8e59b703A"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -70,7 +70,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -97,7 +97,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/40c11d94b7031"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/40c11d94b7031"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -126,7 +126,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -153,7 +153,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/05c7acceb703v"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/05c7acceb703v"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -182,7 +182,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -209,7 +209,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/cacc3b09b803u"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/cacc3b09b803u"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -238,7 +238,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -265,7 +265,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/8fd2ca43b803G"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/8fd2ca43b803G"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -294,7 +294,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -321,7 +321,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/54d8597eb803p"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/54d8597eb803p"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -350,7 +350,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -377,7 +377,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/19dee8b8b8030"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/19dee8b8b8030"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -406,7 +406,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -433,7 +433,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/dee377f3b803g"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/dee377f3b803g"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -462,7 +462,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -489,7 +489,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/a3e9062eb903X"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/a3e9062eb903X"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -518,7 +518,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -545,7 +545,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/68ef9568b903O"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/68ef9568b903O"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -574,7 +574,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -601,7 +601,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2df524a3b903s"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2df524a3b903s"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -630,7 +630,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -657,7 +657,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/f2fab3ddb903j"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/f2fab3ddb903j"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -686,7 +686,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -713,7 +713,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b7004318ba03V"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b7004318ba03V"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -742,7 +742,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -769,7 +769,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/7c06d252ba03w"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/7c06d252ba03w"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -798,7 +798,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -825,7 +825,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/410c618dba03b"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/410c618dba03b"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -854,7 +854,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -881,7 +881,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/0612f0c7ba03r"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/0612f0c7ba03r"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -910,7 +910,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -937,7 +937,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/cb177f02bb03D"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/cb177f02bb03D"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -966,7 +966,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -993,7 +993,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/901d0e3dbb03e"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/901d0e3dbb03e"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1022,7 +1022,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1049,7 +1049,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/55239d77bb03u"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/55239d77bb03u"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1078,7 +1078,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1105,7 +1105,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1a292cb2bb03f"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1a292cb2bb03f"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1134,7 +1134,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1161,7 +1161,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/df2ebbecbb03T"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/df2ebbecbb03T"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1190,7 +1190,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1217,7 +1217,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/a4344a27bc03c"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/a4344a27bc03c"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1246,7 +1246,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1273,7 +1273,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/693ad961bc03P"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/693ad961bc03P"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1302,7 +1302,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1329,7 +1329,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2e40689cbc03s"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2e40689cbc03s"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1358,7 +1358,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1385,7 +1385,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/f345f7d6bc03g"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/f345f7d6bc03g"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/PagesOfNarrenschiffOrderedBySeqnumNextOffset.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/PagesOfNarrenschiffOrderedBySeqnumNextOffset.jsonld
@@ -14,7 +14,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -41,7 +41,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b84b8611bd035"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b84b8611bd035"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -70,7 +70,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -97,7 +97,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/7d51154cbd03G"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/7d51154cbd03G"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -126,7 +126,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -153,7 +153,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/4257a486bd03w"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/4257a486bd03w"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -182,7 +182,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -209,7 +209,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/075d33c1bd03V"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/075d33c1bd03V"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -238,7 +238,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -265,7 +265,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/cc62c2fbbd03="
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/cc62c2fbbd03="
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -294,7 +294,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -321,7 +321,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/91685136be03G"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/91685136be03G"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -350,7 +350,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -377,7 +377,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/566ee070be03t"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/566ee070be03t"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -406,7 +406,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -433,7 +433,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1b746fabbe03v"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1b746fabbe03v"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -462,7 +462,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -489,7 +489,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/e079fee5be03n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/e079fee5be03n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -518,7 +518,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -545,7 +545,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/a57f8d20bf03A"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/a57f8d20bf03A"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -574,7 +574,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -601,7 +601,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/6a851c5bbf03N"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/6a851c5bbf03N"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -630,7 +630,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -657,7 +657,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2f8bab95bf03c"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2f8bab95bf03c"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -686,7 +686,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -713,7 +713,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/f4903ad0bf03X"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/f4903ad0bf03X"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -742,7 +742,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -769,7 +769,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b996c90ac003Q"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b996c90ac003Q"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -798,7 +798,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -825,7 +825,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/7e9c5845c0039"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/7e9c5845c0039"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -854,7 +854,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -881,7 +881,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/43a2e77fc0033"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/43a2e77fc0033"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -910,7 +910,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -937,7 +937,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/08a876bac0030"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/08a876bac0030"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -966,7 +966,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -993,7 +993,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/cdad05f5c003H"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/cdad05f5c003H"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1022,7 +1022,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1049,7 +1049,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/92b3942fc103N"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/92b3942fc103N"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1078,7 +1078,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1105,7 +1105,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/57b9236ac103S"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/57b9236ac103S"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1134,7 +1134,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1161,7 +1161,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1cbfb2a4c103N"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1cbfb2a4c103N"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1190,7 +1190,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1217,7 +1217,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/e1c441dfc103L"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/e1c441dfc103L"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1246,7 +1246,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1273,7 +1273,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/a6cad019c203K"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/a6cad019c203K"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1302,7 +1302,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1329,7 +1329,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/6bd05f54c2039"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/6bd05f54c2039"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -1358,7 +1358,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -1385,7 +1385,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/30d6ee8ec203="
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/30d6ee8ec203="
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ProjectsWithOptionalPersonOrBiblio.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ProjectsWithOptionalPersonOrBiblio.jsonld
@@ -4,7 +4,7 @@
     "@type" : "gravsearchtest1:Project",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0666/1rK4ZevpT5eIxj48kgncsQu"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0666/1rK4ZevpT5eIxj48kgncsQu"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0666"
@@ -23,7 +23,7 @@
     "@type" : "gravsearchtest1:Project",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0666/NLe33EVtTKGozGJOqKT_2QL"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0666/NLe33EVtTKGozGJOqKT_2QL"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0666"
@@ -58,7 +58,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0666/xY8O4uSeQb=MDC4VtvQGdwm"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0666/xY8O4uSeQb=MDC4VtvQGdwm"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0666"
@@ -81,7 +81,7 @@
     "@type" : "gravsearchtest1:Project",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0666/tWf2vqMqQ_OcUMJSRj6e5wm"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0666/tWf2vqMqQ_OcUMJSRj6e5wm"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0666"
@@ -116,7 +116,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0666/wopH6GHOSpCyASdrsNqg_Am"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0666/wopH6GHOSpCyASdrsNqg_Am"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0666"
@@ -154,7 +154,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0666/yjOFfSKPR_uiw8KoJu5mQgy"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0666/yjOFfSKPR_uiw8KoJu5mQgy"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0666"

--- a/webapi/src/test/resources/test-data/searchR2RV2/RegionsForPage.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/RegionsForPage.jsonld
@@ -4,7 +4,7 @@
     "@type" : "knora-api:Region",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/021ec18f1735T"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/021ec18f1735T"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -56,7 +56,7 @@
         "@type" : "http://0.0.0.0:3333/ontology/0803/incunabula/v2#page",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/9d626dc76c039"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/9d626dc76c039"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -78,7 +78,7 @@
     "@type" : "knora-api:Region",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b64a62b006z"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b64a62b006z"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -130,7 +130,7 @@
         "@type" : "http://0.0.0.0:3333/ontology/0803/incunabula/v2#page",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/9d626dc76c039"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/9d626dc76c039"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingBiggerThanDecimal.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingBiggerThanDecimal.jsonld
@@ -15,7 +15,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/uqmMo72OQ2K2xe7mkIytlgf"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/uqmMo72OQ2K2xe7mkIytlgf"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingByIriWithRequestedValues.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingByIriWithRequestedValues.jsonld
@@ -21,7 +21,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingEqualsDecimal.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingEqualsDecimal.jsonld
@@ -15,7 +15,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/uqmMo72OQ2K2xe7mkIytlgf"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/uqmMo72OQ2K2xe7mkIytlgf"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingSmallerThanDecimal.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingSmallerThanDecimal.jsonld
@@ -16,7 +16,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -47,7 +47,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/uqmMo72OQ2K2xe7mkIytlgf"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/uqmMo72OQ2K2xe7mkIytlgf"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingUniform.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingUniform.jsonld
@@ -3,7 +3,7 @@
   "@type" : "anything:Thing",
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/LOV=6aLYQFW15jwdyS51YwF"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/LOV=6aLYQFW15jwdyS51YwF"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBoolean.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBoolean.jsonld
@@ -13,7 +13,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -41,7 +41,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/uqmMo72OQ2K2xe7mkIytlgf"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/uqmMo72OQ2K2xe7mkIytlgf"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBooleanOptionalOffset0.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBooleanOptionalOffset0.jsonld
@@ -4,7 +4,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/0C=0L1kORryKzJAJxxRyRQY"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/0C=0L1kORryKzJAJxxRyRQY"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -23,7 +23,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/5IEswyQFQp2bxXDrOyEfEAr"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/5IEswyQFQp2bxXDrOyEfEAr"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -42,7 +42,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/7uuGcnFcQJq08dMOralyCQY"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/7uuGcnFcQJq08dMOralyCQY"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -61,7 +61,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/9eSuQ_J7T0aOqoImTkwPxAX"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/9eSuQ_J7T0aOqoImTkwPxAX"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -80,7 +80,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/A67ka6UQRHWf313tbhQBjwu"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/A67ka6UQRHWf313tbhQBjwu"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -99,7 +99,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/CNhWoNGGT7iWOrIwxsEqvAO"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/CNhWoNGGT7iWOrIwxsEqvAO"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -127,7 +127,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -146,7 +146,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/L5xU7Qe5QUu6Wz3cDaCxbAU"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/L5xU7Qe5QUu6Wz3cDaCxbAU"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -165,7 +165,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/LOV=6aLYQFW15jwdyS51YwF"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/LOV=6aLYQFW15jwdyS51YwF"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -184,7 +184,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/Lz7WEqJETJqqsUZQYexBQgy"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/Lz7WEqJETJqqsUZQYexBQgy"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -203,7 +203,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/MiBwAFcxQZGHNL=WfgFAPQb"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/MiBwAFcxQZGHNL=WfgFAPQb"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -222,7 +222,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/WLSHxQUgTOmG1T0lBU2r5wb"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/WLSHxQUgTOmG1T0lBU2r5wb"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -241,7 +241,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/YgL4JhwfSQq=1davjrp8Owz"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/YgL4JhwfSQq=1davjrp8Owz"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -260,7 +260,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/ZYNUiHtsTROWblui9xHEuwP"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/ZYNUiHtsTROWblui9xHEuwP"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -279,7 +279,7 @@
     "@type" : "anything:BlueThing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/a=blue=thing7"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=blue=thing7"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -298,7 +298,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/a=thingO"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thingO"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -317,7 +317,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/a=thing=with=pictureE"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thing=with=pictureE"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -336,7 +336,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/a=thing=with=text=valuesv"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thing=with=text=valuesv"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -355,7 +355,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/a=thing=with=text=valuesLanguageB"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thing=with=text=valuesLanguageB"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -374,7 +374,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/another=thing4"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/another=thing4"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -393,7 +393,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/cL5AwEioRLOm6Vrqwl1RmQ8"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/cL5AwEioRLOm6Vrqwl1RmQ8"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -412,7 +412,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/cmfk1DMHRBiR4=_6HXpEFAn"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/cmfk1DMHRBiR4=_6HXpEFAn"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -431,7 +431,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/contained=thing=13"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/contained=thing=13"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -450,7 +450,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/contained=thing=21"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/contained=thing=21"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -469,7 +469,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/containing=thing5"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/containing=thing5"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBooleanOptionalOffset1.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBooleanOptionalOffset1.jsonld
@@ -4,7 +4,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/iqW_PBiHRdyTFzik8tuSogZ"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/iqW_PBiHRdyTFzik8tuSogZ"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -23,7 +23,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/lklGBGI2RR=nWemGTL4uOQB"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/lklGBGI2RR=nWemGTL4uOQB"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -42,7 +42,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/nResNuvARcWYUdWyo0GWGwA"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/nResNuvARcWYUdWyo0GWGwA"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -61,7 +61,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/nVh9YJ1ZStSmCHb9hIdwWwC"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/nVh9YJ1ZStSmCHb9hIdwWwC"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -80,7 +80,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/project=thing=1m"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/project=thing=1m"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -99,7 +99,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/project=thing=2k"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/project=thing=2k"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -118,7 +118,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/qN1igiDRSAemBBktbRHn6gn"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/qN1igiDRSAemBBktbRHn6gn"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -137,7 +137,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/rzRrc2G1StKUMyZVjJnxuwX"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/rzRrc2G1StKUMyZVjJnxuwX"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -156,7 +156,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/sHCLAGg=R5qJ6oPZPV=zOQF"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/sHCLAGg=R5qJ6oPZPV=zOQF"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -175,7 +175,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/startU"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/startU"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -194,7 +194,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/tPfZeNMvRVujCQqbIbvO0AM"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/tPfZeNMvRVujCQqbIbvO0AM"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -213,7 +213,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/thing_with_BCE_dateb"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_BCE_dateb"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -232,7 +232,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/thing_with_BCE_date2S"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_BCE_date2S"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -251,7 +251,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/thing_with_list_valueO"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -270,7 +270,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/thing_with_richtext_with_markupO"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_richtext_with_markupO"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -289,7 +289,7 @@
     "@type" : "anything:Thing",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/thing_with_two_list_valuesx"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_two_list_valuesx"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -317,7 +317,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/uqmMo72OQ2K2xe7mkIytlgf"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/uqmMo72OQ2K2xe7mkIytlgf"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBooleanOrDecimal.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithBooleanOrDecimal.jsonld
@@ -13,7 +13,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -53,7 +53,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/uqmMo72OQ2K2xe7mkIytlgf"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/uqmMo72OQ2K2xe7mkIytlgf"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithRichtextWithTermTextInParagraph.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithRichtextWithTermTextInParagraph.jsonld
@@ -15,7 +15,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/thing_with_richtext_with_markupO"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_richtext_with_markupO"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ZeitgloeckleinExtendedSearchNoTitleInAnswer.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ZeitgloeckleinExtendedSearchNoTitleInAnswer.jsonld
@@ -4,7 +4,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c5058f3a5"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -23,7 +23,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ZeitgloeckleinExtendedSearchWithTitleInAnswer.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ZeitgloeckleinExtendedSearchWithTitleInAnswer.jsonld
@@ -13,7 +13,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c5058f3a5"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -41,7 +41,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/ZeitgloeckleinExtendedSearchWithTitleInAnswerSimple.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ZeitgloeckleinExtendedSearchWithTitleInAnswerSimple.jsonld
@@ -5,7 +5,7 @@
     "incunabula:title" : "Zeitglöcklein des Lebens und Leidens Christi",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c5058f3a5"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5"
     },
     "rdfs:label" : "Zeitglöcklein des Lebens und Leidens Christi"
   }, {
@@ -14,7 +14,7 @@
     "incunabula:title" : "Zeitglöcklein des Lebens und Leidens Christi",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
     },
     "rdfs:label" : "Zeitglöcklein des Lebens und Leidens Christi"
   } ],

--- a/webapi/src/test/resources/test-data/searchR2RV2/bookWithIncomingPagesOnlyLink.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/bookWithIncomingPagesOnlyLink.jsonld
@@ -20,7 +20,7 @@
   } ],
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/8be1b7cf7103G"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/8be1b7cf7103G"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0803"
@@ -55,7 +55,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/50e7460a72036"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/50e7460a72036"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/bookWithIncomingPagesWithAllRequestedProps.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/bookWithIncomingPagesWithAllRequestedProps.jsonld
@@ -20,7 +20,7 @@
   } ],
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/8be1b7cf7103G"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/8be1b7cf7103G"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0803"
@@ -64,7 +64,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/50e7460a72036"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/50e7460a72036"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/booksWithPage100.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/booksWithPage100.jsonld
@@ -4,7 +4,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1967a9933401n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1967a9933401n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -48,7 +48,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/0da887734b01l"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/0da887734b01l"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -71,7 +71,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2a6221216701W"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2a6221216701W"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -115,7 +115,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/1ea3ff007e01L"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/1ea3ff007e01L"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -138,7 +138,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/41d01bd9fb0"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/41d01bd9fb0"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -182,7 +182,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/700b6b7e1201t"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/700b6b7e1201t"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -205,7 +205,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/5e77e98d2603U"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/5e77e98d2603U"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -249,7 +249,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/52b8c76d3d03p"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/52b8c76d3d03p"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -272,7 +272,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/861b5644b302T"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/861b5644b302T"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -316,7 +316,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/7a5c3424ca02J"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/7a5c3424ca02J"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -339,7 +339,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/8be1b7cf7103G"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/8be1b7cf7103G"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -383,7 +383,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/7f2296af8803U"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/7f2296af8803U"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -406,7 +406,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/9311a421b501n"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/9311a421b501n"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -450,7 +450,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/87528201cc01p"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/87528201cc01p"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -473,7 +473,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/939baf3f2a02L"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/939baf3f2a02L"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -517,7 +517,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/87dc8d1f41020"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/87dc8d1f41020"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -540,7 +540,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -584,7 +584,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/aaf6ddfecd03Z"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/aaf6ddfecd03Z"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -607,7 +607,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c5058f3a5"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -651,7 +651,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b9466d1a17j"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b9466d1a17j"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -674,7 +674,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/cf0892760104a"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/cf0892760104a"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -718,7 +718,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c34970561804T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c34970561804T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -741,7 +741,7 @@
     "@type" : "incunabula:book",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -785,7 +785,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b85e520aae015"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b85e520aae015"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/foafPerson.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/foafPerson.jsonld
@@ -21,7 +21,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"

--- a/webapi/src/test/resources/test-data/searchR2RV2/incomingPagesForBook.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/incomingPagesForBook.jsonld
@@ -20,7 +20,7 @@
   } ],
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0803"
@@ -64,7 +64,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/05c7acceb703v"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/05c7acceb703v"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"
@@ -111,7 +111,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/19dee8b8b8030"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/19dee8b8b8030"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"
@@ -158,7 +158,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/40c11d94b7031"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/40c11d94b7031"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"
@@ -205,7 +205,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/54d8597eb803p"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/54d8597eb803p"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"
@@ -252,7 +252,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/68ef9568b903O"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/68ef9568b903O"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"
@@ -299,7 +299,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/7bbb8e59b703A"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/7bbb8e59b703A"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"
@@ -346,7 +346,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/8fd2ca43b803G"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/8fd2ca43b803G"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"
@@ -393,7 +393,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/a3e9062eb903X"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/a3e9062eb903X"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"
@@ -440,7 +440,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/cacc3b09b803u"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/cacc3b09b803u"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"
@@ -487,7 +487,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/dee377f3b803g"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/dee377f3b803g"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/letterWithAuthor.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/letterWithAuthor.jsonld
@@ -31,7 +31,7 @@
       "@type" : "beol:person",
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"
@@ -49,7 +49,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"

--- a/webapi/src/test/resources/test-data/searchR2RV2/letterWithAuthorWithInformation.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/letterWithAuthorWithInformation.jsonld
@@ -40,7 +40,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"
@@ -77,7 +77,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/H7s3FmuWTkaCXa54eFANOAd"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/H7s3FmuWTkaCXa54eFANOAd"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"
@@ -95,7 +95,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"

--- a/webapi/src/test/resources/test-data/searchR2RV2/letterWithPersonWithName.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/letterWithPersonWithName.jsonld
@@ -40,7 +40,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"
@@ -58,7 +58,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"

--- a/webapi/src/test/resources/test-data/searchR2RV2/letterWithPersonWithName2.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/letterWithPersonWithName2.jsonld
@@ -40,7 +40,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/H7s3FmuWTkaCXa54eFANOAd"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/H7s3FmuWTkaCXa54eFANOAd"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"
@@ -58,7 +58,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"

--- a/webapi/src/test/resources/test-data/searchR2RV2/letterWithPersonWithNameOptional.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/letterWithPersonWithNameOptional.jsonld
@@ -40,7 +40,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"
@@ -68,7 +68,7 @@
       "@type" : "beol:person",
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/H7s3FmuWTkaCXa54eFANOAd"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/H7s3FmuWTkaCXa54eFANOAd"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"
@@ -86,7 +86,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"

--- a/webapi/src/test/resources/test-data/searchR2RV2/letterWithPersonWithoutName.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/letterWithPersonWithoutName.jsonld
@@ -31,7 +31,7 @@
       "@type" : "beol:person",
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/H7s3FmuWTkaCXa54eFANOAd"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/H7s3FmuWTkaCXa54eFANOAd"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"
@@ -49,7 +49,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"

--- a/webapi/src/test/resources/test-data/searchR2RV2/letterWithSubject.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/letterWithSubject.jsonld
@@ -15,7 +15,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"

--- a/webapi/src/test/resources/test-data/searchR2RV2/lettersByMeier.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/lettersByMeier.jsonld
@@ -40,7 +40,7 @@
       },
       "knora-api:arkUrl" : {
         "@type" : "xsd:anyURI",
-        "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
       },
       "knora-api:attachedToProject" : {
         "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"
@@ -58,7 +58,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"

--- a/webapi/src/test/resources/test-data/searchR2RV2/pagesOfLatinNarrenschiffWithSeqnumLowerEquals10.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/pagesOfLatinNarrenschiffWithSeqnumLowerEquals10.jsonld
@@ -14,7 +14,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -41,7 +41,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/7bbb8e59b703A"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/7bbb8e59b703A"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -70,7 +70,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -97,7 +97,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/40c11d94b7031"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/40c11d94b7031"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -126,7 +126,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -153,7 +153,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/05c7acceb703v"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/05c7acceb703v"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -182,7 +182,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -209,7 +209,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/cacc3b09b803u"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/cacc3b09b803u"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -238,7 +238,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -265,7 +265,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/8fd2ca43b803G"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/8fd2ca43b803G"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -294,7 +294,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -321,7 +321,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/54d8597eb803p"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/54d8597eb803p"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -350,7 +350,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -377,7 +377,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/19dee8b8b8030"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/19dee8b8b8030"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -406,7 +406,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -433,7 +433,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/dee377f3b803g"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/dee377f3b803g"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -462,7 +462,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -489,7 +489,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/a3e9062eb903X"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/a3e9062eb903X"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -518,7 +518,7 @@
         "@type" : "incunabula:book",
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/b6b5ff1eb703T"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/b6b5ff1eb703T"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -545,7 +545,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/68ef9568b903O"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/68ef9568b903O"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/regionsOfZeitgloecklein.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/regionsOfZeitgloecklein.jsonld
@@ -4,7 +4,7 @@
     "@type" : "knora-api:Region",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/2e0252679a35p"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/2e0252679a35p"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -48,7 +48,7 @@
             },
             "knora-api:arkUrl" : {
               "@type" : "xsd:anyURI",
-              "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+              "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
             },
             "knora-api:attachedToProject" : {
               "@id" : "http://rdfh.ch/projects/0803"
@@ -66,7 +66,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/3f89a693a501w"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/3f89a693a501w"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -88,7 +88,7 @@
     "@type" : "knora-api:Region",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/4e2223eb204c01w"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/4e2223eb204c01w"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -132,7 +132,7 @@
             },
             "knora-api:arkUrl" : {
               "@type" : "xsd:anyURI",
-              "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+              "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
             },
             "knora-api:attachedToProject" : {
               "@id" : "http://rdfh.ch/projects/0803"
@@ -150,7 +150,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/6240ce899801x"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/6240ce899801x"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -172,7 +172,7 @@
     "@type" : "knora-api:Region",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c2807e831a4c01G"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c2807e831a4c01G"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -216,7 +216,7 @@
             },
             "knora-api:arkUrl" : {
               "@type" : "xsd:anyURI",
-              "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+              "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
             },
             "knora-api:attachedToProject" : {
               "@id" : "http://rdfh.ch/projects/0803"
@@ -234,7 +234,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c568b7239a01k"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c568b7239a01k"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"
@@ -256,7 +256,7 @@
     "@type" : "knora-api:Region",
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/c4160576204c01K"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c4160576204c01K"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0803"
@@ -300,7 +300,7 @@
             },
             "knora-api:arkUrl" : {
               "@type" : "xsd:anyURI",
-              "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/ff17e5ef9601j"
+              "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
             },
             "knora-api:attachedToProject" : {
               "@id" : "http://rdfh.ch/projects/0803"
@@ -318,7 +318,7 @@
         },
         "knora-api:arkUrl" : {
           "@type" : "xsd:anyURI",
-          "@value" : "http://ark.dasch.swiss/ark:/72163/1/0803/6240ce899801x"
+          "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/6240ce899801x"
         },
         "knora-api:attachedToProject" : {
           "@id" : "http://rdfh.ch/projects/0803"

--- a/webapi/src/test/resources/test-data/searchR2RV2/thingWithURI.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/thingWithURI.jsonld
@@ -15,7 +15,7 @@
   },
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/thingsWithStandoffLinks.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/thingsWithStandoffLinks.jsonld
@@ -27,7 +27,7 @@
     } ],
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/a=thing=with=text=valuesv"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thing=with=text=valuesv"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"
@@ -58,7 +58,7 @@
     },
     "knora-api:arkUrl" : {
       "@type" : "xsd:anyURI",
-      "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/project=thing=1m"
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/project=thing=1m"
     },
     "knora-api:attachedToProject" : {
       "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/resources/test-data/searchR2RV2/thingsWithStandoffLinksToSpecificThing.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/thingsWithStandoffLinksToSpecificThing.jsonld
@@ -26,7 +26,7 @@
   } ],
   "knora-api:arkUrl" : {
     "@type" : "xsd:anyURI",
-    "@value" : "http://ark.dasch.swiss/ark:/72163/1/0001/a=thing=with=text=valuesv"
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thing=with=text=valuesv"
   },
   "knora-api:attachedToProject" : {
     "@id" : "http://rdfh.ch/projects/0001"

--- a/webapi/src/test/scala/org/knora/webapi/util/StringFormatterSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/StringFormatterSpec.scala
@@ -1051,7 +1051,7 @@ class StringFormatterSpec extends CoreSpec() {
         "generate an ARK URL for a resource IRI without a timestamp" in {
             val resourceIri: IRI = "http://rdfh.ch/0001/cmfk1DMHRBiR4-_6HXpEFA"
             val arkUrl = resourceIri.toSmartIri.fromResourceIriToArkUrl()
-            assert(arkUrl == "http://ark.dasch.swiss/ark:/72163/1/0001/cmfk1DMHRBiR4=_6HXpEFAn")
+            assert(arkUrl == "http://0.0.0.0:3336/ark:/72163/1/0001/cmfk1DMHRBiR4=_6HXpEFAn")
         }
     }
 }


### PR DESCRIPTION
In `application.conf`:

```
app {
    ark {
        resolver = "http://0.0.0.0:3336"
        assigned-number = 72163
    }
}
```

This way you can set `app.ark.resolver` to `https://ark.dasch.swiss` so that ARK URLs will use HTTPS.