### PR TITLE
fix(api-v2): Make external ontology IRIs dereferenceable over https

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/Settings.scala
+++ b/webapi/src/main/scala/org/knora/webapi/Settings.scala
@@ -51,6 +51,14 @@ class SettingsImpl(config: Config) extends Extension {
     val externalKnoraApiHostPort: String = externalKnoraApiHost + (if (externalKnoraApiPort != 80) ":" + externalKnoraApiPort else "")
     val externalKnoraApiBaseUrl: String = externalKnoraApiProtocol + "://" + externalKnoraApiHost + (if (externalKnoraApiPort != 80) ":" + externalKnoraApiPort else "")
 
+    // If the external hostname is localhost, include the configured external port number in ontology IRIs for manual testing.
+    val externalOntologyIriHostAndPort: String = if (externalKnoraApiHost == "0.0.0.0" || externalKnoraApiHost == "localhost") {
+        externalKnoraApiHostPort
+    } else {
+        // Otherwise, don't include any port number in IRIs, so the IRIs will work both with http
+        // and with https.
+        externalKnoraApiHost
+    }
 
     val salsah1BaseUrl: String = config.getString("app.salsah1.base-url")
     val salsah1ProjectIconsBasePath: String = config.getString("app.salsah1.project-icons-basepath")

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -47,15 +47,15 @@ class OntologiesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData)
                     // This is the route used to dereference an actual ontology IRI. If the URL path looks like it
                     // belongs to a built-in API ontology (which has to contain "knora-api"), prefix it with
                     // http://api.knora.org to get the ontology IRI. Otherwise, if it looks like it belongs to a
-                    // project-specific API ontology, prefix it with settings.knoraApiHttpBaseUrl to get the ontology
-                    // IRI.
+                    // project-specific API ontology, prefix it with settings.externalOntologyIriHostAndPort to get the
+                    // ontology IRI.
 
                     val urlPath = requestContext.request.uri.path.toString
 
                     val requestedOntologyStr: IRI = if (stringFormatter.isBuiltInApiV2OntologyUrlPath(urlPath)) {
                         OntologyConstants.KnoraApi.ApiOntologyHostname + urlPath
                     } else if (stringFormatter.isProjectSpecificApiV2OntologyUrlPath(urlPath)) {
-                        settings.externalKnoraApiBaseUrl + urlPath
+                        "http://" + settings.externalOntologyIriHostAndPort + urlPath
                     } else {
                         throw BadRequestException(s"Invalid or unknown URL path for external ontology: $urlPath")
                     }
@@ -136,7 +136,7 @@ class OntologiesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData)
                     }
                 }
             }
-        } ~ path("v2" / "ontologies" / "metadata" / Segments) { (projectIris: List[IRI]) =>
+        } ~ path("v2" / "ontologies" / "metadata" / Segments) { projectIris: List[IRI] =>
             get {
                 requestContext => {
 

--- a/webapi/src/main/scala/org/knora/webapi/util/StringFormatter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/StringFormatter.scala
@@ -597,9 +597,11 @@ class StringFormatter private(val maybeSettings: Option[SettingsImpl], initForTe
     // The host and port number that this Knora server is running on, and that should be used
     // when constructing IRIs for project-specific ontologies.
     private val knoraApiHostAndPort: Option[String] = if (initForTest) {
+        // Use the default host and port for automated testing.
         Some("0.0.0.0:3333")
     } else {
-        maybeSettings.map(_.externalKnoraApiHostPort)
+        // Use the configured host and port.
+        maybeSettings.map(_.externalOntologyIriHostAndPort)
     }
 
     // The protocol and host that the ARK resolver is running on.


### PR DESCRIPTION
In external ontology IRIs, always use `http` instead of `https`, and don't include a port number, unless Knora's external API hostname is `localhost` or `0.0.0.0`.

@subotic I don't know how to test this.

Fixes #1261.