### PR TITLE
Ignore order of attributes when comparing standoff

### DIFF
--- a/docs/src/paradox/00-release-notes/next.md
+++ b/docs/src/paradox/00-release-notes/next.md
@@ -15,3 +15,4 @@ Also, please change the **HINT** to the appropriate level:
 - MAJOR: Reorganize user and project routes (@github[#1209](#1209))
 - FEATURE: Secure routes returning user informations (@github[#961](#961))
 - MAJOR: Change all `xsd:dateTimeStamp` to `xsd:dateTime` in the triplestore (@github[#1211](#1211)). Existing data must be updated.
+- FIX: Ignore order of attributes when comparing standoff (@github[#1224](#1224)).

--- a/webapi/src/main/scala/org/knora/webapi/util/standoff/StandoffTagUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/standoff/StandoffTagUtilV2.scala
@@ -1006,7 +1006,18 @@ object StandoffTagUtilV2 {
         // then make a sequence of sets of tags sorted by index.
 
         standoff.groupBy(_.startIndex).map {
-            case (index: Int, standoffForIndex: Seq[StandoffTagV2]) => index -> standoffForIndex.map(_.copy(uuid = "")).toSet
+            case (index: Int, standoffForIndex: Seq[StandoffTagV2]) =>
+                // Set each tag's UUID to the empty string (because these should not affect the comparison),
+                // and sort its attributes by standoff property IRI.
+                val comparableTags = standoffForIndex.map {
+                    tag =>
+                        tag.copy(
+                            uuid = "",
+                            attributes = tag.attributes.sortBy(_.standoffPropertyIri)
+                        )
+                }
+
+                index -> comparableTags.toSet
         }.toVector.sortBy {
             case (index: Int, standoffForIndex: Set[StandoffTagV2]) => index
         }.map {

--- a/webapi/src/test/scala/org/knora/webapi/util/standoff/StandoffTagUtilV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/standoff/StandoffTagUtilV2Spec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.util.standoff
+
+import org.knora.webapi.CoreSpec
+import org.knora.webapi.twirl.{StandoffTagStringAttributeV2, StandoffTagV2}
+
+/**
+  * Tests [[StandoffTagUtilV2]].
+  */
+class StandoffTagUtilV2Spec extends CoreSpec {
+    "StandoffTagUtilV2" should {
+
+        "compare standoff when the order of attributes is different" in {
+            val comparableStandoff1 = StandoffTagUtilV2.makeComparableStandoffCollection(StandoffTagUtilV2Spec.standoff1)
+            val comparableStandoff2 = StandoffTagUtilV2.makeComparableStandoffCollection(StandoffTagUtilV2Spec.standoff2)
+            assert(comparableStandoff1 == comparableStandoff2)
+        }
+    }
+}
+
+object StandoffTagUtilV2Spec {
+    val standoff1: Vector[StandoffTagV2] = Vector(
+        StandoffTagV2(
+            endParentIndex = None,
+            originalXMLID = None,
+            uuid = "e8c2c060-a41d-4403-ac7d-d0f84f772378",
+            endPosition = 5,
+            startParentIndex = None,
+            attributes = Nil,
+            startIndex = 0,
+            endIndex = None,
+            dataType = None,
+            startPosition = 0,
+            standoffTagClassIri = "http://www.knora.org/ontology/standoff#StandoffRootTag"
+        ),
+        StandoffTagV2(
+            endParentIndex = None,
+            originalXMLID = None,
+            uuid = "1d250370-9692-497f-a28b-bd20ebafe171",
+            endPosition = 4,
+            startParentIndex = Some(0),
+            attributes = Vector(
+                StandoffTagStringAttributeV2(
+                    standoffPropertyIri = "http://www.knora.org/ontology/0113/lumieres-lausanne#standoffEditionTagHasFix",
+                    value = "correction"
+                ),
+                StandoffTagStringAttributeV2(
+                    standoffPropertyIri = "http://www.knora.org/ontology/0113/lumieres-lausanne#standoffEditionTagHasTitle",
+                    value = "titre"
+                )
+            ),
+            startIndex = 1,
+            endIndex = None,
+            dataType = None,
+            startPosition = 0,
+            standoffTagClassIri = "http://www.knora.org/ontology/0113/lumieres-lausanne#StandoffEditionTag"
+        )
+    )
+
+    val standoff2: Vector[StandoffTagV2] = Vector(
+        StandoffTagV2(
+            endParentIndex = None,
+            originalXMLID = None,
+            uuid = "e8c2c060-a41d-4403-ac7d-d0f84f772378",
+            endPosition = 5,
+            startParentIndex = None,
+            attributes = Nil,
+            startIndex = 0,
+            endIndex = None,
+            dataType = None,
+            startPosition = 0,
+            standoffTagClassIri = "http://www.knora.org/ontology/standoff#StandoffRootTag"
+        ),
+        StandoffTagV2(
+            endParentIndex = None,
+            originalXMLID = None,
+            uuid = "1d250370-9692-497f-a28b-bd20ebafe171",
+            endPosition = 4,
+            startParentIndex = Some(0),
+            attributes = Vector(
+                StandoffTagStringAttributeV2(
+                    standoffPropertyIri = "http://www.knora.org/ontology/0113/lumieres-lausanne#standoffEditionTagHasTitle",
+                    value = "titre"
+                ),
+                StandoffTagStringAttributeV2(
+                    standoffPropertyIri = "http://www.knora.org/ontology/0113/lumieres-lausanne#standoffEditionTagHasFix",
+                    value = "correction"
+                )
+            ),
+            startIndex = 1,
+            endIndex = None,
+            dataType = None,
+            startPosition = 0,
+            standoffTagClassIri = "http://www.knora.org/ontology/0113/lumieres-lausanne#StandoffEditionTag"
+        )
+    )
+}


### PR DESCRIPTION
When verifying whether a value was saved correctly, we compare the saved value with the one that was supposed to be saved. Before we can compare standoff, we call `StandoffTagUtilV2.makeComparableStandoffCollection`, which normalises insignificant differences to make the standoff comparable. The bug in #1221 is that one of these insignificant differences is not taken into account: if the order of standoff tag attributes is different, the standoff incorrectly appears to be different.

Fixes #1221.