### PR TITLE
fix(sipi): Improve error checking of Sipi's knora.json response

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/store/sipimessages/SipiMessages.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/store/sipimessages/SipiMessages.scala
@@ -333,7 +333,15 @@ case class GetImageMetadataRequestV2(fileUrl: String,
 case class GetImageMetadataResponseV2(originalFilename: String,
                                       originalMimeType: String,
                                       width: Int,
-                                      height: Int)
+                                      height: Int) {
+    if (originalFilename.isEmpty) {
+        throw SipiException(s"Sipi returned an empty originalFilename")
+    }
+
+    if (originalMimeType.isEmpty) {
+        throw SipiException(s"Sipi returned an empty originalMimeType")
+    }
+}
 
 object GetImageMetadataResponseV2JsonProtocol extends SprayJsonSupport with DefaultJsonProtocol {
     implicit val getImageMetadataResponseV2Format: RootJsonFormat[GetImageMetadataResponseV2] = jsonFormat4(GetImageMetadataResponseV2)


### PR DESCRIPTION
This PR improves Knora's error checking if Sipi's `knora.json` route returns an empty filename or MIME type, as in #1268.

Resolves #1268.