### PR TITLE
test: Compare Knora response with its class definition

### DIFF
--- a/knora-ontologies/knora-admin.ttl
+++ b/knora-ontologies/knora-admin.ttl
@@ -255,7 +255,9 @@
 
 :givenName rdf:type owl:DatatypeProperty ;
 
-      rdfs:subPropertyOf foaf:givenName, :objectCannotBeMarkedAsDeleted .
+      rdfs:subPropertyOf foaf:givenName, :objectCannotBeMarkedAsDeleted ;
+
+      knora-base:objectDatatypeConstraint xsd:string .
 
 
 
@@ -263,7 +265,9 @@
 
 :familyName rdf:type owl:DatatypeProperty ;
 
-      rdfs:subPropertyOf foaf:familyName, :objectCannotBeMarkedAsDeleted .
+      rdfs:subPropertyOf foaf:familyName, :objectCannotBeMarkedAsDeleted ;
+
+      knora-base:objectDatatypeConstraint xsd:string .
 
 
 

--- a/webapi/src/it/scala/org/knora/webapi/e2e/v1/KnoraSipiIntegrationV1ITSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/e2e/v1/KnoraSipiIntegrationV1ITSpec.scala
@@ -27,14 +27,13 @@ import akka.http.scaladsl.model.{HttpEntity, _}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.knora.webapi._
 import org.knora.webapi.messages.store.triplestoremessages.{RdfDataObject, TriplestoreJsonProtocol}
-import org.knora.webapi.util.MutableTestIri
+import org.knora.webapi.util.{FileUtil, MutableTestIri}
 import org.xmlunit.builder.{DiffBuilder, Input}
 import org.xmlunit.diff.Diff
 import spray.json._
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
-import scala.io.Source
 import scala.xml._
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
@@ -87,7 +86,7 @@ class KnoraSipiIntegrationV1ITSpec extends ITKnoraLiveSpec(KnoraSipiIntegrationV
         val mappingXML: Elem = XML.loadString(mapping)
 
         // add the XSL transformation's Iri to the mapping XML (replacing the string 'toBeDefined')
-        val rule = new RewriteRule() {
+        val rule: RewriteRule = new RewriteRule() {
             override def transform(node: Node): Node = {
 
                 node match {
@@ -126,8 +125,7 @@ class KnoraSipiIntegrationV1ITSpec extends ITKnoraLiveSpec(KnoraSipiIntegrationV
                     case res: JsObject =>
                         res.fields.get("clientResourceID") match {
                             case Some(JsString(id)) if id == clientID => true
-
-                            case other => false
+                            case _ => false
                         }
                     case _ => false
                 }
@@ -230,7 +228,7 @@ class KnoraSipiIntegrationV1ITSpec extends ITKnoraLiveSpec(KnoraSipiIntegrationV
                             locdata.fields.get("path") match {
                                 case Some(JsString(path)) => path
                                 case None => throw InvalidApiJsonException("no 'path' given")
-                                case other => throw InvalidApiJsonException("'path' could not pe parsed correctly")
+                                case _ => throw InvalidApiJsonException("'path' could not pe parsed correctly")
                             }
                         case None => throw InvalidApiJsonException("no 'locdata' given")
 
@@ -509,14 +507,12 @@ class KnoraSipiIntegrationV1ITSpec extends ITKnoraLiveSpec(KnoraSipiIntegrationV
             // get the Iri of the XSL transformation
             val resId: String = responseJson.fields.get("res_id") match {
                 case Some(JsString(resid: String)) => resid
-                case other => throw InvalidApiJsonException("member 'res_id' was expected")
+                case _ => throw InvalidApiJsonException("member 'res_id' was expected")
             }
-
-            val mappingWithXSLT = new File(pathToMappingWithXSLT)
 
             // add a mapping referring to the XSLT as the default XSL transformation
 
-            val mapping = Source.fromFile(mappingWithXSLT).getLines.mkString
+            val mapping = FileUtil.readTextFile(new File(pathToMappingWithXSLT))
 
             val updatedMapping = addXSLTIriToMapping(mapping, resId)
 
@@ -551,7 +547,7 @@ class KnoraSipiIntegrationV1ITSpec extends ITKnoraLiveSpec(KnoraSipiIntegrationV
 
         "create a sample BEOL letter" in {
 
-            val mapping = Source.fromFile(pathToBEOLLetterMapping).getLines.mkString
+            val mapping = FileUtil.readTextFile(new File(pathToBEOLLetterMapping))
 
             val paramsForMapping =
                 s"""
@@ -578,11 +574,11 @@ class KnoraSipiIntegrationV1ITSpec extends ITKnoraLiveSpec(KnoraSipiIntegrationV
             // send mapping xml to route
             val knoraPostRequest = Post(baseApiUrl + "/v1/mapping", formDataMapping) ~> addCredentials(BasicHttpCredentials(username, password))
 
-            val mappingResponse: JsValue = getResponseJson(knoraPostRequest)
+            val _: JsValue = getResponseJson(knoraPostRequest)
 
             // create a letter via bulk import
 
-            val bulkXML = Source.fromFile(pathToBEOLBulkXML).getLines.mkString
+            val bulkXML = FileUtil.readTextFile(new File(pathToBEOLBulkXML))
 
             val bulkRequest = Post(baseApiUrl + "/v1/resources/xmlimport/" + URLEncoder.encode("http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF", "UTF-8"), HttpEntity(ContentType(MediaTypes.`application/xml`, HttpCharsets.`UTF-8`), bulkXML)) ~> addCredentials(BasicHttpCredentials(username, password))
 
@@ -627,14 +623,12 @@ class KnoraSipiIntegrationV1ITSpec extends ITKnoraLiveSpec(KnoraSipiIntegrationV
             // get the Iri of the XSL transformation
             val resId: String = bodyXSLTJson.fields.get("res_id") match {
                 case Some(JsString(resid: String)) => resid
-                case other => throw InvalidApiJsonException("member 'res_id' was expected")
+                case _ => throw InvalidApiJsonException("member 'res_id' was expected")
             }
-
-            val mappingWithXSLT = new File(pathToBEOLStandoffTEIMapping)
 
             // add a mapping referring to the XSLT as the default XSL transformation
 
-            val mapping = Source.fromFile(mappingWithXSLT).getLines.mkString
+            val mapping = FileUtil.readTextFile(new File(pathToBEOLStandoffTEIMapping))
 
             val updatedMapping = addXSLTIriToMapping(mapping, resId)
 
@@ -663,7 +657,7 @@ class KnoraSipiIntegrationV1ITSpec extends ITKnoraLiveSpec(KnoraSipiIntegrationV
             // send mapping xml to route
             val mappingRequest = Post(baseApiUrl + "/v1/mapping", formDataMapping) ~> addCredentials(BasicHttpCredentials(username, password))
 
-            val mappingJSON = getResponseJson(mappingRequest)
+            getResponseJson(mappingRequest)
 
             // create an XSL transformation
             val gravsearchTemplateParams = JsObject(
@@ -785,9 +779,17 @@ class KnoraSipiIntegrationV1ITSpec extends ITKnoraLiveSpec(KnoraSipiIntegrationV
                   |   </profileDesc>
                   |</teiHeader>
                   |
-                  |<text><body>                <p>[...] Viro Clarissimo.</p>                <p>Dn. Jacobo Hermanno S. S. M. C. </p>                <p>et Ph. M.</p>                <p>S. P. D. </p>                <p>J. J. Sch.</p>                <p>En quae desideras, vir Erud.<hi rend="sup">e</hi> κεχαρισμένω θυμῷ Actorum Lipsiensium fragmenta<note>Gemeint sind die im Brief Hermanns von 1703.06.05 erbetenen Exemplare AE Aprilis 1703 und AE Suppl., tom. III, 1702.</note> animi mei erga te prope[n]sissimi tenuia indicia. Dudum est, ex quo Tibi innotescere, et tuam ambire amicitiam decrevi, dudum, ex quo Ingenij Tui acumen suspexi, immo non potui quin admirarer pro eo, quod summam Demonstrationem Tuam de Iride communicare dignatus fueris summas ago grates; quamvis in hoc studij genere, non alias [siquid] μετρικώτατος, propter aliorum negotiorum continuam seriem non altos possim scandere gradus. Perge Vir Clariss. Erudito orbi propalare Ingenij Tui fructum; sed et me amare. </p>                <p>d. [10] Jun. 1703.<note>Der Tag ist im Manuskript unleserlich. Da der Entwurf in Scheuchzers "Copiae epistolarum" zwischen zwei Einträgen vom 10. Juni 1703 steht, ist der Brief wohl auf den gleichen Tag zu datieren.</note>                </p>            </body></text>
+                  |<text><body>
+                  |                <p>[...] Viro Clarissimo.</p>
+                  |                <p>Dn. Jacobo Hermanno S. S. M. C. </p>
+                  |                <p>et Ph. M.</p>
+                  |                <p>S. P. D. </p>
+                  |                <p>J. J. Sch.</p>
+                  |                <p>En quae desideras, vir Erud.<hi rend="sup">e</hi> κεχαρισμένω θυμῷ Actorum Lipsiensium fragmenta<note>Gemeint sind die im Brief Hermanns von 1703.06.05 erbetenen Exemplare AE Aprilis 1703 und AE Suppl., tom. III, 1702.</note> animi mei erga te prope[n]sissimi tenuia indicia. Dudum est, ex quo Tibi innotescere, et tuam ambire amicitiam decrevi, dudum, ex quo Ingenij Tui acumen suspexi, immo non potui quin admirarer pro eo, quod summam Demonstrationem Tuam de Iride communicare dignatus fueris summas ago grates; quamvis in hoc studij genere, non alias [siquid] μετρικώτατος, propter aliorum negotiorum continuam seriem non altos possim scandere gradus. Perge Vir Clariss. Erudito orbi propalare Ingenij Tui fructum; sed et me amare. </p>
+                  |                <p>d. [10] Jun. 1703.<note>Der Tag ist im Manuskript unleserlich. Da der Entwurf in Scheuchzers "Copiae epistolarum" zwischen zwei Einträgen vom 10. Juni 1703 steht, ist der Brief wohl auf den gleichen Tag zu datieren.</note>
+                  |                </p>
+                  |            </body></text>
                   |</TEI>
-                  |
                 """.stripMargin
 
             val xmlDiff: Diff = DiffBuilder.compare(Input.fromString(letterResponseBodyXML)).withTest(Input.fromString(xmlExpected)).build()

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -980,7 +980,7 @@ object OntologyConstants {
 
         val File: IRI = KnoraApiV2PrefixExpansion + "File"
 
-        val CustomDatatypes: Set[IRI] = Set(
+        val KnoraDatatypes: Set[IRI] = Set(
             Date,
             Geom,
             Color,

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -970,9 +970,15 @@ object OntologyConstants {
 
         val File: IRI = KnoraApiV2PrefixExpansion + "File"
 
-        val HasStandoffLinkTo: IRI = KnoraApiV2PrefixExpansion + "hasStandoffLinkTo"
-        val CreationDate: IRI = KnoraApiV2PrefixExpansion + "creationDate"
-        val LastModificationDate: IRI = KnoraApiV2PrefixExpansion + "lastModificationDate"
+        val CustomDatatypes: Set[IRI] = Set(
+            Date,
+            Geom,
+            Color,
+            Interval,
+            Geoname,
+            File
+        )
+
         val ArkUrl: IRI = KnoraApiV2PrefixExpansion + "arkUrl"
         val VersionArkUrl: IRI = KnoraApiV2PrefixExpansion + "versionArkUrl"
     }

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -747,6 +747,16 @@ object OntologyConstants {
         val DateBase: IRI = KnoraApiV2PrefixExpansion + "DateBase"
         val DecimalBase: IRI = KnoraApiV2PrefixExpansion + "DecimalBase"
 
+        val ValueBaseClasses: Set[IRI] = Set(
+            IntBase,
+            BooleanBase,
+            UriBase,
+            IntervalBase,
+            ColorBase,
+            DateBase,
+            DecimalBase
+        )
+
         val Value: IRI = KnoraApiV2PrefixExpansion + "Value"
         val TextValue: IRI = KnoraApiV2PrefixExpansion + "TextValue"
         val IntValue: IRI = KnoraApiV2PrefixExpansion + "IntValue"

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -682,6 +682,7 @@ object OntologyConstants {
         val KnoraApiV2PrefixExpansion: IRI = KnoraApiOntologyIri + "#"
 
         val Result: IRI = KnoraApiV2PrefixExpansion + "result"
+        val Error: IRI = KnoraApiV2PrefixExpansion + "error"
 
         val IsShared: IRI = KnoraApiV2PrefixExpansion + "isShared"
         val IsBuiltIn: IRI = KnoraApiV2PrefixExpansion + "isBuiltIn"
@@ -737,6 +738,14 @@ object OntologyConstants {
         val XMLToStandoffMapping: IRI = KnoraApiV2PrefixExpansion + "XMLToStandoffMapping"
         val ListNode: IRI = KnoraApiV2PrefixExpansion + "ListNode"
         val LinkObj: IRI = KnoraApiV2PrefixExpansion + "LinkObj"
+
+        val IntBase: IRI = KnoraApiV2PrefixExpansion + "IntBase"
+        val BooleanBase: IRI = KnoraApiV2PrefixExpansion + "BooleanBase"
+        val UriBase: IRI = KnoraApiV2PrefixExpansion + "UriBase"
+        val IntervalBase: IRI = KnoraApiV2PrefixExpansion + "IntervalBase"
+        val ColorBase: IRI = KnoraApiV2PrefixExpansion + "ColorBase"
+        val DateBase: IRI = KnoraApiV2PrefixExpansion + "DateBase"
+        val DecimalBase: IRI = KnoraApiV2PrefixExpansion + "DecimalBase"
 
         val Value: IRI = KnoraApiV2PrefixExpansion + "Value"
         val TextValue: IRI = KnoraApiV2PrefixExpansion + "TextValue"
@@ -1009,10 +1018,13 @@ object OntologyConstants {
             KnoraBase.SubjectClassConstraint -> KnoraApiV2WithValueObjects.SubjectType,
             KnoraBase.ObjectClassConstraint -> KnoraApiV2WithValueObjects.ObjectType,
             KnoraBase.ObjectDatatypeConstraint -> KnoraApiV2WithValueObjects.ObjectType,
+            KnoraBase.ValueHasString -> KnoraApiV2WithValueObjects.ValueAsString,
             KnoraBase.ValueHasUri -> KnoraApiV2WithValueObjects.UriValueAsUri,
             KnoraBase.ValueHasInteger -> KnoraApiV2WithValueObjects.IntValueAsInt,
+            KnoraBase.ValueHasDecimal -> KnoraApiV2WithValueObjects.DecimalValueAsDecimal,
             KnoraBase.ValueHasBoolean -> KnoraApiV2WithValueObjects.BooleanValueAsBoolean,
-            KnoraBase.ValueHasString -> KnoraApiV2WithValueObjects.ValueAsString,
+            KnoraBase.ValueHasIntervalStart -> KnoraApiV2WithValueObjects.IntervalValueHasStart,
+            KnoraBase.ValueHasIntervalEnd -> KnoraApiV2WithValueObjects.IntervalValueHasEnd,
             KnoraBase.ValueHasLanguage -> KnoraApiV2WithValueObjects.TextValueHasLanguage,
             KnoraBase.ValueHasListNode -> KnoraApiV2WithValueObjects.ListValueAsListNode,
             KnoraBase.ValueHasGeonameCode -> KnoraApiV2WithValueObjects.GeonameValueAsGeonameCode,
@@ -1047,6 +1059,8 @@ object OntologyConstants {
             KnoraApiV2WithValueObjects.IntValueAsInt -> KnoraBase.ValueHasInteger,
             KnoraApiV2WithValueObjects.DecimalValueAsDecimal -> KnoraBase.ValueHasDecimal,
             KnoraApiV2WithValueObjects.BooleanValueAsBoolean -> KnoraBase.ValueHasBoolean,
+            KnoraApiV2WithValueObjects.IntervalValueHasStart -> KnoraBase.ValueHasIntervalStart,
+            KnoraApiV2WithValueObjects.IntervalValueHasEnd -> KnoraBase.ValueHasIntervalEnd,
             KnoraApiV2WithValueObjects.ValueAsString -> KnoraBase.ValueHasString,
             KnoraApiV2WithValueObjects.TextValueHasLanguage -> KnoraBase.ValueHasLanguage,
             KnoraApiV2WithValueObjects.ListValueAsListNode -> KnoraBase.ValueHasListNode,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2SimpleTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2SimpleTransformationRules.scala
@@ -351,6 +351,8 @@ object KnoraApiV2SimpleTransformationRules extends KnoraBaseTransformationRules 
       * Properties to remove from `knora-base` before converting it to the [[ApiV2Simple]] schema.
       */
     override val knoraBasePropertiesToRemove: Set[SmartIri] = Set(
+        OntologyConstants.KnoraBase.CreationDate,
+        OntologyConstants.KnoraBase.LastModificationDate,
         OntologyConstants.KnoraBase.IsEditable,
         OntologyConstants.KnoraBase.CanBeInstantiated,
         OntologyConstants.KnoraBase.HasPermissions,
@@ -364,6 +366,7 @@ object KnoraApiV2SimpleTransformationRules extends KnoraBaseTransformationRules 
         OntologyConstants.KnoraBase.ObjectDatatypeConstraint,
         OntologyConstants.KnoraBase.ObjectClassConstraint,
         OntologyConstants.KnoraBase.SubjectClassConstraint,
+        OntologyConstants.KnoraBase.HasStandoffLinkTo,
         OntologyConstants.KnoraBase.StandoffParentClassConstraint,
         OntologyConstants.KnoraBase.ValueHasLanguage,
         OntologyConstants.KnoraBase.ValueHasStandoff,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2SimpleTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2SimpleTransformationRules.scala
@@ -366,7 +366,6 @@ object KnoraApiV2SimpleTransformationRules extends KnoraBaseTransformationRules 
         OntologyConstants.KnoraBase.ObjectDatatypeConstraint,
         OntologyConstants.KnoraBase.ObjectClassConstraint,
         OntologyConstants.KnoraBase.SubjectClassConstraint,
-        OntologyConstants.KnoraBase.HasStandoffLinkTo,
         OntologyConstants.KnoraBase.StandoffParentClassConstraint,
         OntologyConstants.KnoraBase.ValueHasLanguage,
         OntologyConstants.KnoraBase.ValueHasStandoff,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2WithValueObjectsTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2WithValueObjectsTransformationRules.scala
@@ -60,6 +60,26 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         objectType = Some(OntologyConstants.Xsd.String)
     )
 
+    private val Error: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.Error,
+        propertyType = OntologyConstants.Owl.DatatypeProperty,
+        predicates = Seq(
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Label,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "error"
+                )
+            ),
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Comment,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "Provides an error message"
+                )
+            )
+        ),
+        objectType = Some(OntologyConstants.Xsd.String)
+    )
+
     private val UserHasPermission: ReadPropertyInfoV2 = makeProperty(
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.UserHasPermission,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
@@ -598,7 +618,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.DateValueHasStartYear,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateBase),
         objectType = Some(OntologyConstants.Xsd.Integer),
         predicates = Seq(
             makePredicate(
@@ -620,7 +640,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.DateValueHasEndYear,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateBase),
         objectType = Some(OntologyConstants.Xsd.Integer),
         predicates = Seq(
             makePredicate(
@@ -642,7 +662,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.DateValueHasStartMonth,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateBase),
         objectType = Some(OntologyConstants.Xsd.Integer),
         predicates = Seq(
             makePredicate(
@@ -664,7 +684,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.DateValueHasEndMonth,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateBase),
         objectType = Some(OntologyConstants.Xsd.Integer),
         predicates = Seq(
             makePredicate(
@@ -686,7 +706,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.DateValueHasStartDay,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateBase),
         objectType = Some(OntologyConstants.Xsd.Integer),
         predicates = Seq(
             makePredicate(
@@ -708,7 +728,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.DateValueHasEndDay,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateBase),
         objectType = Some(OntologyConstants.Xsd.Integer),
         predicates = Seq(
             makePredicate(
@@ -730,7 +750,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.DateValueHasStartEra,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateBase),
         objectType = Some(OntologyConstants.Xsd.String),
         predicates = Seq(
             makePredicate(
@@ -752,7 +772,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.DateValueHasEndEra,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateBase),
         objectType = Some(OntologyConstants.Xsd.String),
         predicates = Seq(
             makePredicate(
@@ -774,7 +794,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.DateValueHasCalendar,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DateBase),
         objectType = Some(OntologyConstants.Xsd.String),
         predicates = Seq(
             makePredicate(
@@ -840,7 +860,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.IntValueAsInt,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.IntValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.IntBase),
         objectType = Some(OntologyConstants.Xsd.Integer),
         predicates = Seq(
             makePredicate(
@@ -862,7 +882,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.DecimalValueAsDecimal,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DecimalValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.DecimalBase),
         objectType = Some(OntologyConstants.Xsd.Decimal),
         predicates = Seq(
             makePredicate(
@@ -880,11 +900,55 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         )
     )
 
+    private val IntervalValueHasStart: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.IntervalValueHasStart,
+        propertyType = OntologyConstants.Owl.DatatypeProperty,
+        subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.IntervalBase),
+        objectType = Some(OntologyConstants.Xsd.Decimal),
+        predicates = Seq(
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Label,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "interval value has start"
+                )
+            ),
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Comment,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "Represents the start position of an interval."
+                )
+            )
+        )
+    )
+
+    private val IntervalValueHasEnd: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.IntervalValueHasEnd,
+        propertyType = OntologyConstants.Owl.DatatypeProperty,
+        subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.IntervalBase),
+        objectType = Some(OntologyConstants.Xsd.Decimal),
+        predicates = Seq(
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Label,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "interval value has end"
+                )
+            ),
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Comment,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "Represents the end position of an interval."
+                )
+            )
+        )
+    )
+
     private val BooleanValueAsBoolean: ReadPropertyInfoV2 = makeProperty(
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.BooleanValueAsBoolean,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.BooleanBase),
         objectType = Some(OntologyConstants.Xsd.Boolean),
         predicates = Seq(
             makePredicate(
@@ -972,7 +1036,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.ColorValueAsColor,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.ColorValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.ColorBase),
         objectType = Some(OntologyConstants.Xsd.String),
         predicates = Seq(
             makePredicate(
@@ -994,7 +1058,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.UriValueAsUri,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
         subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.UriValue),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.UriBase),
         objectType = Some(OntologyConstants.Xsd.Uri),
         predicates = Seq(
             makePredicate(
@@ -1281,7 +1345,8 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         OntologyConstants.KnoraApiV2WithValueObjects.ArkUrl -> Cardinality.MustHaveOne,
         OntologyConstants.KnoraApiV2WithValueObjects.VersionArkUrl -> Cardinality.MustHaveOne,
         OntologyConstants.KnoraApiV2WithValueObjects.VersionDate -> Cardinality.MayHaveOne,
-        OntologyConstants.KnoraApiV2WithValueObjects.UserHasPermission -> Cardinality.MustHaveOne
+        OntologyConstants.KnoraApiV2WithValueObjects.UserHasPermission -> Cardinality.MustHaveOne,
+        OntologyConstants.KnoraApiV2WithValueObjects.IsDeleted -> Cardinality.MayHaveOne
     )
 
     private val DateBaseCardinalities = Map(
@@ -1323,7 +1388,8 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
 
     private val ValueCardinalities = Map(
         OntologyConstants.KnoraApiV2WithValueObjects.ValueAsString -> Cardinality.MayHaveOne,
-        OntologyConstants.KnoraApiV2WithValueObjects.UserHasPermission -> Cardinality.MustHaveOne
+        OntologyConstants.KnoraApiV2WithValueObjects.UserHasPermission -> Cardinality.MustHaveOne,
+        OntologyConstants.KnoraApiV2WithValueObjects.IsDeleted -> Cardinality.MayHaveOne
     )
 
     private val TextValueCardinalities = Map(
@@ -1430,11 +1496,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         OntologyConstants.KnoraBase.HasExtResValue,
         OntologyConstants.KnoraBase.ExtResAccessInfo,
         OntologyConstants.KnoraBase.ExtResId,
-        OntologyConstants.KnoraBase.ExtResProvider,
-        OntologyConstants.KnoraBase.MapEntryKey,
-        OntologyConstants.KnoraBase.MapEntryValue,
-        OntologyConstants.KnoraBase.IsInMap
-
+        OntologyConstants.KnoraBase.ExtResProvider
     ).map(_.toSmartIri)
 
     /**
@@ -1447,9 +1509,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         OntologyConstants.KnoraBase.MappingXMLAttribute,
         OntologyConstants.KnoraBase.XMLToStandoffMapping,
         OntologyConstants.KnoraBase.ExternalResource,
-        OntologyConstants.KnoraBase.ExternalResValue,
-        OntologyConstants.KnoraBase.Map,
-        OntologyConstants.KnoraBase.MapEntry
+        OntologyConstants.KnoraBase.ExternalResValue
     ).map(_.toSmartIri)
 
     /**
@@ -1492,6 +1552,7 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
       */
     override val knoraApiPropertiesToAdd: Map[SmartIri, ReadPropertyInfoV2] = Set(
         Result,
+        Error,
         UserHasPermission,
         VersionDate,
         ArkUrl,
@@ -1527,6 +1588,8 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         DateValueHasStartEra,
         DateValueHasEndEra,
         DateValueHasCalendar,
+        IntervalValueHasStart,
+        IntervalValueHasEnd,
         LinkValueHasTarget,
         LinkValueHasTargetIri,
         IntValueAsInt,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2WithValueObjectsTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraApiV2WithValueObjectsTransformationRules.scala
@@ -812,6 +812,50 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         )
     )
 
+    private val LinkValueHasSource: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.LinkValueHasSource,
+        propertyType = OntologyConstants.Owl.ObjectProperty,
+        subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.LinkValue),
+        objectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.Resource),
+        predicates = Seq(
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Label,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "Link value has source"
+                )
+            ),
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Comment,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "Represents the source resource of a link value."
+                )
+            )
+        )
+    )
+
+    private val LinkValueHasSourceIri: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.LinkValueHasSourceIri,
+        propertyType = OntologyConstants.Owl.DatatypeProperty,
+        subPropertyOf = Set(OntologyConstants.KnoraApiV2WithValueObjects.ValueHas),
+        subjectType = Some(OntologyConstants.KnoraApiV2WithValueObjects.LinkValue),
+        objectType = Some(OntologyConstants.Xsd.Uri),
+        predicates = Seq(
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Label,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "Link value has source IRI"
+                )
+            ),
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Comment,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "Represents the IRI of the source resource of a link value."
+                )
+            )
+        )
+    )
+
     private val LinkValueHasTarget: ReadPropertyInfoV2 = makeProperty(
         propertyIri = OntologyConstants.KnoraApiV2WithValueObjects.LinkValueHasTarget,
         propertyType = OntologyConstants.Owl.ObjectProperty,
@@ -1400,6 +1444,13 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         OntologyConstants.KnoraApiV2WithValueObjects.TextValueHasMapping -> Cardinality.MayHaveOne
     )
 
+    private val LinkValueCardinalities = Map(
+        OntologyConstants.KnoraApiV2WithValueObjects.LinkValueHasSource -> Cardinality.MayHaveOne,
+        OntologyConstants.KnoraApiV2WithValueObjects.LinkValueHasTarget -> Cardinality.MayHaveOne,
+        OntologyConstants.KnoraApiV2WithValueObjects.LinkValueHasSourceIri -> Cardinality.MayHaveOne,
+        OntologyConstants.KnoraApiV2WithValueObjects.LinkValueHasTargetIri -> Cardinality.MayHaveOne
+    )
+
     private val GeomValueCardinalities = Map(
         OntologyConstants.KnoraApiV2WithValueObjects.GeometryValueAsGeometry -> Cardinality.MustHaveOne
     )
@@ -1440,6 +1491,9 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
       * Properties to remove from `knora-base` before converting it to the [[ApiV2WithValueObjects]] schema.
       */
     override val knoraBasePropertiesToRemove: Set[SmartIri] = Set(
+        OntologyConstants.Rdf.Subject,
+        OntologyConstants.Rdf.Predicate,
+        OntologyConstants.Rdf.Object,
         OntologyConstants.KnoraBase.ObjectCannotBeMarkedAsDeleted,
         OntologyConstants.KnoraBase.ObjectDatatypeConstraint,
         OntologyConstants.KnoraBase.ObjectClassConstraint,
@@ -1517,28 +1571,29 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
       * added to the specified classes to obtain `knora-api`.
       */
     override val knoraApiCardinalitiesToAdd: Map[SmartIri, Map[SmartIri, KnoraCardinalityInfo]] = Map(
-        OntologyConstants.KnoraBase.Resource -> ResourceCardinalities,
-        OntologyConstants.KnoraBase.DateBase -> DateBaseCardinalities,
-        OntologyConstants.KnoraBase.UriBase -> UriBaseCardinalities,
-        OntologyConstants.KnoraBase.BooleanBase -> BooleanBaseCardinalities,
-        OntologyConstants.KnoraBase.IntBase -> IntBaseCardinalities,
-        OntologyConstants.KnoraBase.DecimalBase -> DecimalBaseCardinalities,
-        OntologyConstants.KnoraBase.IntervalBase -> IntervalBaseCardinalities,
-        OntologyConstants.KnoraBase.ColorBase -> ColorBaseCardinalities,
-        OntologyConstants.KnoraBase.Value -> ValueCardinalities,
-        OntologyConstants.KnoraBase.TextValue -> TextValueCardinalities,
-        OntologyConstants.KnoraBase.GeomValue -> GeomValueCardinalities,
-        OntologyConstants.KnoraBase.ListValue -> ListValueCardinalities,
-        OntologyConstants.KnoraBase.GeonameValue -> GeonameValueCardinalities,
-        OntologyConstants.KnoraBase.FileValue -> FileValueCardinalities,
-        OntologyConstants.KnoraBase.StillImageFileValue -> StillImageFileValueCardinalities,
-        OntologyConstants.KnoraBase.MovingImageFileValue -> MovingImageFileValueCardinalities,
-        OntologyConstants.KnoraBase.AudioFileValue -> AudioFileValueCardinalities
+        OntologyConstants.KnoraApiV2WithValueObjects.Resource -> ResourceCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.DateBase -> DateBaseCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.UriBase -> UriBaseCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.BooleanBase -> BooleanBaseCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.IntBase -> IntBaseCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.DecimalBase -> DecimalBaseCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.IntervalBase -> IntervalBaseCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.ColorBase -> ColorBaseCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.Value -> ValueCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.TextValue -> TextValueCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.LinkValue -> LinkValueCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.GeomValue -> GeomValueCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.ListValue -> ListValueCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.GeonameValue -> GeonameValueCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.FileValue -> FileValueCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.StillImageFileValue -> StillImageFileValueCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.MovingImageFileValue -> MovingImageFileValueCardinalities,
+        OntologyConstants.KnoraApiV2WithValueObjects.AudioFileValue -> AudioFileValueCardinalities
     ).map {
         case (classIri, cardinalities) =>
-            classIri.toSmartIri.toOntologySchema(ApiV2WithValueObjects) -> cardinalities.map {
+            classIri.toSmartIri -> cardinalities.map {
                 case (propertyIri, cardinality) =>
-                    propertyIri.toSmartIri.toOntologySchema(ApiV2WithValueObjects) -> Cardinality.KnoraCardinalityInfo(cardinality)
+                    propertyIri.toSmartIri -> Cardinality.KnoraCardinalityInfo(cardinality)
             }
     }
 
@@ -1590,6 +1645,8 @@ object KnoraApiV2WithValueObjectsTransformationRules extends KnoraBaseTransforma
         DateValueHasCalendar,
         IntervalValueHasStart,
         IntervalValueHasEnd,
+        LinkValueHasSource,
+        LinkValueHasSourceIri,
         LinkValueHasTarget,
         LinkValueHasTargetIri,
         IntValueAsInt,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
@@ -1919,6 +1919,12 @@ object EntityInfoContentV2 {
                             objects = Seq(stringToLiteral(objStr))
                         )
 
+                    case JsonLDBoolean(objBoolean) =>
+                        PredicateInfoV2(
+                            predicateIri = predicateIri,
+                            objects = Seq(BooleanLiteralV2(objBoolean))
+                        )
+
                     case objObj: JsonLDObject =>
                         if (objObj.isIri) {
                             // This is a JSON-LD IRI value.

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
@@ -23,7 +23,7 @@ package org.knora.webapi.messages.v2.responder.ontologymessages
 import java.time.Instant
 import java.util.UUID
 
-import akka.actor.{ActorRef}
+import akka.actor.ActorRef
 import akka.event.LoggingAdapter
 import akka.util.Timeout
 import org.apache.commons.lang3.builder.HashCodeBuilder
@@ -1300,6 +1300,27 @@ case class InputOntologyV2(ontologyMetadata: OntologyMetadataV2,
     }
 }
 
+/**
+  * Represents a parsing mode used by [[InputOntologyV2]].
+  */
+sealed trait InputOntologyParsingModeV2
+
+/**
+  * A parsing mode that ignores predicates that are present in Knora responses and absent in client input.
+  * In tests, this allows a Knora response containing an entity to be parsed and compared with the client input
+  * that was used to create the entity.
+  */
+case object TestResponseParsingModeV2 extends InputOntologyParsingModeV2
+
+/**
+  * A parsing mode that rejects data not allowed in client input.
+  */
+case object ClientInputParsingModeV2 extends InputOntologyParsingModeV2
+
+/**
+  * A parsing mode for parsing everything returned in a Knora ontology response.
+  */
+case object KnoraOutputParsingModeV2 extends InputOntologyParsingModeV2
 
 /**
   * Processes JSON-LD received either from the client or from the API server. This is intended to support
@@ -1312,12 +1333,11 @@ object InputOntologyV2 {
     /**
       * Constructs an [[InputOntologyV2]] based on a JSON-LD document.
       *
-      * @param jsonLDDocument  a JSON-LD document representing information about the ontology.
-      * @param ignoreExtraData if `true`, extra data in the JSON-LD will be ignored. This is used only in testing.
-      *                        Otherwise, extra data will cause an exception to be thrown.
+      * @param jsonLDDocument a JSON-LD document representing information about the ontology.
+      * @param parsingMode    the parsing mode to be used.
       * @return an [[InputOntologyV2]] representing the same information.
       */
-    def fromJsonLD(jsonLDDocument: JsonLDDocument, ignoreExtraData: Boolean = false): InputOntologyV2 = {
+    def fromJsonLD(jsonLDDocument: JsonLDDocument, parsingMode: InputOntologyParsingModeV2 = ClientInputParsingModeV2): InputOntologyV2 = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
         val ontologyObj = jsonLDDocument.body
@@ -1357,13 +1377,13 @@ object InputOntologyV2 {
 
                 val classes: Map[SmartIri, ClassInfoContentV2] = entitiesWithTypes.collect {
                     case (jsonLDObj, entityType) if OntologyConstants.ClassTypes.contains(entityType.toString) =>
-                        val classInfoContent = ClassInfoContentV2.fromJsonLDObject(jsonLDObj, ignoreExtraData)
+                        val classInfoContent = ClassInfoContentV2.fromJsonLDObject(jsonLDObj, parsingMode)
                         classInfoContent.classIri -> classInfoContent
                 }.toMap
 
                 val properties: Map[SmartIri, PropertyInfoContentV2] = entitiesWithTypes.collect {
                     case (jsonLDObj, entityType) if OntologyConstants.PropertyTypes.contains(entityType.toString) =>
-                        val propertyInfoContent = PropertyInfoContentV2.fromJsonLDObject(jsonLDObj, ignoreExtraData)
+                        val propertyInfoContent = PropertyInfoContentV2.fromJsonLDObject(jsonLDObj, parsingMode)
                         propertyInfoContent.propertyIri -> propertyInfoContent
                 }.toMap
 
@@ -1812,7 +1832,30 @@ sealed trait EntityInfoContentV2 {
     }
 
     /**
-      * Returns the first object specified as a string without a language tag for the given predicate.
+      * Returns the first object specified as a boolean value for the given predicate, or `false` if the
+      * entity doesn't have that predicate.
+      *
+      * @param predicateIri the IRI of the predicate.
+      * @return the predicate's object, if given, otherwise `false`.
+      */
+    def getPredicateBooleanObject(predicateIri: SmartIri): Boolean = {
+        val values: Seq[Boolean] = predicates.get(predicateIri) match {
+            case Some(predicateInfo) => predicateInfo.objects.collect {
+                case BooleanLiteralV2(value) => value
+            }
+
+            case None => Seq.empty[Boolean]
+        }
+
+        if (values.nonEmpty) {
+            values.head
+        } else {
+            false
+        }
+    }
+
+    /**
+      * Returns the first object specified as an IRI for the given predicate.
       *
       * @param predicateIri the IRI of the predicate.
       * @return the predicate's object, if given.
@@ -2497,8 +2540,8 @@ case class ClassInfoContentV2(classIri: SmartIri,
   */
 object ClassInfoContentV2 {
 
-    // The predicates that are allowed in a class definition that is read from JSON-LD.
-    private val AllowedJsonLDClassPredicates = Set(
+    // The predicates that are allowed in a class definition that is read from JSON-LD representing client input.
+    private val AllowedJsonLDClassPredicatesInClientInput = Set(
         JsonLDConstants.ID,
         JsonLDConstants.TYPE,
         OntologyConstants.Rdfs.SubClassOf,
@@ -2506,8 +2549,8 @@ object ClassInfoContentV2 {
         OntologyConstants.Rdfs.Comment
     )
 
-    // The predicates that are allowed in an owl:Restriction that is read from JSON-LD.
-    private val AllowedJsonLDRestrictionPredicates = Set(
+    // The predicates that are allowed in an owl:Restriction that is read from JSON-LD representing client input.
+    private val AllowedJsonLDRestrictionPredicatesInClientInput = Set(
         JsonLDConstants.TYPE,
         OntologyConstants.Owl.Cardinality,
         OntologyConstants.Owl.MinCardinality,
@@ -2519,12 +2562,11 @@ object ClassInfoContentV2 {
     /**
       * Converts a JSON-LD class definition into a [[ClassInfoContentV2]].
       *
-      * @param jsonLDClassDef  a JSON-LD object representing a class definition.
-      * @param ignoreExtraData if `true`, extra data in the class definition will be ignored. This is used only in testing.
-      *                        Otherwise, extra data will cause an exception to be thrown.
+      * @param jsonLDClassDef a JSON-LD object representing a class definition.
+      * @param parsingMode    the parsing mode to be used.
       * @return a [[ClassInfoContentV2]] representing the class definition.
       */
-    def fromJsonLDObject(jsonLDClassDef: JsonLDObject, ignoreExtraData: Boolean): ClassInfoContentV2 = {
+    def fromJsonLDObject(jsonLDClassDef: JsonLDObject, parsingMode: InputOntologyParsingModeV2): ClassInfoContentV2 = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
         val classIri: SmartIri = jsonLDClassDef.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.toSmartIriWithErr)
@@ -2532,15 +2574,26 @@ object ClassInfoContentV2 {
 
         // TODO: handle custom datatypes.
 
-        if (!ignoreExtraData) {
-            val extraClassPredicates = jsonLDClassDef.value.keySet -- AllowedJsonLDClassPredicates
+        // Parse differently depending on parsing mode.
+        val filteredClassDef: JsonLDObject = parsingMode match {
+            case ClientInputParsingModeV2 =>
+                // In client input mode, only certain predicates are allowed.
+                val extraClassPredicates = jsonLDClassDef.value.keySet -- AllowedJsonLDClassPredicatesInClientInput
 
-            if (extraClassPredicates.nonEmpty) {
-                throw BadRequestException(s"The definition of $classIri contains one or more invalid predicates: ${extraClassPredicates.mkString(", ")}")
-            }
+                if (extraClassPredicates.nonEmpty) {
+                    throw BadRequestException(s"The definition of $classIri contains one or more invalid predicates: ${extraClassPredicates.mkString(", ")}")
+                } else {
+                    jsonLDClassDef
+                }
+
+            case TestResponseParsingModeV2 =>
+                // In test response mode, we ignore predicates that wouldn't be allowed as client input.
+                JsonLDObject(jsonLDClassDef.value.filterKeys(AllowedJsonLDClassPredicatesInClientInput))
+
+            case KnoraOutputParsingModeV2 =>
+                // In Knora output parsing mode, we accept all predicates.
+                jsonLDClassDef
         }
-
-        val filteredClassDef = JsonLDObject(jsonLDClassDef.value.filterKeys(AllowedJsonLDClassPredicates))
 
         val (subClassOf: Set[SmartIri], directCardinalities: Map[SmartIri, KnoraCardinalityInfo]) = filteredClassDef.maybeArray(OntologyConstants.Rdfs.SubClassOf) match {
             case Some(valueArray: JsonLDArray) =>
@@ -2561,20 +2614,25 @@ object ClassInfoContentV2 {
                     jsonLDObj => !jsonLDObj.isIri
                 }
 
-                val directCardinalities: Map[SmartIri, KnoraCardinalityInfo] = restrictions.foldLeft(Map.empty[SmartIri, KnoraCardinalityInfo]) {
+                val cardinalities: Map[SmartIri, KnoraCardinalityInfo] = restrictions.foldLeft(Map.empty[SmartIri, KnoraCardinalityInfo]) {
                     case (acc, restriction) =>
-                        if (restriction.value.get(OntologyConstants.KnoraApiV2WithValueObjects.IsInherited).contains(JsonLDBoolean(true))) {
-                            // If ignoreExtraData is true and we encounter knora-api:isInherited in a cardinality, ignore the whole cardinality.
-                            if (ignoreExtraData) {
-                                acc
-                            } else {
-                                throw BadRequestException("Inherited cardinalities are not allowed in this request")
-                            }
-                        } else {
-                            val extraRestrictionPredicates = restriction.value.keySet -- AllowedJsonLDRestrictionPredicates
+                        val isInherited = restriction.value.get(OntologyConstants.KnoraApiV2WithValueObjects.IsInherited).contains(JsonLDBoolean(true))
 
-                            if (!ignoreExtraData && extraRestrictionPredicates.nonEmpty) {
-                                throw BadRequestException(s"A cardinality in the definition of $classIri contains one or more invalid predicates: ${extraRestrictionPredicates.mkString(", ")}")
+                        // If we're in client input mode and the client tries to submit an inherited cardinality, return
+                        // a helpful error message.
+                        if (isInherited && parsingMode == ClientInputParsingModeV2) {
+                            throw BadRequestException("Inherited cardinalities are not allowed in this request")
+                        } else if (isInherited && parsingMode == TestResponseParsingModeV2) {
+                            // In test response parsing mode, ignore inherited cardinalities.
+                            acc
+                        } else {
+                            // In client input mode, only certain predicates are allowed on owl:Restriction nodes.
+                            if (parsingMode == ClientInputParsingModeV2) {
+                                val extraRestrictionPredicates = restriction.value.keySet -- AllowedJsonLDRestrictionPredicatesInClientInput
+
+                                if (extraRestrictionPredicates.nonEmpty) {
+                                    throw BadRequestException(s"A cardinality in the definition of $classIri contains one or more invalid predicates: ${extraRestrictionPredicates.mkString(", ")}")
+                                }
                             }
 
                             val cardinalityType = restriction.requireStringWithValidation(JsonLDConstants.TYPE, stringFormatter.toSmartIriWithErr)
@@ -2607,14 +2665,16 @@ object ClassInfoContentV2 {
                                 guiOrder = guiOrder
                             )
 
-                            acc + (onProperty -> Cardinality.owlCardinality2KnoraCardinality(
+                            val knoraCardinalityInfo = Cardinality.owlCardinality2KnoraCardinality(
                                 propertyIri = onProperty.toString,
                                 owlCardinality = owlCardinalityInfo
-                            ))
+                            )
+
+                            acc + (onProperty -> knoraCardinalityInfo)
                         }
                 }
 
-                (baseClasses, directCardinalities)
+                (baseClasses, cardinalities)
 
             case None => (Set.empty[SmartIri], Map.empty[SmartIri, KnoraCardinalityInfo])
         }
@@ -2740,8 +2800,8 @@ case class PropertyInfoContentV2(propertyIri: SmartIri,
   * Can read a [[PropertyInfoContentV2]] from JSON-LD, and provides constants used by that class.
   */
 object PropertyInfoContentV2 {
-    // The predicates allowed in a property definition that is read from JSON-LD.
-    private val AllowedJsonLDPropertyPredicates = Set(
+    // The predicates allowed in a property definition that is read from JSON-LD representing client input.
+    private val AllowedJsonLDPropertyPredicatesInClientInput = Set(
         JsonLDConstants.ID,
         JsonLDConstants.TYPE,
         OntologyConstants.KnoraApiV2Simple.SubjectType,
@@ -2759,25 +2819,35 @@ object PropertyInfoContentV2 {
       * Reads a [[PropertyInfoContentV2]] from a JSON-LD object.
       *
       * @param jsonLDPropertyDef the JSON-LD object representing a property definition.
-      * @param ignoreExtraData   if `true`, extra data in the property definition will be ignored. This is used only in testing.
-      *                          Otherwise, extra data will cause an exception to be thrown.
+      * @param parsingMode       the parsing mode to be used.
       * @return a [[PropertyInfoContentV2]] representing the property definition.
       */
-    def fromJsonLDObject(jsonLDPropertyDef: JsonLDObject, ignoreExtraData: Boolean): PropertyInfoContentV2 = {
+    def fromJsonLDObject(jsonLDPropertyDef: JsonLDObject, parsingMode: InputOntologyParsingModeV2): PropertyInfoContentV2 = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
         val propertyIri: SmartIri = jsonLDPropertyDef.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.toSmartIriWithErr)
         val ontologySchema: OntologySchema = propertyIri.getOntologySchema.getOrElse(throw BadRequestException(s"Invalid property IRI: $propertyIri"))
 
-        if (!ignoreExtraData) {
-            val extraPropertyPredicates = jsonLDPropertyDef.value.keySet -- AllowedJsonLDPropertyPredicates
+        // Parse differently depending on the parsing mode.
+        val filteredPropertyDef: JsonLDObject = parsingMode match {
+            case ClientInputParsingModeV2 =>
+                // In client input mode, only certain predicates are allowed.
+                val extraPropertyPredicates = jsonLDPropertyDef.value.keySet -- AllowedJsonLDPropertyPredicatesInClientInput
 
-            if (extraPropertyPredicates.nonEmpty) {
-                throw BadRequestException(s"The definition of $propertyIri contains one or more invalid predicates: ${extraPropertyPredicates.mkString(", ")}")
-            }
+                if (extraPropertyPredicates.nonEmpty) {
+                    throw BadRequestException(s"The definition of $propertyIri contains one or more invalid predicates: ${extraPropertyPredicates.mkString(", ")}")
+                } else {
+                    jsonLDPropertyDef
+                }
+
+            case TestResponseParsingModeV2 =>
+                // In test response mode, we ignore predicates that wouldn't be allowed as client input.
+                JsonLDObject(jsonLDPropertyDef.value.filterKeys(AllowedJsonLDPropertyPredicatesInClientInput))
+
+            case KnoraOutputParsingModeV2 =>
+                // In Knora output parsing mode, we accept all predicates.
+                jsonLDPropertyDef
         }
-
-        val filteredPropertyDef = JsonLDObject(jsonLDPropertyDef.value.filterKeys(AllowedJsonLDPropertyPredicates))
 
         val subPropertyOf: Set[SmartIri] = filteredPropertyDef.maybeArray(OntologyConstants.Rdfs.SubPropertyOf) match {
             case Some(valueArray: JsonLDArray) =>

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/GravsearchTypeInspector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/GravsearchTypeInspector.scala
@@ -19,6 +19,7 @@
 
 package org.knora.webapi.responders.v2.search.gravsearch.types
 
+import akka.actor.ActorSystem
 import akka.util.Timeout
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.responders.ResponderData
@@ -33,12 +34,12 @@ import scala.concurrent.{ExecutionContext, Future}
   * entities in the WHERE clause of a Gravsearch query, then runs the next inspector in the pipeline.
   *
   * @param nextInspector the next type inspector in the pipeline, or `None` if this is the last one.
-  * @param system        the Akka actor system.
+  * @param responderData the Knora responder data.
   */
 abstract class GravsearchTypeInspector(protected val nextInspector: Option[GravsearchTypeInspector],
                                        responderData: ResponderData) {
 
-    protected val system = responderData.system
+    protected val system: ActorSystem = responderData.system
     protected val settings: SettingsImpl = Settings(system)
     protected implicit val executionContext: ExecutionContext = system.dispatchers.lookup(KnoraDispatchers.KnoraActorDispatcher)
     protected implicit val timeout: Timeout = settings.defaultTimeout

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/InferringGravsearchTypeInspector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/InferringGravsearchTypeInspector.scala
@@ -540,8 +540,8 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                     case Some(subjectType: SmartIri) =>
                         val subjectTypeStr = subjectType.toString
 
-                        // Is it knora-api:Value?
-                        if (subjectTypeStr == OntologyConstants.KnoraApiV2WithValueObjects.Value) {
+                        // Is it knora-api:Value or one of the knora-api:ValueBase classes?
+                        if (subjectTypeStr == OntologyConstants.KnoraApiV2WithValueObjects.Value || OntologyConstants.KnoraApiV2WithValueObjects.ValueBaseClasses.contains(subjectTypeStr)) {
                             // Yes. Don't use it.
                             None
                         } else if (OntologyConstants.KnoraApiV2WithValueObjects.FileValueClasses.contains(subjectTypeStr)) {

--- a/webapi/src/main/scala/org/knora/webapi/util/OntologyUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/OntologyUtil.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.util
+
+import org.knora.webapi.InconsistentTriplestoreDataException
+
+/**
+  * Utility functions for working with ontology entities.
+  */
+object OntologyUtil {
+    /**
+      * Recursively walks up an entity hierarchy read from the triplestore, collecting the IRIs of all base entities.
+      *
+      * @param iri             the IRI of an entity.
+      * @param directRelations a map of entities to their direct base entities.
+      * @return all the base entities of the specified entity.
+      */
+    def getAllBaseDefs(iri: SmartIri, directRelations: Map[SmartIri, Set[SmartIri]]): Set[SmartIri] = {
+        def getAllBaseDefsRec(initialIri: SmartIri, currentIri: SmartIri): Set[SmartIri] = {
+            directRelations.get(currentIri) match {
+                case Some(baseDefs) =>
+                    baseDefs ++ baseDefs.flatMap {
+                        baseDef =>
+                            if (baseDef == initialIri) {
+                                throw InconsistentTriplestoreDataException(s"Entity $initialIri has an inheritance cycle with entity $baseDef")
+                            } else {
+                                getAllBaseDefsRec(initialIri, baseDef)
+                            }
+                    }
+
+                case None => Set.empty[SmartIri]
+            }
+        }
+
+        getAllBaseDefsRec(initialIri = iri, currentIri = iri)
+    }
+}

--- a/webapi/src/test/resources/logback-test.xml
+++ b/webapi/src/test/resources/logback-test.xml
@@ -104,6 +104,7 @@
     <!-- Spec Logging -->
 
     <logger name="org.knora.webapi.E2ESpec" level="DEBUG"/>
+    <logger name="org.knora.webapi.e2e.InstanceCheckerSpec" level="DEBUG"/>
 
     <!-- V1 -->
     <logger name="org.knora.webapi.responders.v1.ListsResponderV1Spec" level="INFO"/>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/boxOntologyWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/boxOntologyWithValueObjects.jsonld
@@ -89,7 +89,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/boxOntologyWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/boxOntologyWithValueObjects.rdf
@@ -20,111 +20,111 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shared thing.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shared thing</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b17"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b0">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b1">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b2">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b3">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b4">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b5">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b6">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b7">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b7">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b8">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b9">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b10">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b11">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b12">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b12">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b13">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b13">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b14">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b14">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b15">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b15">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b16">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b16">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-01d7825ae64d4f5b99767c5df5b7632b-b17">
+<owl:Restriction rdf:nodeID="genid-b4b4fcba1c0b4e2b9de0d36900038661-b17">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/boxOntologyWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/boxOntologyWithValueObjects.ttl
@@ -32,7 +32,7 @@ example-box:Box a owl:Class;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologySimple.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologySimple.jsonld
@@ -20,6 +20,12 @@
       }
     }, {
       "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
+      }
+    }, {
+      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:hasStillImageFile"
@@ -74,6 +80,12 @@
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
+      }
+    }, {
+      "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -283,6 +295,12 @@
       }
     }, {
       "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
+      }
+    }, {
+      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:versionArkUrl"
@@ -398,6 +416,12 @@
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
+      }
+    }, {
+      "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
       }
     }, {
       "@type" : "owl:Restriction",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologySimple.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologySimple.jsonld
@@ -14,33 +14,15 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:hasStillImageFile"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -89,27 +71,9 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -313,27 +277,9 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -449,33 +395,15 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:hasStillImageFile"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologySimple.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologySimple.rdf
@@ -13,36 +13,41 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Randleistentyp</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Randleiste</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#StillImageRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b8"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b0">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b0">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b1">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b1">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b2">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b2">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b3">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStillImageFile"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b3">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b4">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b4">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b5">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b5">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b6">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#sbTitle">
@@ -54,7 +59,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b6">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b7">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#description">
@@ -67,7 +72,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b7">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b8">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#sideband_comment">
@@ -84,40 +89,45 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diese Resource-Klasse beschreibt ein Buch</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Book</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b25"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b8">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b9">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b9">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b10">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b10">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b11">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b12">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b11">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b13">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b12">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b14">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#title">
@@ -130,11 +140,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b13">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b15">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#description"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b14">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b16">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#hasAuthor">
@@ -147,7 +157,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b15">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b17">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#publisher">
@@ -160,7 +170,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b16">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b18">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#publoc">
@@ -172,7 +182,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b17">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b19">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#citation">
@@ -184,7 +194,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b18">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b20">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#pubdate">
@@ -197,7 +207,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b19">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b21">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#location">
@@ -209,7 +219,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b20">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b22">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#url">
@@ -221,7 +231,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b21">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b23">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#physical_desc">
@@ -233,7 +243,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b22">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b24">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#note">
@@ -245,7 +255,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b23">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b25">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#book_comment">
@@ -269,21 +279,22 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A page is a part of a book</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Page</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#StillImageRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b49"/>
 </owl:Class>
 <owl:ObjectProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#hasRightSideband">
 	<knora-api:objectType rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#Sideband"/>
@@ -296,31 +307,36 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A fake resource class that only has optional properties</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sonstiges</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b33"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b24">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b26">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b25">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b27">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b26">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b28">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b29">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b27">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b30">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b28">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b31">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#miscHasColor">
@@ -331,7 +347,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b29">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b32">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#miscHasGeometry">
@@ -342,7 +358,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b30">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b33">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#miscHasBook">
@@ -360,27 +376,31 @@
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Original filename</rdfs:label>
 	<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasValue"/>
 </owl:DatatypeProperty>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b31">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b34">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b32">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b35">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b33">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b36">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b37">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStillImageFile"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b34">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b38">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b35">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b39">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b36">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b40">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#pagenum">
@@ -392,11 +412,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b37">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b41">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#description"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b38">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b42">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#partOf">
@@ -408,7 +428,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b39">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b43">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#seqnum">
@@ -420,11 +440,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b40">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b44">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#citation"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b41">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b45">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#page_comment">
@@ -436,19 +456,19 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b42">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b46">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#origname"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b43">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b47">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#hasLeftSideband"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b44">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b48">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#hasRightSideband"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b45">
+<owl:Restriction rdf:nodeID="genid-8b819d18dc24401fa9d0b65858ccd859-b49">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#transcription">

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologySimple.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologySimple.rdf
@@ -13,51 +13,36 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Randleistentyp</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Randleiste</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#StillImageRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b7"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b0">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b0">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b1">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b2">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b1">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b3">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b4">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b2">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStillImageFile"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b5">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b6">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b3">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b7">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b4">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b8">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b5">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#sbTitle">
@@ -69,7 +54,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b9">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b6">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#description">
@@ -82,7 +67,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b10">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b7">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#sideband_comment">
@@ -99,55 +84,40 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diese Resource-Klasse beschreibt ein Buch</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Book</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b23"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b11">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b8">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b12">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b13">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b9">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b14">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b15">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b16">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b10">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b17">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b11">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b18">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b12">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#title">
@@ -160,11 +130,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b19">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b13">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#description"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b20">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b14">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#hasAuthor">
@@ -177,7 +147,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b21">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b15">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#publisher">
@@ -190,7 +160,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b22">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b16">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#publoc">
@@ -202,7 +172,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b23">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b17">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#citation">
@@ -214,7 +184,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b24">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b18">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#pubdate">
@@ -227,7 +197,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b25">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b19">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#location">
@@ -239,7 +209,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b26">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b20">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#url">
@@ -251,7 +221,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b27">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b21">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#physical_desc">
@@ -263,7 +233,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b28">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b22">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#note">
@@ -275,7 +245,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b29">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b23">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#book_comment">
@@ -299,24 +269,21 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A page is a part of a book</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Page</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#StillImageRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b51"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b45"/>
 </owl:Class>
 <owl:ObjectProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#hasRightSideband">
 	<knora-api:objectType rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#Sideband"/>
@@ -329,46 +296,31 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A fake resource class that only has optional properties</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sonstiges</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b30"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b30">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b24">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b31">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b32">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b25">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b33">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b34">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b35">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b26">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b36">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b27">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b37">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b28">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#miscHasColor">
@@ -379,7 +331,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b38">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b29">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#miscHasGeometry">
@@ -390,7 +342,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b39">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b30">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#miscHasBook">
@@ -408,39 +360,27 @@
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Original filename</rdfs:label>
 	<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasValue"/>
 </owl:DatatypeProperty>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b40">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b31">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b41">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b42">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b32">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b43">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b44">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b33">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStillImageFile"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b45">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b46">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b34">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b47">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b35">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b48">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b36">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#pagenum">
@@ -452,11 +392,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b49">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b37">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#description"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b50">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b38">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#partOf">
@@ -468,7 +408,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b51">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b39">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#seqnum">
@@ -480,11 +420,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b52">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b40">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#citation"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b53">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b41">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#page_comment">
@@ -496,19 +436,19 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b54">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b42">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#origname"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b55">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b43">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#hasLeftSideband"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b56">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b44">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#hasRightSideband"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-3d6898ea597e4e30a18045f34533855a-b57">
+<owl:Restriction rdf:nodeID="genid-ff1c9e00375847959b7784a0cfdebd3d-b45">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#transcription">

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologySimple.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologySimple.ttl
@@ -15,23 +15,11 @@ incunabula:Sideband a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty incunabula:sideband_comment
-    ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasStillImageFile
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -44,6 +32,9 @@ incunabula:Sideband a owl:Class;
     ], [ a owl:Restriction;
       owl:maxCardinality 1;
       owl:onProperty incunabula:description
+    ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty incunabula:sideband_comment
     ] .
 
 incunabula:sbTitle a owl:DatatypeProperty;
@@ -71,21 +62,6 @@ incunabula:book a owl:Class;
   rdfs:comment "Diese Resource-Klasse beschreibt ein Buch";
   rdfs:label "Book";
   rdfs:subClassOf knora-api:Resource, [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:arkUrl
-    ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
-    ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
-    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
     ], [ a owl:Restriction;
@@ -127,6 +103,12 @@ incunabula:book a owl:Class;
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty incunabula:book_comment
+    ], [ a owl:Restriction;
+      owl:cardinality 1;
+      owl:onProperty knora-api:arkUrl
+    ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasIncomingLink
     ] .
 
 incunabula:title a owl:DatatypeProperty;
@@ -221,20 +203,11 @@ incunabula:page a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasStillImageFile
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -287,17 +260,8 @@ incunabula:misc a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
-    ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologySimple.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologySimple.ttl
@@ -18,6 +18,9 @@ incunabula:Sideband a owl:Class;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
+    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasStillImageFile
     ], [ a owl:Restriction;
@@ -62,6 +65,12 @@ incunabula:book a owl:Class;
   rdfs:comment "Diese Resource-Klasse beschreibt ein Buch";
   rdfs:label "Book";
   rdfs:subClassOf knora-api:Resource, [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasIncomingLink
+    ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
+    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
     ], [ a owl:Restriction;
@@ -106,9 +115,6 @@ incunabula:book a owl:Class;
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:arkUrl
-    ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasIncomingLink
     ] .
 
 incunabula:title a owl:DatatypeProperty;
@@ -206,6 +212,9 @@ incunabula:page a owl:Class;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
+    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasStillImageFile
     ], [ a owl:Restriction;
@@ -262,6 +271,9 @@ incunabula:misc a owl:Class;
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
+    ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologyWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologyWithValueObjects.jsonld
@@ -95,7 +95,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -246,7 +246,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -644,7 +644,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -923,7 +923,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologyWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologyWithValueObjects.rdf
@@ -17,119 +17,119 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Randleistentyp</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Randleiste</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StillImageRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b20"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b0">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b1">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b2">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b3">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b4">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b5">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b6">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b7">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b7">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b8">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b9">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b10">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b11">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b12">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b12">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b13">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b13">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b14">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b14">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b15">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b15">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b16">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b16">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b17">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b17">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b18">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b18">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -147,7 +147,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b19">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b19">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -164,7 +164,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b20">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b20">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -187,122 +187,122 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diese Resource-Klasse beschreibt ein Buch</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Book</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b49"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b21">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b21">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b22">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b22">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b23">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b23">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b24">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b24">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b25">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b25">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b26">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b26">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b27">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b27">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b28">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b28">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b29">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b29">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b30">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b30">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b31">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b31">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b32">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b32">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b33">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b33">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b34">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b34">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b35">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b35">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b36">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b36">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b37">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b37">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b38">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b38">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
@@ -321,12 +321,12 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b39">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b39">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#description"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b40">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b40">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -345,7 +345,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b41">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b41">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -364,7 +364,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b42">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b42">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -382,7 +382,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b43">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b43">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -401,7 +401,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b44">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b44">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -418,7 +418,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b45">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b45">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -437,7 +437,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b46">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b46">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -455,7 +455,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b47">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b47">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -474,7 +474,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b48">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b48">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -493,7 +493,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b49">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b49">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -531,37 +531,37 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A page is a part of a book</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Page</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StillImageRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b71"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b74"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b77"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b79"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b81"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b83"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b84"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b85"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b86"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b87"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b89"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b90"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b91"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b92"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b93"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b94"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b95"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b96"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b97"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b98"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b99"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b100"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b101"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b85"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b86"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b87"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b88"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b89"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b90"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b91"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b92"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b93"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b94"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b95"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b96"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b97"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b98"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b99"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b100"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b101"/>
 </owl:Class>
 <owl:ObjectProperty rdf:about="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasLeftSidebandValue">
 	<knora-api:isEditable rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isEditable>
@@ -603,114 +603,114 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A fake resource class that only has optional properties</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sonstiges</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b51"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b62"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b63"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b66"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b68"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b63"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b70"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b50">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b50">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b51">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b51">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b52">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b52">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b53">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b53">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b54">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b54">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b55">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b55">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b56">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b56">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b57">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b57">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b58">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b58">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b59">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b59">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b60">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b60">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b61">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b61">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b62">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b62">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b63">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b63">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b64">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b64">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b65">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b65">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b66">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b66">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b67">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b67">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -725,7 +725,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b68">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b68">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -740,7 +740,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b69">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b69">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -756,7 +756,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b70">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b70">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -784,97 +784,97 @@
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Original filename</rdfs:label>
 	<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasValue"/>
 </owl:ObjectProperty>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b71">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b71">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b72">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b72">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b73">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b73">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b74">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b74">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b75">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b75">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b76">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b76">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b77">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b77">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b78">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b78">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b79">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b79">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b80">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b80">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b81">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b81">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b82">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b82">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b83">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b83">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b84">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b84">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b85">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b85">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b86">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b86">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b87">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b87">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b88">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b88">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b89">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b89">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -892,12 +892,12 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b90">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b90">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#description"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b91">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b91">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -914,7 +914,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b92">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b92">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -931,7 +931,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b93">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b93">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -949,12 +949,12 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b94">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b94">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#citation"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b95">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b95">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -973,32 +973,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b96">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b96">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#origname"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b97">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b97">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasLeftSideband"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b98">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b98">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasLeftSidebandValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b99">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b99">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasRightSideband"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b100">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b100">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasRightSidebandValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-e3ec6804a8bb4cfcbe6559cb483694d4-b101">
+<owl:Restriction rdf:nodeID="genid-77c9e3e96be6471f92becfd14689b719-b101">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologyWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaOntologyWithValueObjects.ttl
@@ -33,7 +33,7 @@ incunabula:Sideband a owl:Class;
       owl:onProperty knora-api:hasStillImageFileValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -183,7 +183,7 @@ incunabula:book a owl:Class;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -451,7 +451,7 @@ incunabula:page a owl:Class;
       owl:onProperty knora-api:hasStillImageFileValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -604,7 +604,7 @@ incunabula:misc a owl:Class;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaPageAndBookWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaPageAndBookWithValueObjects.jsonld
@@ -89,7 +89,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -310,7 +310,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaPageAndBookWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaPageAndBookWithValueObjects.rdf
@@ -18,177 +18,177 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diese Resource-Klasse beschreibt ein Buch</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Book</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b28"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b0">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b1">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b2">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b3">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b4">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b5">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b6">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b7">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b7">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b8">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b9">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b10">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b11">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b12">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b12">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b13">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b13">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b14">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b14">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b15">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b15">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b16">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b16">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b17">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b17">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#title"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b18">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b18">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#description"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b19">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b19">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasAuthor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b20">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b20">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#publisher"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b21">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b21">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#publoc"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b22">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b22">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#citation"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b23">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b23">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#pubdate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b24">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b24">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#location"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b25">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b25">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#url"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b26">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b26">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">9</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#physical_desc"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b27">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b27">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#note"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b28">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b28">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#book_comment"/>
@@ -200,189 +200,189 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A page is a part of a book</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Page</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StillImageRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b51"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b59"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b29">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b29">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b30">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b30">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b31">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b31">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b32">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b32">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b33">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b33">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b34">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b34">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b35">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b35">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b36">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b36">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b37">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b37">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b38">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b38">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b39">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b39">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b40">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b40">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b41">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b41">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b42">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b42">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b43">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b43">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b44">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b44">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b45">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b45">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b46">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b46">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b47">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b47">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#pagenum"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b48">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b48">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#description"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b49">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b49">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#partOf"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b50">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b50">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#partOfValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b51">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b51">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#seqnum"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b52">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b52">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">5</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#citation"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b53">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b53">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">6</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#page_comment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b54">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b54">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">7</salsah-gui:guiOrder>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#origname"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b55">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b55">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasLeftSideband"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b56">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b56">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">10</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasLeftSidebandValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b57">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b57">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasRightSideband"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b58">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b58">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">11</salsah-gui:guiOrder>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#hasRightSidebandValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-cabf94b5b5fc4575adde88592d115a5d-b59">
+<owl:Restriction rdf:nodeID="genid-81d145f436e3458192bbb34cec84bb3e-b59">
 	<salsah-gui:guiOrder rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">12</salsah-gui:guiOrder>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://0.0.0.0:3333/ontology/0803/incunabula/v2#transcription"/>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaPageAndBookWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/incunabulaPageAndBookWithValueObjects.ttl
@@ -30,7 +30,7 @@ incunabula:book a owl:Class;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -190,7 +190,7 @@ incunabula:page a owl:Class;
       owl:onProperty knora-api:hasStillImageFileValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiDateValue.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiDateValue.jsonld
@@ -109,7 +109,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiDateValue.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiDateValue.rdf
@@ -16,117 +16,117 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Knora date value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b18"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b0">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b1">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b2">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b3">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b4">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b5">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b6">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b7">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b7">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b8">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b9">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b10">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b11">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b12">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b12">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b13">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b13">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b14">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b14">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b15">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b15">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b16">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b16">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b17">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b17">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-c26914b116db48d581f158e2f75367fa-b18">
+<owl:Restriction rdf:nodeID="genid-8100581841bb40aabf416f7e7a670add-b18">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiDateValue.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiDateValue.ttl
@@ -38,7 +38,7 @@ knora-api:DateValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.jsonld
@@ -26,6 +26,12 @@
       }
     }, {
       "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
+      }
+    }, {
+      "@type" : "owl:Restriction",
       "owl:minCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isAnnotationOf"
@@ -67,6 +73,12 @@
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
+      }
+    }, {
+      "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -122,6 +134,12 @@
       }
     }, {
       "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
+      }
+    }, {
+      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:versionArkUrl"
@@ -173,6 +191,12 @@
       }
     }, {
       "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
+      }
+    }, {
+      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:versionArkUrl"
@@ -216,6 +240,12 @@
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
+      }
+    }, {
+      "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -300,6 +330,12 @@
       }
     }, {
       "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
+      }
+    }, {
+      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:versionArkUrl"
@@ -335,6 +371,12 @@
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:hasMovingImageFile"
+      }
+    }, {
+      "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -389,6 +431,12 @@
       }
     }, {
       "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
+      }
+    }, {
+      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isRegionOf"
@@ -433,6 +481,12 @@
       }
     }, {
       "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
+      }
+    }, {
+      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:versionArkUrl"
@@ -460,6 +514,12 @@
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
+      }
+    }, {
+      "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -492,6 +552,12 @@
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
+      }
+    }, {
+      "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -533,6 +599,12 @@
       }
     }, {
       "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
+      }
+    }, {
+      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:hasTextFile"
@@ -568,6 +640,12 @@
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
+      }
+    }, {
+      "@type" : "owl:Restriction",
+      "owl:minCardinality" : 0,
+      "owl:onProperty" : {
+        "@id" : "knora-api:hasStandoffLinkTo"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -755,6 +833,20 @@
     },
     "rdfs:comment" : "References an instance of a Representation. A Representation contains the metadata of a digital object (= file) which represents some physical entity such as an image, a sound, an encoded text etc.",
     "rdfs:label" : "has Representation",
+    "rdfs:subPropertyOf" : {
+      "@id" : "knora-api:hasLinkTo"
+    }
+  }, {
+    "@id" : "knora-api:hasStandoffLinkTo",
+    "@type" : "owl:ObjectProperty",
+    "knora-api:objectType" : {
+      "@id" : "knora-api:Resource"
+    },
+    "knora-api:subjectType" : {
+      "@id" : "knora-api:Resource"
+    },
+    "rdfs:comment" : "Represents a link in standoff markup from one resource to another.",
+    "rdfs:label" : "has Standoff Link to",
     "rdfs:subPropertyOf" : {
       "@id" : "knora-api:hasLinkTo"
     }

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.jsonld
@@ -14,12 +14,6 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:hasComment"
@@ -32,21 +26,9 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isAnnotationOf"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -78,12 +60,6 @@
       "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
         "@id" : "knora-api:hasAudioFile"
       }
     }, {
@@ -91,18 +67,6 @@
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -148,12 +112,6 @@
       "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
         "@id" : "knora-api:hasDDDFile"
       }
     }, {
@@ -161,18 +119,6 @@
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -217,12 +163,6 @@
       "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
         "@id" : "knora-api:hasDocumentFile"
       }
     }, {
@@ -230,18 +170,6 @@
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -279,12 +207,6 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasComment"
@@ -294,18 +216,6 @@
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -372,12 +282,6 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasComment"
@@ -393,18 +297,6 @@
       "owl:minCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:hasLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -434,12 +326,6 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
@@ -449,18 +335,6 @@
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:hasMovingImageFile"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -493,12 +367,6 @@
       "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
         "@id" : "knora-api:hasColor"
       }
     }, {
@@ -521,21 +389,9 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isRegionOf"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -567,12 +423,6 @@
       "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
         "@id" : "knora-api:hasFile"
       }
     }, {
@@ -580,18 +430,6 @@
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -619,27 +457,9 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -669,33 +489,15 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:hasStillImageFile"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -725,33 +527,15 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:hasTextFile"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -781,33 +565,15 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:creationDate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:minCardinality" : 0,
       "owl:onProperty" : {
         "@id" : "knora-api:hasIncomingLink"
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:minCardinality" : 0,
-      "owl:onProperty" : {
-        "@id" : "knora-api:hasStandoffLinkTo"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "owl:cardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:hasTextFile"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:maxCardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:lastModificationDate"
       }
     }, {
       "@type" : "owl:Restriction",
@@ -830,16 +596,6 @@
     },
     "rdfs:comment" : "Provides the ARK URL of a resource.",
     "rdfs:label" : "ARK URL"
-  }, {
-    "@id" : "knora-api:creationDate",
-    "@type" : "owl:DatatypeProperty",
-    "knora-api:objectType" : {
-      "@id" : "xsd:dateTimeStamp"
-    },
-    "knora-api:subjectType" : {
-      "@id" : "knora-api:Resource"
-    },
-    "rdfs:comment" : "Indicates when a resource was created"
   }, {
     "@id" : "knora-api:error",
     "@type" : "owl:DatatypeProperty",
@@ -1003,20 +759,6 @@
       "@id" : "knora-api:hasLinkTo"
     }
   }, {
-    "@id" : "knora-api:hasStandoffLinkTo",
-    "@type" : "owl:ObjectProperty",
-    "knora-api:objectType" : {
-      "@id" : "knora-api:Resource"
-    },
-    "knora-api:subjectType" : {
-      "@id" : "knora-api:Resource"
-    },
-    "rdfs:comment" : "Represents a link in standoff markup from one resource to another.",
-    "rdfs:label" : "has Standoff Link to",
-    "rdfs:subPropertyOf" : {
-      "@id" : "knora-api:hasLinkTo"
-    }
-  }, {
     "@id" : "knora-api:hasStillImageFile",
     "@type" : "owl:DatatypeProperty",
     "knora-api:objectType" : {
@@ -1105,12 +847,6 @@
     "rdfs:label" : "is region of",
     "rdfs:subPropertyOf" : {
       "@id" : "knora-api:hasLinkTo"
-    }
-  }, {
-    "@id" : "knora-api:lastModificationDate",
-    "@type" : "owl:DatatypeProperty",
-    "knora-api:objectType" : {
-      "@id" : "xsd:dateTimeStamp"
     }
   }, {
     "@id" : "knora-api:objectType",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.rdf
@@ -12,28 +12,22 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic class for representing annotations</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b5"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Resource">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents something in the world, or an abstract thing</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Resource</rdfs:label>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b85"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b86"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b87"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b89"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b90"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b91"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b61"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b0">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b0">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl">
@@ -43,17 +37,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b1">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty>
-		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#creationDate">
-			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#dateTimeStamp"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Indicates when a resource was created</rdfs:comment>
-		</owl:DatatypeProperty>
-	</owl:onProperty>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b2">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b1">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasComment">
@@ -65,7 +49,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b3">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b2">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink">
@@ -77,19 +61,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b4">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty>
-		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo">
-			<knora-api:objectType rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a link in standoff markup from one resource to another.</rdfs:comment>
-			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has Standoff Link to</rdfs:label>
-			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasLinkTo"/>
-		</owl:ObjectProperty>
-	</owl:onProperty>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b5">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b3">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#isAnnotationOf">
@@ -100,15 +72,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b6">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty>
-		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate">
-			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#dateTimeStamp"/>
-		</owl:DatatypeProperty>
-	</owl:onProperty>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b7">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b4">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl">
@@ -118,7 +82,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b8">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b5">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -126,37 +90,27 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containing audio data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Audio)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b10"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Representation">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can store a file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b77"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b79"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b81"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b83"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b57"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b9">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b6">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b10">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b11">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b7">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasAudioFile">
@@ -168,23 +122,15 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b12">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b8">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b13">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b14">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b15">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b9">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b16">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b10">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -192,10 +138,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Color literal</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b17">
+		<rdfs:Datatype rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b11">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b18">
+				<rdf:Description rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b12">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">#([0-9a-fA-F]{3}){1,2}</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -206,24 +152,17 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containg 3D data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (3D)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b17"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b19">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b13">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b20">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b21">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b14">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasDDDFile">
@@ -235,23 +174,15 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b22">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b15">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b23">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b24">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b25">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b16">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b26">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b17">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -259,10 +190,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date as a period with different possible precisions.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date literal</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b27">
+		<rdfs:Datatype rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b18">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b28">
+				<rdf:Description rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b19">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(GREGORIAN|JULIAN):\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?(:\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?)?</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -272,24 +203,17 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#DocumentRepresentation">
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Document)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b24"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b29">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b20">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b30">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b31">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b21">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasDocumentFile">
@@ -301,23 +225,15 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b32">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b22">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b33">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b34">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b35">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b23">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b36">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b24">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -330,44 +246,29 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b29"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b37">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b25">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b38">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b39">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b26">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b40">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b27">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b41">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b42">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b43">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b28">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b44">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b29">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -380,10 +281,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Geoname code.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Geoname code</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b45">
+		<rdfs:Datatype rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b30">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b46">
+				<rdf:Description rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b31">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">\d{1,8}</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -394,10 +295,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an interval.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interprivate val literal</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b47">
+		<rdfs:Datatype rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b32">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b48">
+				<rdf:Description rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b33">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">\d+(\.\d+)?,\d+(\.\d+)?</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -409,33 +310,26 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a generic link object</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link Object</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b51"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b39"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b49">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b34">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b50">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b51">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b35">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b52">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b36">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b53">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b37">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasLinkTo">
@@ -447,19 +341,11 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b54">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b55">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b56">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b38">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b57">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b39">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -467,28 +353,21 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing moving image data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Movie)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b62"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b63"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b44"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b58">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b40">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b59">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b60">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b41">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b61">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b42">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasMovingImageFile">
@@ -500,19 +379,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b62">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b63">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b64">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b43">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b65">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b44">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -521,27 +392,20 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometric region of a resource. The geometry is represented currently as JSON string.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b66"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b68"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b71"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b74"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b52"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b66">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b45">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b67">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b68">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b46">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasColor">
@@ -553,11 +417,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b69">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b47">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b70">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b48">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasGeometry">
@@ -569,15 +433,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b71">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b49">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b72">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b73">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b50">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#isRegionOf">
@@ -589,27 +449,19 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b74">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b75">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b51">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b76">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b52">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b77">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b53">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b78">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b79">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b54">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasFile">
@@ -621,51 +473,31 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b80">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b55">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b81">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b82">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b83">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b56">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b84">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b57">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b85">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b58">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b86">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b87">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b59">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b88">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b89">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b90">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b60">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b91">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b61">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -673,32 +505,21 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can contain a two-dimensional still image file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Image)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b92"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b93"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b94"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b95"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b96"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b97"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b98"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b99"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b63"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b66"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b92">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b62">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b93">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b94">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b63">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b95">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b96">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b64">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasStillImageFile">
@@ -710,15 +531,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b97">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b98">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b65">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b99">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b66">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -726,32 +543,21 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing a text file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Text)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b100"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b101"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b102"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b103"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b104"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b105"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b106"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b107"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b71"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b100">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b67">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b101">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b102">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b68">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b103">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b104">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b69">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasTextFile">
@@ -763,15 +569,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b105">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b106">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b70">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b107">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b71">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -779,44 +581,29 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff.  The transformation's result is ecptected to be HTML.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff. The transformation's result is ecptected to be HTML.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#TextRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b108"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b109"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b110"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b111"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b112"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b113"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b114"/>
-	<rdfs:subClassOf rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b115"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b76"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b108">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b72">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b109">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#creationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b110">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b73">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b111">
-	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b112">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b74">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasTextFile"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b113">
-	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#lastModificationDate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b114">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b75">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-dc05f32753834936b97e917a7e756107-b115">
+<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b76">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.rdf
@@ -12,22 +12,24 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic class for representing annotations</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b6"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Resource">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents something in the world, or an abstract thing</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Resource</rdfs:label>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b71"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b0">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b0">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl">
@@ -37,7 +39,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b1">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b1">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasComment">
@@ -49,7 +51,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b2">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b2">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink">
@@ -61,7 +63,19 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b3">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b3">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty>
+		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo">
+			<knora-api:objectType rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
+			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a link in standoff markup from one resource to another.</rdfs:comment>
+			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has Standoff Link to</rdfs:label>
+			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasLinkTo"/>
+		</owl:ObjectProperty>
+	</owl:onProperty>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b4">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#isAnnotationOf">
@@ -72,7 +86,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b4">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b5">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl">
@@ -82,7 +96,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b5">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b6">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -90,27 +104,29 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containing audio data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Audio)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b12"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Representation">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can store a file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b63"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b66"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b6">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b7">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b7">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b8">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasAudioFile">
@@ -122,15 +138,19 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b8">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b9">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b9">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b10">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b11">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b10">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b12">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -138,10 +158,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Color literal</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b11">
+		<rdfs:Datatype rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b13">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b12">
+				<rdf:Description rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b14">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">#([0-9a-fA-F]{3}){1,2}</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -152,17 +172,18 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containg 3D data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (3D)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b20"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b13">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b15">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b14">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b16">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasDDDFile">
@@ -174,15 +195,19 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b15">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b17">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b16">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b18">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b19">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b17">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b20">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -190,10 +215,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date as a period with different possible precisions.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date literal</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b18">
+		<rdfs:Datatype rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b21">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b19">
+				<rdf:Description rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b22">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(GREGORIAN|JULIAN):\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?(:\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?)?</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -203,17 +228,18 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#DocumentRepresentation">
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Document)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b28"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b20">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b23">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b21">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b24">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasDocumentFile">
@@ -225,15 +251,19 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b22">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b25">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b23">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b26">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b27">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b24">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b28">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -246,29 +276,34 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b34"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b25">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b29">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b26">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b30">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b27">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b31">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b28">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b32">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b33">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b29">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b34">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -281,10 +316,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Geoname code.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Geoname code</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b30">
+		<rdfs:Datatype rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b35">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b31">
+				<rdf:Description rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b36">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">\d{1,8}</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -295,10 +330,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an interval.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interprivate val literal</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b32">
+		<rdfs:Datatype rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b37">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b33">
+				<rdf:Description rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b38">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">\d+(\.\d+)?,\d+(\.\d+)?</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -310,26 +345,27 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a generic link object</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link Object</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b45"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b34">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b39">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b35">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b40">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b36">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b41">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b37">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b42">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasLinkTo">
@@ -341,11 +377,15 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b38">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b43">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b44">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b39">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b45">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -353,21 +393,22 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing moving image data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Movie)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b51"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b40">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b46">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b41">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b47">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b42">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b48">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasMovingImageFile">
@@ -379,11 +420,15 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b43">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b49">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b50">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b44">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b51">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -392,20 +437,21 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometric region of a resource. The geometry is represented currently as JSON string.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b51"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b60"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b45">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b52">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b46">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b53">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasColor">
@@ -417,11 +463,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b47">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b54">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b48">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b55">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasGeometry">
@@ -433,11 +479,15 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b49">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b56">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b50">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b57">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b58">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#isRegionOf">
@@ -449,19 +499,19 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b51">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b59">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b52">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b60">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b53">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b61">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b54">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b62">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasFile">
@@ -473,31 +523,39 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b55">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b63">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b56">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b64">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b65">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b57">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b66">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b58">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b67">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b59">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b68">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b60">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b69">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b70">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b61">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b71">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -505,21 +563,26 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can contain a two-dimensional still image file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Image)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b62"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b63"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b77"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b62">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b72">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b63">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b73">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b64">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b74">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b75">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasStillImageFile">
@@ -531,11 +594,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b65">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b76">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b66">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b77">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -543,21 +606,26 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing a text file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Text)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b68"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b83"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b67">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b78">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b68">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b79">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b69">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b80">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b81">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasTextFile">
@@ -569,11 +637,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b70">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b82">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b71">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b83">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -581,29 +649,34 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff.  The transformation's result is ecptected to be HTML.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff. The transformation's result is ecptected to be HTML.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#TextRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b74"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b85"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b86"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b87"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b88"/>
+	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b89"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b72">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b84">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b73">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b85">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b74">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b86">
+	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
+	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b87">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasTextFile"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b75">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b88">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-77debbed6db44264b74e893eb19fb8c3-b76">
+<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b89">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.ttl
@@ -14,23 +14,14 @@ knora-api:Annotation a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
       owl:minCardinality 1;
       owl:onProperty knora-api:hasComment
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
       owl:minCardinality 1;
       owl:onProperty knora-api:isAnnotationOf
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -46,17 +37,8 @@ knora-api:Resource a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
-    ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -69,11 +51,6 @@ knora-api:arkUrl a owl:DatatypeProperty;
   knora-api:objectType xsd:anyURI;
   rdfs:comment "Provides the ARK URL of a resource.";
   rdfs:label "ARK URL" .
-
-knora-api:creationDate a owl:DatatypeProperty;
-  knora-api:objectType xsd:dateTimeStamp;
-  knora-api:subjectType knora-api:Resource;
-  rdfs:comment "Indicates when a resource was created" .
 
 knora-api:hasComment a owl:DatatypeProperty;
   knora-api:objectType xsd:string;
@@ -89,21 +66,11 @@ knora-api:hasIncomingLink a owl:ObjectProperty;
   rdfs:label "has incoming link";
   rdfs:subPropertyOf knora-api:hasLinkTo .
 
-knora-api:hasStandoffLinkTo a owl:ObjectProperty;
-  knora-api:objectType knora-api:Resource;
-  knora-api:subjectType knora-api:Resource;
-  rdfs:comment "Represents a link in standoff markup from one resource to another.";
-  rdfs:label "has Standoff Link to";
-  rdfs:subPropertyOf knora-api:hasLinkTo .
-
 knora-api:isAnnotationOf a owl:ObjectProperty;
   knora-api:objectType knora-api:Resource;
   knora-api:subjectType knora-api:Annotation;
   rdfs:label "is Annotation of";
   rdfs:subPropertyOf knora-api:hasLinkTo .
-
-knora-api:lastModificationDate a owl:DatatypeProperty;
-  knora-api:objectType xsd:dateTimeStamp .
 
 knora-api:versionArkUrl a owl:DatatypeProperty;
   knora-api:objectType xsd:anyURI;
@@ -115,7 +82,10 @@ knora-api:AudioRepresentation a owl:Class;
   rdfs:label "Representation (Audio)";
   rdfs:subClassOf knora-api:Representation, [ a owl:Restriction;
       owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
+      owl:onProperty rdfs:label
+    ], [ a owl:Restriction;
+      owl:cardinality 1;
+      owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasAudioFile
@@ -123,20 +93,8 @@ knora-api:AudioRepresentation a owl:Class;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
-    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
-    ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty rdfs:label
-    ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:arkUrl
     ] .
 
 knora-api:Representation a owl:Class;
@@ -147,19 +105,10 @@ knora-api:Representation a owl:Class;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
       owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
-      owl:cardinality 1;
       owl:onProperty knora-api:hasFile
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
-    ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -193,19 +142,10 @@ knora-api:DDDRepresentation a owl:Class;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
       owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
-      owl:cardinality 1;
       owl:onProperty knora-api:hasDDDFile
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
-    ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -238,19 +178,10 @@ knora-api:DocumentRepresentation a owl:Class;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
       owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
-      owl:cardinality 1;
       owl:onProperty knora-api:hasDocumentFile
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
-    ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -278,20 +209,11 @@ knora-api:ForbiddenResource a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasComment
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
-    ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -333,9 +255,6 @@ knora-api:LinkObj a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasComment
     ], [ a owl:Restriction;
@@ -344,12 +263,6 @@ knora-api:LinkObj a owl:Class;
     ], [ a owl:Restriction;
       owl:minCardinality 1;
       owl:onProperty knora-api:hasLinkTo
-    ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -372,20 +285,11 @@ knora-api:MovingImageRepresentation a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasMovingImageFile
-    ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -410,9 +314,6 @@ knora-api:Region a owl:Class;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
       owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
-      owl:cardinality 1;
       owl:onProperty knora-api:hasColor
     ], [ a owl:Restriction;
       owl:minCardinality 1;
@@ -424,14 +325,8 @@ knora-api:Region a owl:Class;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:isRegionOf
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -475,20 +370,11 @@ knora-api:StillImageRepresentation a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasStillImageFile
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -511,20 +397,11 @@ knora-api:TextRepresentation a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasTextFile
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -547,20 +424,11 @@ knora-api:XSLTransformation a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:arkUrl
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:creationDate
-    ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
-      owl:minCardinality 0;
-      owl:onProperty knora-api:hasStandoffLinkTo
-    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasTextFile
-    ], [ a owl:Restriction;
-      owl:maxCardinality 1;
-      owl:onProperty knora-api:lastModificationDate
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.ttl
@@ -20,6 +20,9 @@ knora-api:Annotation a owl:Class;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
+    ], [ a owl:Restriction;
       owl:minCardinality 1;
       owl:onProperty knora-api:isAnnotationOf
     ], [ a owl:Restriction;
@@ -39,6 +42,9 @@ knora-api:Resource a owl:Class;
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
+    ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -66,6 +72,13 @@ knora-api:hasIncomingLink a owl:ObjectProperty;
   rdfs:label "has incoming link";
   rdfs:subPropertyOf knora-api:hasLinkTo .
 
+knora-api:hasStandoffLinkTo a owl:ObjectProperty;
+  knora-api:objectType knora-api:Resource;
+  knora-api:subjectType knora-api:Resource;
+  rdfs:comment "Represents a link in standoff markup from one resource to another.";
+  rdfs:label "has Standoff Link to";
+  rdfs:subPropertyOf knora-api:hasLinkTo .
+
 knora-api:isAnnotationOf a owl:ObjectProperty;
   knora-api:objectType knora-api:Resource;
   knora-api:subjectType knora-api:Annotation;
@@ -81,6 +94,12 @@ knora-api:AudioRepresentation a owl:Class;
   rdfs:comment "Represents a file containing audio data";
   rdfs:label "Representation (Audio)";
   rdfs:subClassOf knora-api:Representation, [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
+    ], [ a owl:Restriction;
+      owl:cardinality 1;
+      owl:onProperty knora-api:versionArkUrl
+    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty rdfs:label
     ], [ a owl:Restriction;
@@ -92,9 +111,6 @@ knora-api:AudioRepresentation a owl:Class;
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
-    ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:versionArkUrl
     ] .
 
 knora-api:Representation a owl:Class;
@@ -109,6 +125,9 @@ knora-api:Representation a owl:Class;
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
+    ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -147,6 +166,9 @@ knora-api:DDDRepresentation a owl:Class;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
+    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
     ], [ a owl:Restriction;
@@ -183,6 +205,9 @@ knora-api:DocumentRepresentation a owl:Class;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
+    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
     ], [ a owl:Restriction;
@@ -214,6 +239,9 @@ knora-api:ForbiddenResource a owl:Class;
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
+    ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -264,6 +292,9 @@ knora-api:LinkObj a owl:Class;
       owl:minCardinality 1;
       owl:onProperty knora-api:hasLinkTo
     ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
+    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
     ], [ a owl:Restriction;
@@ -290,6 +321,9 @@ knora-api:MovingImageRepresentation a owl:Class;
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasMovingImageFile
+    ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:versionArkUrl
@@ -324,6 +358,9 @@ knora-api:Region a owl:Class;
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
+    ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:isRegionOf
@@ -373,6 +410,9 @@ knora-api:StillImageRepresentation a owl:Class;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
+    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasStillImageFile
     ], [ a owl:Restriction;
@@ -400,6 +440,9 @@ knora-api:TextRepresentation a owl:Class;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
     ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
+    ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasTextFile
     ], [ a owl:Restriction;
@@ -426,6 +469,9 @@ knora-api:XSLTransformation a owl:Class;
     ], [ a owl:Restriction;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasIncomingLink
+    ], [ a owl:Restriction;
+      owl:minCardinality 0;
+      owl:onProperty knora-api:hasStandoffLinkTo
     ], [ a owl:Restriction;
       owl:cardinality 1;
       owl:onProperty knora-api:hasTextFile

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
@@ -106,7 +106,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -211,7 +211,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -338,7 +338,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -444,7 +444,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -543,7 +543,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -635,7 +635,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -762,7 +762,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -972,7 +972,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -1071,7 +1071,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -1162,7 +1162,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -1288,7 +1288,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -1384,7 +1384,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -1511,7 +1511,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -1602,7 +1602,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -1685,7 +1685,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -1784,7 +1784,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -1896,7 +1896,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -2037,7 +2037,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -2124,7 +2124,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -2236,7 +2236,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -2340,7 +2340,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -2497,7 +2497,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -2645,7 +2645,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -2791,7 +2791,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -2905,7 +2905,7 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -3833,7 +3833,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -3978,7 +3978,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -4077,7 +4077,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -4204,7 +4204,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -4288,7 +4288,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -4410,7 +4410,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -4489,7 +4489,7 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -4615,7 +4615,7 @@
     }, {
       "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
-      "owl:cardinality" : 1,
+      "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:isDeleted"
       }
@@ -4708,7 +4708,7 @@
       "@id" : "xsd:boolean"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:BooleanValue"
+      "@id" : "knora-api:BooleanBase"
     },
     "rdfs:comment" : "Represents the literal boolean value of a BooleanValue.",
     "rdfs:label" : "Boolean value as decimal",
@@ -4733,7 +4733,7 @@
       "@id" : "xsd:string"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:ColorValue"
+      "@id" : "knora-api:ColorBase"
     },
     "rdfs:comment" : "Represents the literal RGB value of a ColorValue.",
     "rdfs:label" : "Color value as color",
@@ -4757,7 +4757,7 @@
       "@id" : "xsd:string"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:DateValue"
+      "@id" : "knora-api:DateBase"
     },
     "rdfs:comment" : "Represents the calendar of a date value.",
     "rdfs:label" : "Date value has calendar",
@@ -4771,7 +4771,7 @@
       "@id" : "xsd:integer"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:DateValue"
+      "@id" : "knora-api:DateBase"
     },
     "rdfs:comment" : "Represents the end day of a date value.",
     "rdfs:label" : "Date value has end day",
@@ -4785,7 +4785,7 @@
       "@id" : "xsd:string"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:DateValue"
+      "@id" : "knora-api:DateBase"
     },
     "rdfs:comment" : "Represents the end era of a date value.",
     "rdfs:label" : "Date value has end era",
@@ -4799,7 +4799,7 @@
       "@id" : "xsd:integer"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:DateValue"
+      "@id" : "knora-api:DateBase"
     },
     "rdfs:comment" : "Represents the end month of a date value.",
     "rdfs:label" : "Date value has end month",
@@ -4813,7 +4813,7 @@
       "@id" : "xsd:integer"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:DateValue"
+      "@id" : "knora-api:DateBase"
     },
     "rdfs:comment" : "Represents the end year of a date value.",
     "rdfs:label" : "Date value has end year",
@@ -4827,7 +4827,7 @@
       "@id" : "xsd:integer"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:DateValue"
+      "@id" : "knora-api:DateBase"
     },
     "rdfs:comment" : "Represents the start day of a date value.",
     "rdfs:label" : "Date value has start day",
@@ -4841,7 +4841,7 @@
       "@id" : "xsd:string"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:DateValue"
+      "@id" : "knora-api:DateBase"
     },
     "rdfs:comment" : "Represents the start era of a date value.",
     "rdfs:label" : "Date value has start era",
@@ -4855,7 +4855,7 @@
       "@id" : "xsd:integer"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:DateValue"
+      "@id" : "knora-api:DateBase"
     },
     "rdfs:comment" : "Represents the start month of a date value.",
     "rdfs:label" : "Date value has start month",
@@ -4869,7 +4869,7 @@
       "@id" : "xsd:integer"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:DateValue"
+      "@id" : "knora-api:DateBase"
     },
     "rdfs:comment" : "Represents the start year of a date value.",
     "rdfs:label" : "Date value has start year",
@@ -4883,7 +4883,7 @@
       "@id" : "xsd:decimal"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:DecimalValue"
+      "@id" : "knora-api:DecimalBase"
     },
     "rdfs:comment" : "Represents the literal decimal value of a DecimalValue.",
     "rdfs:label" : "Decimal value as decimal",
@@ -4911,6 +4911,14 @@
       "@id" : "knora-admin:User"
     },
     "rdfs:comment" : "Indicates who deleted a resource or value"
+  }, {
+    "@id" : "knora-api:error",
+    "@type" : "owl:DatatypeProperty",
+    "knora-api:objectType" : {
+      "@id" : "xsd:string"
+    },
+    "rdfs:comment" : "Provides an error message",
+    "rdfs:label" : "error"
   }, {
     "@id" : "knora-api:fileValueAsUrl",
     "@type" : "owl:DatatypeProperty",
@@ -5297,10 +5305,38 @@
       "@id" : "xsd:integer"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:IntValue"
+      "@id" : "knora-api:IntBase"
     },
     "rdfs:comment" : "Represents the literal integer value of an IntValue.",
     "rdfs:label" : "Integer value as integer",
+    "rdfs:subPropertyOf" : {
+      "@id" : "knora-api:valueHas"
+    }
+  }, {
+    "@id" : "knora-api:intervalValueHasEnd",
+    "@type" : "owl:DatatypeProperty",
+    "knora-api:objectType" : {
+      "@id" : "xsd:decimal"
+    },
+    "knora-api:subjectType" : {
+      "@id" : "knora-api:IntervalBase"
+    },
+    "rdfs:comment" : "Represents the end position of an interval.",
+    "rdfs:label" : "interval value has end",
+    "rdfs:subPropertyOf" : {
+      "@id" : "knora-api:valueHas"
+    }
+  }, {
+    "@id" : "knora-api:intervalValueHasStart",
+    "@type" : "owl:DatatypeProperty",
+    "knora-api:objectType" : {
+      "@id" : "xsd:decimal"
+    },
+    "knora-api:subjectType" : {
+      "@id" : "knora-api:IntervalBase"
+    },
+    "rdfs:comment" : "Represents the start position of an interval.",
+    "rdfs:label" : "interval value has start",
     "rdfs:subPropertyOf" : {
       "@id" : "knora-api:valueHas"
     }
@@ -5933,7 +5969,7 @@
       "@id" : "xsd:anyURI"
     },
     "knora-api:subjectType" : {
-      "@id" : "knora-api:UriValue"
+      "@id" : "knora-api:UriBase"
     },
     "rdfs:comment" : "Represents the literal URI value of a UriValue.",
     "rdfs:label" : "URI value as URI",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
@@ -2130,6 +2130,30 @@
       }
     }, {
       "@type" : "owl:Restriction",
+      "owl:maxCardinality" : 1,
+      "owl:onProperty" : {
+        "@id" : "knora-api:linkValueHasSource"
+      }
+    }, {
+      "@type" : "owl:Restriction",
+      "owl:maxCardinality" : 1,
+      "owl:onProperty" : {
+        "@id" : "knora-api:linkValueHasSourceIri"
+      }
+    }, {
+      "@type" : "owl:Restriction",
+      "owl:maxCardinality" : 1,
+      "owl:onProperty" : {
+        "@id" : "knora-api:linkValueHasTarget"
+      }
+    }, {
+      "@type" : "owl:Restriction",
+      "owl:maxCardinality" : 1,
+      "owl:onProperty" : {
+        "@id" : "knora-api:linkValueHasTargetIri"
+      }
+    }, {
+      "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
       "owl:cardinality" : 1,
       "owl:onProperty" : {
@@ -2155,24 +2179,6 @@
       "owl:maxCardinality" : 1,
       "owl:onProperty" : {
         "@id" : "knora-api:valueHasComment"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "rdf:object"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "rdf:predicate"
-      }
-    }, {
-      "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "rdf:subject"
       }
     } ]
   }, {
@@ -5550,6 +5556,34 @@
     "@type" : "owl:DatatypeProperty",
     "knora-api:objectType" : {
       "@id" : "xsd:dateTimeStamp"
+    }
+  }, {
+    "@id" : "knora-api:linkValueHasSource",
+    "@type" : "owl:ObjectProperty",
+    "knora-api:objectType" : {
+      "@id" : "knora-api:Resource"
+    },
+    "knora-api:subjectType" : {
+      "@id" : "knora-api:LinkValue"
+    },
+    "rdfs:comment" : "Represents the source resource of a link value.",
+    "rdfs:label" : "Link value has source",
+    "rdfs:subPropertyOf" : {
+      "@id" : "knora-api:valueHas"
+    }
+  }, {
+    "@id" : "knora-api:linkValueHasSourceIri",
+    "@type" : "owl:DatatypeProperty",
+    "knora-api:objectType" : {
+      "@id" : "xsd:anyURI"
+    },
+    "knora-api:subjectType" : {
+      "@id" : "knora-api:LinkValue"
+    },
+    "rdfs:comment" : "Represents the IRI of the source resource of a link value.",
+    "rdfs:label" : "Link value has source IRI",
+    "rdfs:subPropertyOf" : {
+      "@id" : "knora-api:valueHas"
     }
   }, {
     "@id" : "knora-api:linkValueHasTarget",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
@@ -18,50 +18,50 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic class for representing annotations</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b19"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Resource">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents something in the world, or an abstract thing</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Resource</rdfs:label>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b375"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b376"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b377"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b378"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b379"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b380"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b381"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b382"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b383"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b384"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b385"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b386"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b387"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b388"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b389"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b390"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b391"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b375"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b376"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b377"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b378"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b379"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b380"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b381"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b382"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b383"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b384"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b385"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b386"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b387"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b388"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b389"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b390"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b391"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b0">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -72,7 +72,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b1">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -83,7 +83,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b2">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -94,7 +94,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b3">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -105,7 +105,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b4">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -115,7 +115,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b5">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -125,7 +125,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b6">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -135,7 +135,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b7">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b7">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasComment">
@@ -150,7 +150,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b8">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -165,7 +165,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b9">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -174,7 +174,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b10">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -189,7 +189,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b11">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -204,7 +204,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b12">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b12">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOf">
@@ -218,7 +218,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b13">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b13">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOfValue">
@@ -231,9 +231,9 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b14">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b14">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isDeleted">
 			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
@@ -241,7 +241,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b15">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b15">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -250,7 +250,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b16">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b16">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -261,7 +261,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b17">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b17">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -272,7 +272,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b18">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b18">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -283,7 +283,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b19">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b19">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -292,42 +292,42 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an audio file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b32"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#FileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b175"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b176"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b177"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b178"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b179"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b180"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b181"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b182"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b183"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b184"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b185"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b186"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b175"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b176"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b177"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b178"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b179"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b180"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b181"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b182"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b183"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b184"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b185"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b186"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b20">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b20">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b21">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b21">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#audioFileValueHasDuration">
@@ -339,22 +339,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b22">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b22">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b23">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b23">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b24">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b24">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b25">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b25">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -367,7 +367,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b26">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b26">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -380,22 +380,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b27">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b27">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b28">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b28">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b29">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b29">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b30">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b30">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -406,7 +406,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b31">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b31">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -417,7 +417,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b32">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b32">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -434,85 +434,85 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containing audio data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Audio)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b50"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Representation">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can store a file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b357"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b358"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b359"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b360"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b361"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b362"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b363"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b364"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b365"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b366"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b367"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b368"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b369"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b370"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b371"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b372"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b373"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b374"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b357"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b358"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b359"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b360"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b361"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b362"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b363"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b364"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b365"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b366"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b367"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b368"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b369"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b370"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b371"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b372"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b373"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b374"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b33">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b33">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b34">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b34">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b35">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b35">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b36">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b36">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b37">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b37">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b38">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b38">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b39">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b39">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b40">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b40">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasAudioFileValue">
@@ -527,67 +527,67 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b41">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b41">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b42">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b42">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b43">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b43">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b44">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b44">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b45">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b45">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b46">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b46">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b47">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b47">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b48">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b48">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b49">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b49">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b50">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b50">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#BooleanBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b51"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b51">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b51">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean">
 			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanValue"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the literal boolean value of a BooleanValue.</rdfs:comment>
 			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Boolean value as decimal</rdfs:label>
 			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
@@ -599,84 +599,84 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b62"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Value">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The base class of classes representing Knora values</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b588"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b589"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b590"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b591"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b592"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b593"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b594"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b595"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b596"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b597"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b588"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b589"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b590"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b591"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b592"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b593"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b594"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b595"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b596"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b597"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b52">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b52">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b53">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b53">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b54">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b54">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b55">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b55">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b56">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b56">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b57">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b57">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b58">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b58">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b59">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b59">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b60">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b60">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b61">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b61">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b62">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b62">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -684,12 +684,12 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ColorBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b63">
+		<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b63">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor">
 					<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-					<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorValue"/>
+					<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 					<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the literal RGB value of a ColorValue.</rdfs:comment>
 					<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Color value as color</rdfs:label>
 					<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
@@ -703,69 +703,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in HTML format, e.g. "#33eeff"</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b66"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b68"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b71"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b74"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b64">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b64">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b65">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b65">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b66">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b66">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b67">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b67">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b68">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b68">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b69">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b69">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b70">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b70">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b71">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b71">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b72">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b72">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b73">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b73">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b74">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b74">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -774,75 +774,75 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This represents some 3D-object with mesh data, point cloud, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b77"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b79"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b81"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b83"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b84"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b85"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b86"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b85"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b86"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b75">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b75">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b76">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b76">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b77">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b77">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b78">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b78">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b79">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b79">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b80">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b80">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b81">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b81">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b82">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b82">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b83">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b83">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b84">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b84">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b85">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b85">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b86">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b86">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -852,61 +852,61 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containg 3D data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (3D)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b87"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b89"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b90"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b91"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b92"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b93"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b94"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b95"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b96"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b97"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b98"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b99"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b100"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b101"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b102"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b103"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b104"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b87"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b88"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b89"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b90"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b91"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b92"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b93"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b94"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b95"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b96"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b97"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b98"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b99"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b100"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b101"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b102"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b103"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b104"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b87">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b87">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b88">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b88">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b89">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b89">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b90">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b90">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b91">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b91">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b92">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b92">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b93">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b93">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b94">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b94">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDDDFileValue">
@@ -921,170 +921,170 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b95">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b95">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b96">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b96">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b97">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b97">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b98">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b98">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b99">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b99">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b100">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b100">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b101">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b101">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b102">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b102">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b103">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b103">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b104">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b104">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DateBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b105"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b106"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b107"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b108"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b109"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b110"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b111"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b112"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b113"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b105"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b106"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b107"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b108"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b109"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b110"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b111"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b112"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b113"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b105">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b105">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar">
 			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateValue"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the calendar of a date value.</rdfs:comment>
 			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date value has calendar</rdfs:label>
 			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b106">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b106">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay">
 			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateValue"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the end day of a date value.</rdfs:comment>
 			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date value has end day</rdfs:label>
 			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b107">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b107">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra">
 			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateValue"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the end era of a date value.</rdfs:comment>
 			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date value has end era</rdfs:label>
 			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b108">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b108">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth">
 			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateValue"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the end month of a date value.</rdfs:comment>
 			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date value has end month</rdfs:label>
 			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b109">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b109">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear">
 			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateValue"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the end year of a date value.</rdfs:comment>
 			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date value has end year</rdfs:label>
 			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b110">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b110">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay">
 			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateValue"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the start day of a date value.</rdfs:comment>
 			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date value has start day</rdfs:label>
 			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b111">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b111">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra">
 			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateValue"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the start era of a date value.</rdfs:comment>
 			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date value has start era</rdfs:label>
 			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b112">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b112">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth">
 			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateValue"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the start month of a date value.</rdfs:comment>
 			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date value has start month</rdfs:label>
 			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b113">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b113">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear">
 			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateValue"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the start year of a date value.</rdfs:comment>
 			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date value has start year</rdfs:label>
 			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
@@ -1096,117 +1096,117 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Knora date value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b114"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b115"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b116"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b117"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b118"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b119"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b120"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b121"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b122"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b123"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b124"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b125"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b126"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b127"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b128"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b129"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b130"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b131"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b132"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b114"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b115"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b116"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b117"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b118"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b119"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b120"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b121"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b122"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b123"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b124"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b125"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b126"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b127"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b128"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b129"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b130"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b131"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b132"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b114">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b114">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b115">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b115">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b116">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b116">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b117">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b117">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b118">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b118">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b119">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b119">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b120">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b120">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b121">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b121">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b122">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b122">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b123">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b123">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b124">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b124">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b125">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b125">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b126">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b126">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b127">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b127">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b128">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b128">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b129">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b129">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b130">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b130">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b131">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b131">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b132">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b132">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1214,12 +1214,12 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DecimalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b133">
+		<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b133">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal">
 					<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
-					<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalValue"/>
+					<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 					<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the literal decimal value of a DecimalValue.</rdfs:comment>
 					<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Decimal value as decimal</rdfs:label>
 					<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
@@ -1233,69 +1233,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary-precision decimal value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b134"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b135"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b136"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b137"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b138"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b139"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b140"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b141"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b142"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b143"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b144"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b134"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b135"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b136"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b137"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b138"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b139"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b140"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b141"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b142"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b143"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b144"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b134">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b134">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b135">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b135">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b136">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b136">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b137">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b137">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b138">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b138">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b139">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b139">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b140">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b140">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b141">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b141">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b142">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b142">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b143">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b143">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b144">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b144">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1303,75 +1303,75 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DocumentFileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b145"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b146"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b147"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b148"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b149"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b150"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b151"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b152"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b153"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b154"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b155"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b156"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b145"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b146"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b147"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b148"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b149"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b150"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b151"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b152"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b153"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b154"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b155"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b156"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b145">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b145">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b146">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b146">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b147">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b147">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b148">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b148">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b149">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b149">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b150">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b150">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b151">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b151">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b152">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b152">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b153">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b153">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b154">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b154">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b155">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b155">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b156">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b156">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1380,61 +1380,61 @@
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Document)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b157"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b158"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b159"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b160"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b161"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b162"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b163"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b164"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b165"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b166"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b167"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b168"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b169"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b170"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b171"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b172"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b173"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b174"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b157"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b158"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b159"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b160"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b161"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b162"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b163"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b164"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b165"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b166"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b167"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b168"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b169"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b170"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b171"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b172"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b173"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b174"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b157">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b157">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b158">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b158">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b159">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b159">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b160">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b160">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b161">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b161">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b162">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b162">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b163">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b163">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b164">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b164">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDocumentFileValue">
@@ -1449,110 +1449,110 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b165">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b165">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b166">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b166">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b167">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b167">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b168">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b168">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b169">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b169">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b170">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b170">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b171">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b171">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b172">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b172">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b173">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b173">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b174">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b174">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b175">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b175">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b176">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b176">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b177">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b177">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b178">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b178">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b179">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b179">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b180">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b180">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b181">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b181">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b182">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b182">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b183">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b183">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b184">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b184">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b185">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b185">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b186">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b186">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1562,110 +1562,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b187"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b188"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b189"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b190"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b191"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b192"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b193"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b194"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b195"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b196"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b197"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b198"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b199"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b200"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b201"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b202"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b203"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b204"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b187"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b188"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b189"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b190"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b191"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b192"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b193"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b194"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b195"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b196"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b197"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b198"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b199"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b200"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b201"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b202"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b203"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b204"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b187">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b187">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b188">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b188">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b189">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b189">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b190">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b190">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b191">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b191">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b192">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b192">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b193">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b193">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b194">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b194">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b195">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b195">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b196">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b196">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b197">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b197">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b198">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b198">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b199">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b199">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b200">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b200">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b201">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b201">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b202">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b202">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b203">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b203">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b204">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b204">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -1674,39 +1674,39 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometrical objects as JSON string</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b205"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b206"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b207"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b208"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b209"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b210"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b211"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b212"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b213"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b214"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b215"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b205"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b206"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b207"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b208"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b209"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b210"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b211"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b212"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b213"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b214"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b215"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b205">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b205">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b206">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b206">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b207">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b207">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b208">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b208">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b209">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b209">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geometryValueAsGeometry">
@@ -1718,32 +1718,32 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b210">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b210">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b211">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b211">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b212">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b212">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b213">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b213">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b214">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b214">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b215">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b215">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1751,39 +1751,39 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#GeonameValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b216"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b217"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b218"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b219"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b220"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b221"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b222"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b223"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b224"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b225"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b226"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b216"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b217"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b218"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b219"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b220"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b221"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b222"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b223"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b224"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b225"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b226"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b216">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b216">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b217">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b217">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b218">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b218">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b219">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b219">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b220">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b220">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geonameValueAsGeonameCode">
@@ -1795,32 +1795,32 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b221">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b221">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b222">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b222">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b223">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b223">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b224">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b224">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b225">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b225">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b226">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b226">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1828,12 +1828,12 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b227">
+		<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b227">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intValueAsInt">
 					<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-					<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntValue"/>
+					<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 					<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the literal integer value of an IntValue.</rdfs:comment>
 					<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Integer value as integer</rdfs:label>
 					<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
@@ -1847,160 +1847,176 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b228"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b229"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b230"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b231"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b232"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b233"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b234"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b235"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b236"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b237"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b238"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b228"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b229"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b230"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b231"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b232"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b233"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b234"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b235"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b236"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b237"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b238"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b228">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b228">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b229">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b229">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b230">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b230">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b231">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b231">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b232">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b232">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b233">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b233">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b234">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b234">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b235">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b235">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b236">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b236">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b237">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b237">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b238">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b238">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntervalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b239"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b240"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b239"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b240"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b239">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b239">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
+	<owl:onProperty>
+		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd">
+			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
+			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the end position of an interval.</rdfs:comment>
+			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">interval value has end</rdfs:label>
+			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
+		</owl:DatatypeProperty>
+	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b240">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b240">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
+	<owl:onProperty>
+		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart">
+			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
+			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the start position of an interval.</rdfs:comment>
+			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">interval value has start</rdfs:label>
+			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
+		</owl:DatatypeProperty>
+	</owl:onProperty>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntervalValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a time interval, e.g. in an audio recording</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b241"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b242"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b243"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b244"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b245"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b246"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b247"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b248"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b249"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b250"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b251"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b252"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b241"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b242"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b243"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b244"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b245"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b246"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b247"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b248"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b249"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b250"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b251"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b252"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b241">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b241">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b242">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b242">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b243">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b243">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b244">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b244">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b245">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b245">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b246">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b246">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b247">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b247">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b248">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b248">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b249">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b249">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b250">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b250">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b251">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b251">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b252">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b252">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2012,72 +2028,72 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a generic link object</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link Object</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b253"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b254"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b255"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b256"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b257"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b258"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b259"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b260"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b261"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b262"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b263"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b264"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b265"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b266"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b267"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b268"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b269"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b270"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b271"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b272"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b253"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b254"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b255"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b256"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b257"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b258"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b259"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b260"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b261"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b262"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b263"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b264"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b265"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b266"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b267"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b268"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b269"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b270"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b271"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b272"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b253">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b253">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b254">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b254">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b255">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b255">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b256">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b256">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b257">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b257">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b258">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b258">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b259">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b259">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b260">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b260">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b261">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b261">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b262">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b262">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkTo">
@@ -2092,7 +2108,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b263">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b263">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkToValue">
@@ -2107,47 +2123,47 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b264">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b264">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b265">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b265">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b266">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b266">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b267">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b267">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b268">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b268">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b269">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b269">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b270">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b270">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b271">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b271">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b272">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b272">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -2157,142 +2173,142 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A reification node that describes direct links between resources</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
 	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b273"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b274"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b275"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b276"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b277"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b278"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b279"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b280"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b281"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b282"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b283"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b284"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b285"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b273"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b274"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b275"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b276"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b277"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b278"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b279"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b280"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b281"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b282"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b283"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b284"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b285"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b273">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b273">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b274">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b274">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b275">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b275">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b276">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b276">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b277">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b277">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b278">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b278">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b279">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b279">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b280">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b280">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b281">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b281">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b282">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b282">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b283">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b283">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#object"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b284">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b284">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b285">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b285">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListNode">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a flat or hierarchical list</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b286"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b287"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b286"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b287"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b286">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b286">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b287">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b287">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b288"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b289"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b290"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b291"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b292"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b293"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b294"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b295"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b296"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b297"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b298"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b299"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b288"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b289"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b290"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b291"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b292"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b293"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b294"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b295"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b296"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b297"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b298"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b299"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b288">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b288">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b289">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b289">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b290">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b290">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b291">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b291">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b292">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b292">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b293">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b293">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b294">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b294">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#listValueAsListNode">
@@ -2304,7 +2320,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b295">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b295">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#listValueAsListNodeLabel">
@@ -2316,22 +2332,22 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b296">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b296">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b297">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b297">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b298">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b298">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b299">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b299">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2340,65 +2356,65 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a moving image file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b300"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b301"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b302"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b303"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b304"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b305"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b306"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b307"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b308"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b309"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b310"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b311"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b312"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b313"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b314"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b315"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b316"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b300"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b301"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b302"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b303"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b304"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b305"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b306"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b307"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b308"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b309"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b310"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b311"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b312"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b313"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b314"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b315"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b316"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b300">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b300">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b301">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b301">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b302">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b302">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b303">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b303">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b304">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b304">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b305">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b305">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b306">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b306">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b307">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b307">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b308">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b308">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimX">
@@ -2410,7 +2426,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b309">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b309">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimY">
@@ -2422,7 +2438,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b310">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b310">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDuration">
@@ -2434,7 +2450,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b311">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b311">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasFps">
@@ -2446,7 +2462,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b312">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b312">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasQualityLevel">
@@ -2458,22 +2474,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b313">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b313">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b314">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b314">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b315">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b315">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b316">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b316">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2483,66 +2499,66 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing moving image data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Movie)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b317"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b318"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b319"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b320"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b321"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b322"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b323"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b324"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b325"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b326"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b327"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b328"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b329"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b330"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b331"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b332"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b333"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b334"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b317"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b318"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b319"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b320"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b321"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b322"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b323"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b324"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b325"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b326"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b327"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b328"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b329"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b330"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b331"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b332"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b333"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b334"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b317">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b317">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b318">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b318">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b319">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b319">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b320">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b320">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b321">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b321">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b322">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b322">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b323">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b323">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b324">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b324">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b325">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b325">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasMovingImageFileValue">
@@ -2557,47 +2573,47 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b326">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b326">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b327">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b327">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b328">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b328">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b329">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b329">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b330">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b330">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b331">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b331">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b332">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b332">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b333">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b333">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b334">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b334">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -2609,65 +2625,65 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometric region of a resource. The geometry is represented currently as JSON string.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b335"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b336"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b337"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b338"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b339"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b340"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b341"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b342"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b343"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b344"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b345"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b346"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b347"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b348"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b349"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b350"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b351"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b352"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b353"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b354"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b355"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b356"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b335"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b336"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b337"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b338"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b339"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b340"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b341"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b342"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b343"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b344"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b345"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b346"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b347"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b348"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b349"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b350"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b351"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b352"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b353"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b354"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b355"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b356"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b335">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b335">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b336">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b336">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b337">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b337">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b338">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b338">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b339">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b339">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b340">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b340">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b341">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b341">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b342">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b342">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasColor">
@@ -2683,11 +2699,11 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b343">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b343">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b344">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b344">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasGeometry">
@@ -2702,32 +2718,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b345">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b345">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b346">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b346">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b347">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b347">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b348">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b348">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b349">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b349">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b350">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b350">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOf">
@@ -2742,7 +2758,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b351">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b351">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOfValue">
@@ -2757,67 +2773,67 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b352">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b352">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b353">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b353">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b354">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b354">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b355">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b355">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b356">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b356">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b357">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b357">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b358">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b358">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b359">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b359">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b360">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b360">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b361">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b361">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b362">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b362">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b363">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b363">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b364">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b364">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasFileValue">
@@ -2831,121 +2847,121 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b365">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b365">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b366">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b366">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b367">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b367">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b368">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b368">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b369">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b369">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b370">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b370">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b371">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b371">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b372">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b372">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b373">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b373">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b374">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b374">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b375">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b375">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b376">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b376">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b377">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b377">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b378">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b378">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b379">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b379">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b380">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b380">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b381">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b381">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b382">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b382">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b383">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b383">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b384">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b384">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b385">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b385">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b386">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b386">
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b387">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b387">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b388">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b388">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b389">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b389">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b390">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b390">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b391">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b391">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -2954,35 +2970,35 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b392"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b393"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b394"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b395"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b396"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b397"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b398"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b399"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b400"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b392"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b393"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b394"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b395"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b396"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b397"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b398"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b399"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b400"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a knora-base value type in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b410"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b411"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b412"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b413"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b414"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b415"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b416"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b417"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b410"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b411"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b412"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b413"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b414"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b415"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b416"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b417"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b392">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b392">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b393">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b393">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -2992,7 +3008,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b394">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b394">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3002,7 +3018,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b395">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b395">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3012,7 +3028,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b396">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b396">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3022,7 +3038,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b397">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b397">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3032,7 +3048,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b398">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b398">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3042,7 +3058,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b399">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b399">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3053,7 +3069,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b400">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b400">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3068,57 +3084,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b401"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b402"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b403"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b404"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b405"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b406"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b407"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b408"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b409"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b401"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b402"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b403"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b404"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b405"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b406"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b407"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b408"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b409"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b401">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b401">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b402">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b402">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b403">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b403">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b404">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b404">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b405">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b405">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b406">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b406">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b407">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b407">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b408">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b408">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b409">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b409">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3126,51 +3142,51 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a standoff markup tag</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b481"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b482"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b483"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b484"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b485"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b486"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b487"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b488"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b481"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b482"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b483"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b484"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b485"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b486"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b487"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b488"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b410">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b410">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b411">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b411">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b412">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b412">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b413">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b413">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b414">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b414">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b415">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b415">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b416">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b416">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b417">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b417">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3180,105 +3196,105 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b418"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b419"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b420"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b421"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b422"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b423"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b424"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b425"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b426"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b427"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b428"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b429"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b430"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b431"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b432"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b433"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b434"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b418"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b419"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b420"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b421"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b422"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b423"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b424"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b425"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b426"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b427"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b428"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b429"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b430"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b431"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b432"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b433"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b434"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b418">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b418">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b419">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b419">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b420">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b420">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b421">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b421">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b422">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b422">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b423">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b423">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b424">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b424">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b425">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b425">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b426">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b426">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b427">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b427">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b428">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b428">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b429">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b429">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b430">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b430">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b431">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b431">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b432">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b432">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b433">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b433">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b434">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b434">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3288,57 +3304,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a decimal (floating point) value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b435"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b436"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b437"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b438"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b439"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b440"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b441"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b442"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b443"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b435"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b436"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b437"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b438"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b439"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b440"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b441"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b442"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b443"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b435">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b435">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b436">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b436">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b437">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b437">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b438">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b438">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b439">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b439">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b440">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b440">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b441">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b441">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b442">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b442">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b443">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b443">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3348,57 +3364,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b444"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b445"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b446"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b447"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b448"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b449"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b450"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b451"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b452"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b444"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b445"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b446"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b447"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b448"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b449"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b450"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b451"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b452"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b444">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b444">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b445">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b445">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b446">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b446">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b447">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b447">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b448">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b448">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b449">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b449">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b450">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b450">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b451">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b451">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b452">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b452">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3408,32 +3424,32 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an internal reference in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b453"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b454"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b455"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b456"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b457"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b458"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b459"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b460"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b461"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b453"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b454"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b455"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b456"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b457"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b458"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b459"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b460"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b461"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b453">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b453">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b454">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b454">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b455">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b455">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b456">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b456">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasInternalReference">
@@ -3442,27 +3458,27 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b457">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b457">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b458">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b458">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b459">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b459">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b460">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b460">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b461">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b461">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3472,63 +3488,63 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an interval in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b462"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b463"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b464"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b465"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b466"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b467"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b468"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b469"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b470"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b471"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b462"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b463"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b464"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b465"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b466"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b467"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b468"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b469"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b470"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b471"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b462">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b462">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b463">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b463">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b464">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b464">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b465">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b465">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b466">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b466">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b467">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b467">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b468">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b468">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b469">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b469">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b470">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b470">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b471">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b471">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3537,32 +3553,32 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a reference to a Knora resource in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b472"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b473"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b474"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b475"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b476"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b477"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b478"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b479"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b480"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b472"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b473"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b474"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b475"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b476"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b477"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b478"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b479"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b480"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b472">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b472">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b473">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b473">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b474">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b474">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b475">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b475">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasLink">
@@ -3571,60 +3587,60 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b476">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b476">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b477">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b477">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b478">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b478">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b479">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b479">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b480">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b480">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b481">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b481">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b482">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b482">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b483">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b483">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b484">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b484">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b485">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b485">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b486">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b486">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b487">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b487">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b488">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b488">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
@@ -3633,67 +3649,67 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary URI in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b489"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b490"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b491"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b492"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b493"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b494"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b495"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b496"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b497"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b489"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b490"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b491"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b492"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b493"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b494"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b495"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b496"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b497"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#UriBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b576"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b576"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b489">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b489">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b490">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b490">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b491">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b491">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b492">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b492">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b493">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b493">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b494">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b494">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b495">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b495">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b496">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b496">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b497">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b497">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri">
 			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriValue"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
 			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the literal URI value of a UriValue.</rdfs:comment>
 			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">URI value as URI</rdfs:label>
 			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
@@ -3704,63 +3720,63 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A file containing a two-dimensional still image</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b498"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b499"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b500"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b501"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b502"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b503"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b504"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b505"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b506"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b507"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b508"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b509"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b510"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b511"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b512"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b498"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b499"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b500"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b501"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b502"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b503"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b504"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b505"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b506"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b507"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b508"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b509"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b510"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b511"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b512"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b498">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b498">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b499">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b499">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b500">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b500">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b501">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b501">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b502">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b502">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b503">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b503">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b504">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b504">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b505">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b505">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b506">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b506">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimX">
@@ -3772,7 +3788,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b507">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b507">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimY">
@@ -3784,7 +3800,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b508">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b508">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasIIIFBaseUrl">
@@ -3796,22 +3812,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b509">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b509">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b510">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b510">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b511">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b511">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b512">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b512">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -3821,81 +3837,81 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can contain a two-dimensional still image file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Image)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b513"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b514"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b515"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b516"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b517"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b518"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b519"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b520"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b521"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b522"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b523"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b524"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b525"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b526"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b527"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b528"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b529"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b530"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b513"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b514"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b515"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b516"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b517"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b518"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b519"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b520"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b521"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b522"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b523"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b524"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b525"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b526"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b527"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b528"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b529"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b530"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b513">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b513">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b514">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b514">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b515">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b515">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b516">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b516">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b517">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b517">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b518">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b518">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b519">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b519">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b520">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b520">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b521">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b521">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b522">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b522">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b523">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b523">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b524">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b524">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue">
@@ -3910,32 +3926,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b525">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b525">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b526">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b526">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b527">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b527">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b528">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b528">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b529">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b529">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b530">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b530">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -3944,75 +3960,75 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A text file such as plain Unicode text, LaTeX, TEI/XML, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b531"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b532"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b533"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b534"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b535"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b536"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b537"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b538"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b539"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b540"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b541"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b542"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b531"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b532"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b533"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b534"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b535"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b536"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b537"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b538"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b539"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b540"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b541"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b542"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b531">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b531">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b532">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b532">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b533">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b533">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b534">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b534">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b535">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b535">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b536">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b536">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b537">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b537">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b538">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b538">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b539">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b539">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b540">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b540">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b541">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b541">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b542">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b542">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -4022,81 +4038,81 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing a text file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Text)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b543"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b544"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b545"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b546"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b547"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b548"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b549"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b550"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b551"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b552"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b553"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b554"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b555"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b556"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b557"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b558"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b559"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b560"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b543"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b544"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b545"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b546"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b547"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b548"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b549"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b550"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b551"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b552"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b553"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b554"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b555"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b556"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b557"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b558"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b559"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b560"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b543">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b543">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b544">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b544">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b545">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b545">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b546">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b546">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b547">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b547">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b548">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b548">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b549">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b549">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b550">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b550">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b551">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b551">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b552">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b552">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b553">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b553">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b554">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b554">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue">
@@ -4111,32 +4127,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b555">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b555">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b556">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b556">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b557">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b557">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b558">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b558">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b559">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b559">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b560">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b560">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -4144,53 +4160,53 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#TextValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b561"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b562"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b563"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b564"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b565"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b566"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b567"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b568"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b569"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b570"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b571"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b572"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b573"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b574"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b575"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b561"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b562"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b563"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b564"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b565"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b566"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b567"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b568"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b569"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b570"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b571"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b572"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b573"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b574"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b575"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b561">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b561">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b562">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b562">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b563">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b563">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b564">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b564">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b565">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b565">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b566">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b566">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b567">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b567">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsHtml">
@@ -4202,7 +4218,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b568">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b568">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsXml">
@@ -4214,7 +4230,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b569">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b569">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasLanguage">
@@ -4226,7 +4242,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b570">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b570">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMapping">
@@ -4238,7 +4254,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b571">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b571">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasStandoff">
@@ -4250,27 +4266,27 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b572">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b572">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b573">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b573">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b574">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b574">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b575">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b575">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b576">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b576">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
@@ -4279,110 +4295,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a URI</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b577"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b578"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b579"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b580"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b581"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b582"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b583"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b584"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b585"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b586"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b587"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b577"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b578"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b579"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b580"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b581"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b582"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b583"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b584"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b585"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b586"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b587"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b577">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b577">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b578">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b578">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b579">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b579">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b580">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b580">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b581">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b581">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b582">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b582">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b583">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b583">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b584">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b584">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b585">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b585">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b586">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b586">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b587">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b587">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b588">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b588">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b589">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b589">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b590">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b590">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b591">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b591">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b592">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b592">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b593">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b593">
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b594">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b594">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b595">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b595">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b596">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b596">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b597">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b597">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
@@ -4391,110 +4407,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff.  The transformation's result is ecptected to be HTML.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff. The transformation's result is ecptected to be HTML.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#TextRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b598"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b599"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b600"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b601"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b602"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b603"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b604"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b605"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b606"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b607"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b608"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b609"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b610"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b611"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b612"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b613"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b614"/>
-	<rdfs:subClassOf rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b615"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b598"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b599"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b600"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b601"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b602"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b603"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b604"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b605"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b606"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b607"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b608"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b609"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b610"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b611"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b612"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b613"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b614"/>
+	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b615"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b598">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b598">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b599">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b599">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b600">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b600">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b601">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b601">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b602">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b602">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b603">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b603">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b604">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b604">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b605">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b605">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b606">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b606">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b607">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b607">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b608">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b608">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b609">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b609">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b610">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b610">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b611">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b611">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b612">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b612">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b613">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b613">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b614">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b614">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-416fdf4815fb4fb99f12a698af808ab5-b615">
+<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b615">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -4513,6 +4529,11 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Indicates whether a resource class can be instantiated via the Knora API.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">can be instantiated</rdfs:label>
 </owl:AnnotationProperty>
+<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#error">
+	<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Provides an error message</rdfs:comment>
+	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">error</rdfs:label>
+</owl:DatatypeProperty>
 <owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasValue">
 	<knora-api:isResourceProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceProperty>
 	<knora-api:objectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
@@ -18,50 +18,50 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic class for representing annotations</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b19"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Resource">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents something in the world, or an abstract thing</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Resource</rdfs:label>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b375"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b376"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b377"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b378"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b379"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b380"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b381"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b382"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b383"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b384"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b385"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b386"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b387"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b388"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b389"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b390"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b391"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b376"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b377"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b378"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b379"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b380"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b381"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b382"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b383"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b384"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b385"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b386"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b387"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b388"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b389"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b390"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b391"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b392"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b0">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -72,7 +72,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b1">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -83,7 +83,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b2">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -94,7 +94,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b3">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -105,7 +105,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b4">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -115,7 +115,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b5">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -125,7 +125,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b6">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -135,7 +135,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b7">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b7">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasComment">
@@ -150,7 +150,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b8">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -165,7 +165,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b9">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -174,7 +174,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b10">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -189,7 +189,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b11">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -204,7 +204,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b12">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b12">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOf">
@@ -218,7 +218,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b13">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b13">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOfValue">
@@ -231,7 +231,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b14">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b14">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -241,7 +241,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b15">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b15">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -250,7 +250,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b16">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b16">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -261,7 +261,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b17">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b17">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -272,7 +272,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b18">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b18">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -283,7 +283,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b19">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b19">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -292,42 +292,42 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an audio file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b32"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#FileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b175"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b176"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b177"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b178"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b179"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b180"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b181"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b182"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b183"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b184"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b185"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b186"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b175"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b176"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b177"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b178"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b179"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b180"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b181"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b182"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b183"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b184"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b185"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b186"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b20">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b20">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b21">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b21">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#audioFileValueHasDuration">
@@ -339,22 +339,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b22">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b22">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b23">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b23">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b24">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b24">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b25">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b25">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -367,7 +367,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b26">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b26">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -380,22 +380,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b27">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b27">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b28">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b28">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b29">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b29">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b30">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b30">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -406,7 +406,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b31">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b31">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -417,7 +417,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b32">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b32">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -434,85 +434,85 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containing audio data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Audio)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b50"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Representation">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can store a file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b357"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b358"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b359"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b360"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b361"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b362"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b363"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b364"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b365"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b366"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b367"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b368"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b369"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b370"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b371"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b372"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b373"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b374"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b358"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b359"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b360"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b361"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b362"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b363"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b364"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b365"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b366"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b367"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b368"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b369"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b370"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b371"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b372"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b373"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b374"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b375"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b33">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b33">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b34">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b34">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b35">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b35">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b36">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b36">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b37">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b37">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b38">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b38">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b39">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b39">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b40">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b40">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasAudioFileValue">
@@ -527,62 +527,62 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b41">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b41">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b42">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b42">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b43">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b43">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b44">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b44">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b45">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b45">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b46">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b46">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b47">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b47">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b48">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b48">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b49">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b49">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b50">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b50">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#BooleanBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b51"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b51">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b51">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean">
@@ -599,84 +599,84 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b62"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Value">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The base class of classes representing Knora values</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b588"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b589"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b590"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b591"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b592"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b593"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b594"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b595"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b596"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b597"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b589"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b590"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b591"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b592"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b593"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b594"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b595"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b596"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b597"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b598"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b52">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b52">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b53">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b53">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b54">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b54">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b55">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b55">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b56">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b56">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b57">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b57">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b58">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b58">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b59">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b59">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b60">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b60">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b61">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b61">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b62">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b62">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -684,7 +684,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ColorBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b63">
+		<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b63">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor">
@@ -703,69 +703,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in HTML format, e.g. "#33eeff"</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b66"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b68"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b71"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b74"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b64">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b64">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b65">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b65">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b66">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b66">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b67">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b67">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b68">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b68">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b69">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b69">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b70">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b70">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b71">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b71">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b72">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b72">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b73">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b73">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b74">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b74">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -774,75 +774,75 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This represents some 3D-object with mesh data, point cloud, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b77"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b79"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b81"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b83"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b84"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b85"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b86"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b85"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b86"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b75">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b75">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b76">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b76">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b77">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b77">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b78">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b78">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b79">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b79">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b80">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b80">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b81">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b81">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b82">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b82">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b83">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b83">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b84">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b84">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b85">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b85">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b86">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b86">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -852,61 +852,61 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containg 3D data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (3D)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b87"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b89"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b90"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b91"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b92"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b93"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b94"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b95"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b96"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b97"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b98"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b99"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b100"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b101"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b102"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b103"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b104"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b87"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b88"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b89"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b90"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b91"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b92"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b93"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b94"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b95"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b96"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b97"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b98"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b99"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b100"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b101"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b102"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b103"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b104"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b87">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b87">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b88">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b88">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b89">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b89">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b90">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b90">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b91">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b91">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b92">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b92">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b93">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b93">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b94">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b94">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDDDFileValue">
@@ -921,69 +921,69 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b95">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b95">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b96">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b96">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b97">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b97">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b98">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b98">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b99">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b99">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b100">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b100">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b101">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b101">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b102">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b102">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b103">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b103">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b104">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b104">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DateBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b105"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b106"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b107"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b108"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b109"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b110"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b111"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b112"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b113"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b105"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b106"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b107"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b108"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b109"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b110"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b111"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b112"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b113"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b105">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b105">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar">
@@ -995,7 +995,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b106">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b106">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay">
@@ -1007,7 +1007,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b107">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b107">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra">
@@ -1019,7 +1019,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b108">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b108">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth">
@@ -1031,7 +1031,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b109">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b109">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear">
@@ -1043,7 +1043,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b110">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b110">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay">
@@ -1055,7 +1055,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b111">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b111">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra">
@@ -1067,7 +1067,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b112">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b112">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth">
@@ -1079,7 +1079,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b113">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b113">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear">
@@ -1096,117 +1096,117 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Knora date value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b114"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b115"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b116"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b117"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b118"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b119"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b120"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b121"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b122"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b123"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b124"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b125"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b126"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b127"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b128"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b129"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b130"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b131"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b132"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b114"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b115"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b116"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b117"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b118"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b119"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b120"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b121"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b122"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b123"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b124"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b125"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b126"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b127"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b128"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b129"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b130"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b131"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b132"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b114">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b114">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b115">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b115">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b116">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b116">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b117">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b117">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b118">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b118">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b119">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b119">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b120">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b120">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b121">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b121">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b122">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b122">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b123">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b123">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b124">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b124">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b125">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b125">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b126">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b126">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b127">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b127">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b128">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b128">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b129">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b129">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b130">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b130">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b131">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b131">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b132">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b132">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1214,7 +1214,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DecimalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b133">
+		<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b133">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal">
@@ -1233,69 +1233,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary-precision decimal value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b134"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b135"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b136"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b137"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b138"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b139"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b140"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b141"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b142"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b143"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b144"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b134"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b135"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b136"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b137"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b138"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b139"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b140"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b141"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b142"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b143"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b144"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b134">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b134">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b135">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b135">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b136">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b136">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b137">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b137">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b138">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b138">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b139">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b139">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b140">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b140">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b141">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b141">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b142">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b142">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b143">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b143">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b144">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b144">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1303,75 +1303,75 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DocumentFileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b145"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b146"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b147"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b148"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b149"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b150"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b151"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b152"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b153"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b154"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b155"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b156"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b145"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b146"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b147"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b148"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b149"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b150"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b151"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b152"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b153"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b154"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b155"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b156"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b145">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b145">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b146">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b146">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b147">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b147">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b148">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b148">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b149">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b149">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b150">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b150">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b151">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b151">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b152">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b152">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b153">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b153">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b154">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b154">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b155">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b155">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b156">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b156">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1380,61 +1380,61 @@
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Document)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b157"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b158"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b159"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b160"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b161"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b162"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b163"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b164"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b165"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b166"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b167"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b168"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b169"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b170"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b171"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b172"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b173"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b174"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b157"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b158"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b159"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b160"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b161"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b162"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b163"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b164"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b165"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b166"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b167"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b168"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b169"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b170"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b171"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b172"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b173"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b174"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b157">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b157">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b158">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b158">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b159">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b159">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b160">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b160">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b161">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b161">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b162">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b162">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b163">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b163">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b164">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b164">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDocumentFileValue">
@@ -1449,110 +1449,110 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b165">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b165">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b166">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b166">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b167">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b167">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b168">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b168">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b169">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b169">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b170">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b170">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b171">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b171">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b172">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b172">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b173">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b173">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b174">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b174">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b175">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b175">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b176">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b176">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b177">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b177">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b178">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b178">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b179">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b179">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b180">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b180">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b181">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b181">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b182">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b182">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b183">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b183">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b184">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b184">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b185">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b185">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b186">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b186">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1562,110 +1562,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b187"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b188"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b189"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b190"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b191"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b192"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b193"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b194"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b195"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b196"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b197"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b198"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b199"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b200"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b201"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b202"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b203"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b204"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b187"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b188"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b189"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b190"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b191"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b192"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b193"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b194"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b195"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b196"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b197"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b198"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b199"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b200"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b201"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b202"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b203"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b204"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b187">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b187">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b188">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b188">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b189">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b189">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b190">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b190">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b191">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b191">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b192">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b192">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b193">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b193">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b194">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b194">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b195">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b195">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b196">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b196">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b197">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b197">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b198">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b198">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b199">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b199">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b200">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b200">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b201">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b201">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b202">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b202">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b203">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b203">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b204">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b204">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -1674,39 +1674,39 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometrical objects as JSON string</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b205"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b206"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b207"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b208"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b209"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b210"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b211"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b212"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b213"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b214"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b215"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b205"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b206"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b207"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b208"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b209"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b210"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b211"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b212"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b213"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b214"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b215"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b205">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b205">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b206">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b206">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b207">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b207">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b208">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b208">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b209">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b209">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geometryValueAsGeometry">
@@ -1718,32 +1718,32 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b210">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b210">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b211">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b211">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b212">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b212">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b213">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b213">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b214">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b214">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b215">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b215">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1751,39 +1751,39 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#GeonameValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b216"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b217"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b218"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b219"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b220"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b221"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b222"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b223"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b224"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b225"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b226"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b216"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b217"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b218"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b219"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b220"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b221"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b222"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b223"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b224"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b225"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b226"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b216">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b216">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b217">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b217">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b218">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b218">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b219">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b219">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b220">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b220">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geonameValueAsGeonameCode">
@@ -1795,32 +1795,32 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b221">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b221">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b222">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b222">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b223">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b223">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b224">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b224">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b225">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b225">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b226">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b226">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1828,7 +1828,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b227">
+		<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b227">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intValueAsInt">
@@ -1847,79 +1847,79 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b228"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b229"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b230"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b231"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b232"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b233"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b234"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b235"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b236"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b237"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b238"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b228"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b229"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b230"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b231"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b232"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b233"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b234"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b235"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b236"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b237"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b238"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b228">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b228">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b229">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b229">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b230">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b230">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b231">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b231">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b232">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b232">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b233">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b233">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b234">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b234">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b235">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b235">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b236">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b236">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b237">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b237">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b238">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b238">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntervalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b239"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b240"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b239"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b240"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b239">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b239">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd">
@@ -1931,7 +1931,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b240">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b240">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart">
@@ -1948,75 +1948,75 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a time interval, e.g. in an audio recording</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b241"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b242"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b243"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b244"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b245"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b246"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b247"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b248"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b249"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b250"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b251"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b252"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b241"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b242"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b243"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b244"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b245"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b246"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b247"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b248"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b249"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b250"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b251"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b252"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b241">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b241">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b242">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b242">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b243">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b243">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b244">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b244">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b245">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b245">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b246">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b246">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b247">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b247">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b248">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b248">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b249">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b249">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b250">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b250">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b251">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b251">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b252">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b252">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2028,72 +2028,72 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a generic link object</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link Object</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b253"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b254"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b255"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b256"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b257"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b258"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b259"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b260"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b261"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b262"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b263"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b264"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b265"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b266"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b267"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b268"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b269"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b270"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b271"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b272"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b253"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b254"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b255"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b256"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b257"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b258"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b259"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b260"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b261"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b262"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b263"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b264"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b265"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b266"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b267"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b268"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b269"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b270"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b271"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b272"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b253">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b253">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b254">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b254">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b255">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b255">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b256">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b256">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b257">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b257">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b258">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b258">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b259">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b259">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b260">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b260">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b261">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b261">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b262">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b262">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkTo">
@@ -2108,7 +2108,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b263">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b263">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkToValue">
@@ -2123,47 +2123,47 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b264">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b264">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b265">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b265">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b266">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b266">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b267">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b267">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b268">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b268">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b269">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b269">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b270">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b270">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b271">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b271">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b272">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b272">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -2173,142 +2173,179 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A reification node that describes direct links between resources</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
 	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b273"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b274"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b275"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b276"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b277"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b278"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b279"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b280"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b281"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b282"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b283"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b284"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b285"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b273"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b274"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b275"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b276"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b277"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b278"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b279"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b280"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b281"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b282"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b283"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b284"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b285"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b286"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b273">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b273">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b274">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b274">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b275">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b275">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b276">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b276">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b277">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b277">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b278">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b278">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b279">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b279">
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+	<owl:onProperty>
+		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasSource">
+			<knora-api:objectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#LinkValue"/>
+			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the source resource of a link value.</rdfs:comment>
+			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link value has source</rdfs:label>
+			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
+		</owl:ObjectProperty>
+	</owl:onProperty>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b280">
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+	<owl:onProperty>
+		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasSourceIri">
+			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#LinkValue"/>
+			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the IRI of the source resource of a link value.</rdfs:comment>
+			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link value has source IRI</rdfs:label>
+			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
+		</owl:DatatypeProperty>
+	</owl:onProperty>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b281">
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+	<owl:onProperty>
+		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasTarget">
+			<knora-api:objectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#LinkValue"/>
+			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the target resource of a link value.</rdfs:comment>
+			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link value has target</rdfs:label>
+			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
+		</owl:ObjectProperty>
+	</owl:onProperty>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b282">
+	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+	<owl:onProperty>
+		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasTargetIri">
+			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#LinkValue"/>
+			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the IRI of the target resource of a link value.</rdfs:comment>
+			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link value has target IRI</rdfs:label>
+			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
+		</owl:DatatypeProperty>
+	</owl:onProperty>
+</owl:Restriction>
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b283">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b280">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b284">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b281">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b285">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b282">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b286">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b283">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#object"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b284">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate"/>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b285">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#subject"/>
-</owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListNode">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a flat or hierarchical list</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b286"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b287"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b287"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b288"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b286">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b287">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b287">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b288">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b288"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b289"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b290"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b291"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b292"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b293"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b294"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b295"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b296"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b297"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b298"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b299"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b289"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b290"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b291"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b292"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b293"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b294"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b295"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b296"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b297"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b298"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b299"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b300"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b288">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b289">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b289">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b290">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b290">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b291">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b291">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b292">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b292">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b293">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b293">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b294">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b294">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b295">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#listValueAsListNode">
@@ -2320,7 +2357,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b295">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b296">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#listValueAsListNodeLabel">
@@ -2332,22 +2369,22 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b296">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b297">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b297">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b298">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b298">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b299">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b299">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b300">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2356,65 +2393,65 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a moving image file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b300"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b301"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b302"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b303"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b304"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b305"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b306"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b307"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b308"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b309"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b310"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b311"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b312"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b313"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b314"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b315"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b316"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b301"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b302"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b303"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b304"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b305"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b306"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b307"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b308"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b309"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b310"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b311"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b312"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b313"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b314"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b315"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b316"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b317"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b300">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b301">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b301">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b302">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b302">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b303">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b303">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b304">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b304">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b305">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b305">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b306">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b306">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b307">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b307">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b308">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b308">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b309">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimX">
@@ -2426,7 +2463,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b309">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b310">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimY">
@@ -2438,7 +2475,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b310">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b311">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDuration">
@@ -2450,7 +2487,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b311">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b312">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasFps">
@@ -2462,7 +2499,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b312">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b313">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasQualityLevel">
@@ -2474,22 +2511,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b313">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b314">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b314">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b315">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b315">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b316">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b316">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b317">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2499,66 +2536,66 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing moving image data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Movie)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b317"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b318"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b319"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b320"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b321"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b322"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b323"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b324"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b325"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b326"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b327"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b328"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b329"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b330"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b331"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b332"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b333"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b334"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b318"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b319"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b320"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b321"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b322"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b323"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b324"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b325"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b326"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b327"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b328"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b329"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b330"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b331"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b332"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b333"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b334"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b335"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b317">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b318">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b318">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b319">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b319">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b320">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b320">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b321">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b321">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b322">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b322">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b323">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b323">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b324">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b324">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b325">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b325">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b326">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasMovingImageFileValue">
@@ -2573,47 +2610,47 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b326">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b327">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b327">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b328">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b328">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b329">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b329">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b330">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b330">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b331">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b331">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b332">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b332">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b333">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b333">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b334">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b334">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b335">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -2625,65 +2662,65 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometric region of a resource. The geometry is represented currently as JSON string.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b335"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b336"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b337"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b338"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b339"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b340"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b341"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b342"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b343"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b344"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b345"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b346"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b347"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b348"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b349"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b350"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b351"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b352"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b353"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b354"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b355"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b356"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b336"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b337"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b338"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b339"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b340"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b341"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b342"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b343"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b344"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b345"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b346"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b347"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b348"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b349"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b350"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b351"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b352"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b353"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b354"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b355"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b356"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b357"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b335">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b336">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b336">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b337">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b337">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b338">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b338">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b339">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b339">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b340">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b340">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b341">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b341">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b342">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b342">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b343">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasColor">
@@ -2699,11 +2736,11 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b343">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b344">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b344">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b345">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasGeometry">
@@ -2718,32 +2755,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b345">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b346">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b346">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b347">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b347">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b348">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b348">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b349">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b349">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b350">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b350">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b351">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOf">
@@ -2758,7 +2795,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b351">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b352">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOfValue">
@@ -2773,67 +2810,67 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b352">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b353">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b353">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b354">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b354">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b355">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b355">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b356">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b356">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b357">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b357">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b358">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b358">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b359">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b359">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b360">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b360">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b361">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b361">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b362">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b362">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b363">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b363">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b364">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b364">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b365">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasFileValue">
@@ -2847,121 +2884,121 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b365">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b366">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b366">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b367">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b367">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b368">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b368">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b369">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b369">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b370">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b370">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b371">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b371">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b372">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b372">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b373">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b373">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b374">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b374">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b375">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b375">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b376">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b376">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b377">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b377">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b378">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b378">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b379">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b379">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b380">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b380">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b381">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b381">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b382">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b382">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b383">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b383">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b384">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b384">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b385">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b385">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b386">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b386">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b387">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b387">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b388">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b388">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b389">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b389">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b390">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b390">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b391">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b391">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b392">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -2970,35 +3007,35 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b392"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b393"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b394"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b395"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b396"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b397"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b398"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b399"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b400"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b393"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b394"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b395"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b396"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b397"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b398"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b399"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b400"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b401"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a knora-base value type in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b410"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b411"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b412"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b413"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b414"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b415"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b416"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b417"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b411"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b412"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b413"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b414"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b415"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b416"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b417"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b418"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b392">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b393">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b393">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b394">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3008,7 +3045,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b394">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b395">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3018,7 +3055,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b395">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b396">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3028,7 +3065,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b396">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b397">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3038,7 +3075,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b397">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b398">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3048,7 +3085,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b398">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b399">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3058,7 +3095,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b399">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b400">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3069,7 +3106,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b400">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b401">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3084,57 +3121,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b401"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b402"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b403"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b404"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b405"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b406"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b407"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b408"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b409"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b402"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b403"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b404"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b405"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b406"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b407"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b408"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b409"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b410"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b401">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b402">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b402">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b403">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b403">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b404">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b404">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b405">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b405">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b406">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b406">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b407">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b407">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b408">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b408">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b409">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b409">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b410">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3142,51 +3179,51 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a standoff markup tag</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b481"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b482"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b483"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b484"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b485"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b486"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b487"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b488"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b482"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b483"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b484"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b485"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b486"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b487"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b488"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b489"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b410">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b411">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b411">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b412">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b412">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b413">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b413">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b414">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b414">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b415">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b415">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b416">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b416">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b417">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b417">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b418">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3196,105 +3233,105 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b418"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b419"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b420"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b421"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b422"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b423"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b424"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b425"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b426"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b427"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b428"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b429"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b430"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b431"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b432"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b433"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b434"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b419"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b420"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b421"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b422"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b423"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b424"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b425"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b426"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b427"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b428"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b429"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b430"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b431"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b432"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b433"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b434"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b435"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b418">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b419">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b419">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b420">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b420">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b421">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b421">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b422">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b422">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b423">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b423">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b424">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b424">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b425">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b425">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b426">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b426">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b427">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b427">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b428">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b428">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b429">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b429">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b430">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b430">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b431">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b431">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b432">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b432">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b433">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b433">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b434">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b434">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b435">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3304,57 +3341,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a decimal (floating point) value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b435"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b436"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b437"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b438"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b439"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b440"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b441"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b442"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b443"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b436"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b437"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b438"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b439"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b440"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b441"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b442"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b443"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b444"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b435">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b436">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b436">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b437">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b437">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b438">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b438">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b439">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b439">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b440">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b440">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b441">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b441">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b442">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b442">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b443">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b443">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b444">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3364,57 +3401,57 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b444"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b445"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b446"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b447"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b448"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b449"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b450"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b451"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b452"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b445"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b446"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b447"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b448"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b449"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b450"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b451"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b452"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b453"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b444">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b445">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b445">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b446">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b446">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b447">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b447">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b448">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b448">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b449">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b449">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b450">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b450">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b451">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b451">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b452">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b452">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b453">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3424,32 +3461,32 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an internal reference in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b453"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b454"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b455"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b456"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b457"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b458"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b459"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b460"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b461"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b454"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b455"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b456"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b457"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b458"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b459"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b460"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b461"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b462"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b453">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b454">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b454">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b455">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b455">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b456">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b456">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b457">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasInternalReference">
@@ -3458,27 +3495,27 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b457">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b458">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b458">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b459">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b459">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b460">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b460">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b461">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b461">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b462">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3488,63 +3525,63 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an interval in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b462"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b463"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b464"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b465"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b466"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b467"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b468"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b469"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b470"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b471"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b463"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b464"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b465"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b466"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b467"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b468"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b469"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b470"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b471"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b472"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b462">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b463">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b463">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b464">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b464">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b465">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b465">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b466">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b466">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b467">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b467">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b468">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b468">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b469">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b469">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b470">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b470">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b471">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b471">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b472">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3553,32 +3590,32 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a reference to a Knora resource in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b472"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b473"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b474"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b475"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b476"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b477"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b478"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b479"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b480"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b473"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b474"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b475"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b476"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b477"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b478"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b479"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b480"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b481"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b472">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b473">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b473">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b474">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b474">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b475">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b475">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b476">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasLink">
@@ -3587,60 +3624,60 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b476">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b477">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b477">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b478">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b478">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b479">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b479">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b480">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b480">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b481">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b481">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b482">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b482">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b483">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b483">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b484">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b484">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b485">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b485">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b486">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b486">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b487">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b487">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b488">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b488">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b489">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
@@ -3649,61 +3686,61 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary URI in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b489"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b490"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b491"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b492"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b493"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b494"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b495"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b496"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b497"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b490"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b491"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b492"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b493"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b494"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b495"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b496"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b497"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b498"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#UriBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b576"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b577"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b489">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b490">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b490">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b491">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b491">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b492">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b492">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b493">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b493">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b494">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b494">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b495">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b495">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b496">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b496">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b497">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b497">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b498">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3720,63 +3757,63 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A file containing a two-dimensional still image</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b498"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b499"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b500"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b501"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b502"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b503"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b504"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b505"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b506"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b507"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b508"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b509"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b510"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b511"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b512"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b499"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b500"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b501"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b502"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b503"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b504"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b505"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b506"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b507"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b508"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b509"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b510"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b511"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b512"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b513"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b498">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b499">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b499">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b500">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b500">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b501">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b501">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b502">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b502">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b503">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b503">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b504">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b504">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b505">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b505">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b506">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b506">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b507">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimX">
@@ -3788,7 +3825,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b507">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b508">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimY">
@@ -3800,7 +3837,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b508">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b509">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasIIIFBaseUrl">
@@ -3812,22 +3849,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b509">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b510">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b510">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b511">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b511">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b512">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b512">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b513">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -3837,81 +3874,81 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can contain a two-dimensional still image file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Image)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b513"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b514"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b515"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b516"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b517"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b518"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b519"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b520"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b521"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b522"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b523"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b524"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b525"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b526"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b527"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b528"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b529"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b530"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b514"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b515"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b516"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b517"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b518"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b519"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b520"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b521"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b522"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b523"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b524"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b525"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b526"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b527"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b528"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b529"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b530"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b531"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b513">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b514">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b514">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b515">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b515">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b516">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b516">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b517">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b517">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b518">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b518">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b519">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b519">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b520">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b520">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b521">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b521">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b522">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b522">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b523">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b523">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b524">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b524">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b525">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue">
@@ -3926,32 +3963,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b525">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b526">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b526">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b527">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b527">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b528">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b528">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b529">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b529">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b530">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b530">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b531">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -3960,75 +3997,75 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A text file such as plain Unicode text, LaTeX, TEI/XML, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b531"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b532"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b533"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b534"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b535"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b536"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b537"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b538"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b539"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b540"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b541"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b542"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b532"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b533"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b534"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b535"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b536"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b537"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b538"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b539"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b540"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b541"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b542"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b543"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b531">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b532">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b532">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b533">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b533">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b534">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b534">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b535">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b535">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b536">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b536">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b537">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b537">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b538">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b538">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b539">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b539">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b540">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b540">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b541">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b541">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b542">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b542">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b543">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -4038,81 +4075,81 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing a text file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Text)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b543"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b544"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b545"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b546"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b547"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b548"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b549"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b550"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b551"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b552"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b553"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b554"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b555"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b556"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b557"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b558"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b559"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b560"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b544"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b545"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b546"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b547"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b548"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b549"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b550"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b551"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b552"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b553"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b554"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b555"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b556"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b557"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b558"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b559"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b560"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b561"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b543">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b544">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b544">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b545">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b545">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b546">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b546">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b547">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b547">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b548">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b548">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b549">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b549">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b550">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b550">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b551">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b551">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b552">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b552">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b553">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b553">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b554">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b554">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b555">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue">
@@ -4127,32 +4164,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b555">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b556">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b556">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b557">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b557">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b558">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b558">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b559">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b559">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b560">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b560">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b561">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -4160,53 +4197,53 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#TextValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b561"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b562"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b563"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b564"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b565"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b566"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b567"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b568"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b569"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b570"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b571"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b572"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b573"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b574"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b575"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b562"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b563"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b564"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b565"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b566"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b567"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b568"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b569"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b570"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b571"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b572"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b573"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b574"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b575"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b576"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b561">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b562">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b562">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b563">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b563">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b564">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b564">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b565">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b565">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b566">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b566">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b567">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b567">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b568">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsHtml">
@@ -4218,7 +4255,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b568">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b569">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsXml">
@@ -4230,7 +4267,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b569">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b570">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasLanguage">
@@ -4242,7 +4279,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b570">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b571">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMapping">
@@ -4254,7 +4291,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b571">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b572">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasStandoff">
@@ -4266,27 +4303,27 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b572">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b573">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b573">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b574">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b574">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b575">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b575">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b576">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b576">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b577">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
@@ -4295,110 +4332,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a URI</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b577"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b578"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b579"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b580"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b581"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b582"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b583"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b584"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b585"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b586"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b587"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b578"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b579"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b580"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b581"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b582"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b583"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b584"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b585"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b586"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b587"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b588"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b577">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b578">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b578">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b579">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b579">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b580">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b580">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b581">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b581">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b582">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b582">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b583">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b583">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b584">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b584">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b585">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b585">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b586">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b586">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b587">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b587">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b588">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b588">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b589">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b589">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b590">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b590">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b591">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b591">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b592">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b592">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b593">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b593">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b594">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b594">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b595">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b595">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b596">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b596">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b597">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b597">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b598">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
@@ -4407,110 +4444,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff.  The transformation's result is ecptected to be HTML.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff. The transformation's result is ecptected to be HTML.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#TextRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b598"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b599"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b600"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b601"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b602"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b603"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b604"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b605"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b606"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b607"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b608"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b609"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b610"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b611"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b612"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b613"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b614"/>
-	<rdfs:subClassOf rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b615"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b599"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b600"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b601"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b602"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b603"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b604"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b605"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b606"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b607"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b608"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b609"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b610"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b611"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b612"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b613"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b614"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b615"/>
+	<rdfs:subClassOf rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b616"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b598">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b599">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b599">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b600">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b600">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b601">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b601">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b602">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b602">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b603">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b603">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b604">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b604">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b605">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b605">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b606">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b606">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b607">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b607">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b608">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b608">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b609">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b609">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b610">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b610">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b611">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b611">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b612">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b612">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b613">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b613">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b614">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b614">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b615">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-6756c58c0da346839a9867addc9c17c1-b615">
+<owl:Restriction rdf:nodeID="genid-1facaedb886948b4b8816891301cb320-b616">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -4637,20 +4674,6 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Indicates whether class is a subclass of Value.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">is value class</rdfs:label>
 </owl:AnnotationProperty>
-<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasTarget">
-	<knora-api:objectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#LinkValue"/>
-	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the target resource of a link value.</rdfs:comment>
-	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link value has target</rdfs:label>
-	<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
-</owl:ObjectProperty>
-<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasTargetIri">
-	<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
-	<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#LinkValue"/>
-	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the IRI of the target resource of a link value.</rdfs:comment>
-	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link value has target IRI</rdfs:label>
-	<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
-</owl:DatatypeProperty>
 <owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#mappingHasName">
 	<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the name of a mapping</rdfs:comment>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
@@ -1702,6 +1702,18 @@ knora-api:LinkValue a owl:Class;
       owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
+      owl:maxCardinality 1;
+      owl:onProperty knora-api:linkValueHasSource
+    ], [ a owl:Restriction;
+      owl:maxCardinality 1;
+      owl:onProperty knora-api:linkValueHasSourceIri
+    ], [ a owl:Restriction;
+      owl:maxCardinality 1;
+      owl:onProperty knora-api:linkValueHasTarget
+    ], [ a owl:Restriction;
+      owl:maxCardinality 1;
+      owl:onProperty knora-api:linkValueHasTargetIri
+    ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
       owl:onProperty knora-api:userHasPermission
@@ -1717,16 +1729,35 @@ knora-api:LinkValue a owl:Class;
       knora-api:isInherited true;
       owl:maxCardinality 1;
       owl:onProperty knora-api:valueHasComment
-    ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty rdf:object
-    ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty rdf:predicate
-    ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty rdf:subject
     ] .
+
+knora-api:linkValueHasSource a owl:ObjectProperty;
+  knora-api:objectType knora-api:Resource;
+  knora-api:subjectType knora-api:LinkValue;
+  rdfs:comment "Represents the source resource of a link value.";
+  rdfs:label "Link value has source";
+  rdfs:subPropertyOf knora-api:valueHas .
+
+knora-api:linkValueHasSourceIri a owl:DatatypeProperty;
+  knora-api:objectType xsd:anyURI;
+  knora-api:subjectType knora-api:LinkValue;
+  rdfs:comment "Represents the IRI of the source resource of a link value.";
+  rdfs:label "Link value has source IRI";
+  rdfs:subPropertyOf knora-api:valueHas .
+
+knora-api:linkValueHasTarget a owl:ObjectProperty;
+  knora-api:objectType knora-api:Resource;
+  knora-api:subjectType knora-api:LinkValue;
+  rdfs:comment "Represents the target resource of a link value.";
+  rdfs:label "Link value has target";
+  rdfs:subPropertyOf knora-api:valueHas .
+
+knora-api:linkValueHasTargetIri a owl:DatatypeProperty;
+  knora-api:objectType xsd:anyURI;
+  knora-api:subjectType knora-api:LinkValue;
+  rdfs:comment "Represents the IRI of the target resource of a link value.";
+  rdfs:label "Link value has target IRI";
+  rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:ListNode a owl:Class;
   rdfs:comment "Represents a flat or hierarchical list";
@@ -3306,20 +3337,6 @@ knora-api:isValueClass a owl:AnnotationProperty;
   knora-api:subjectType owl:Class;
   rdfs:comment "Indicates whether class is a subclass of Value.";
   rdfs:label "is value class" .
-
-knora-api:linkValueHasTarget a owl:ObjectProperty;
-  knora-api:objectType knora-api:Resource;
-  knora-api:subjectType knora-api:LinkValue;
-  rdfs:comment "Represents the target resource of a link value.";
-  rdfs:label "Link value has target";
-  rdfs:subPropertyOf knora-api:valueHas .
-
-knora-api:linkValueHasTargetIri a owl:DatatypeProperty;
-  knora-api:objectType xsd:anyURI;
-  knora-api:subjectType knora-api:LinkValue;
-  rdfs:comment "Represents the IRI of the target resource of a link value.";
-  rdfs:label "Link value has target IRI";
-  rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:mappingHasName a owl:DatatypeProperty;
   knora-api:objectType xsd:string;

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
@@ -40,7 +40,7 @@ knora-api:Annotation a owl:Class;
       owl:onProperty knora-api:isAnnotationOfValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -133,7 +133,7 @@ knora-api:Resource a owl:Class;
       owl:minCardinality 0;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       owl:maxCardinality 1;
@@ -299,7 +299,7 @@ knora-api:AudioFileValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -349,7 +349,7 @@ knora-api:FileValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -459,7 +459,7 @@ knora-api:AudioRepresentation a owl:Class;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -536,7 +536,7 @@ knora-api:Representation a owl:Class;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -580,7 +580,7 @@ knora-api:ValueBase a owl:Class .
 
 knora-api:booleanValueAsBoolean a owl:DatatypeProperty;
   knora-api:objectType xsd:boolean;
-  knora-api:subjectType knora-api:BooleanValue;
+  knora-api:subjectType knora-api:BooleanBase;
   rdfs:comment "Represents the literal boolean value of a BooleanValue.";
   rdfs:label "Boolean value as decimal";
   rdfs:subPropertyOf knora-api:valueHas .
@@ -614,7 +614,7 @@ knora-api:BooleanValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -653,7 +653,7 @@ knora-api:Value a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       owl:cardinality 1;
@@ -677,7 +677,7 @@ knora-api:ColorBase a owl:Class;
 
 knora-api:colorValueAsColor a owl:DatatypeProperty;
   knora-api:objectType xsd:string;
-  knora-api:subjectType knora-api:ColorValue;
+  knora-api:subjectType knora-api:ColorBase;
   rdfs:comment "Represents the literal RGB value of a ColorValue.";
   rdfs:label "Color value as color";
   rdfs:subPropertyOf knora-api:valueHas .
@@ -711,7 +711,7 @@ knora-api:ColorValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -764,7 +764,7 @@ knora-api:DDDFileValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -857,7 +857,7 @@ knora-api:DDDRepresentation a owl:Class;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ] .
 
@@ -903,63 +903,63 @@ knora-api:DateBase a owl:Class;
 
 knora-api:dateValueHasCalendar a owl:DatatypeProperty;
   knora-api:objectType xsd:string;
-  knora-api:subjectType knora-api:DateValue;
+  knora-api:subjectType knora-api:DateBase;
   rdfs:comment "Represents the calendar of a date value.";
   rdfs:label "Date value has calendar";
   rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:dateValueHasEndDay a owl:DatatypeProperty;
   knora-api:objectType xsd:integer;
-  knora-api:subjectType knora-api:DateValue;
+  knora-api:subjectType knora-api:DateBase;
   rdfs:comment "Represents the end day of a date value.";
   rdfs:label "Date value has end day";
   rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:dateValueHasEndEra a owl:DatatypeProperty;
   knora-api:objectType xsd:string;
-  knora-api:subjectType knora-api:DateValue;
+  knora-api:subjectType knora-api:DateBase;
   rdfs:comment "Represents the end era of a date value.";
   rdfs:label "Date value has end era";
   rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:dateValueHasEndMonth a owl:DatatypeProperty;
   knora-api:objectType xsd:integer;
-  knora-api:subjectType knora-api:DateValue;
+  knora-api:subjectType knora-api:DateBase;
   rdfs:comment "Represents the end month of a date value.";
   rdfs:label "Date value has end month";
   rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:dateValueHasEndYear a owl:DatatypeProperty;
   knora-api:objectType xsd:integer;
-  knora-api:subjectType knora-api:DateValue;
+  knora-api:subjectType knora-api:DateBase;
   rdfs:comment "Represents the end year of a date value.";
   rdfs:label "Date value has end year";
   rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:dateValueHasStartDay a owl:DatatypeProperty;
   knora-api:objectType xsd:integer;
-  knora-api:subjectType knora-api:DateValue;
+  knora-api:subjectType knora-api:DateBase;
   rdfs:comment "Represents the start day of a date value.";
   rdfs:label "Date value has start day";
   rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:dateValueHasStartEra a owl:DatatypeProperty;
   knora-api:objectType xsd:string;
-  knora-api:subjectType knora-api:DateValue;
+  knora-api:subjectType knora-api:DateBase;
   rdfs:comment "Represents the start era of a date value.";
   rdfs:label "Date value has start era";
   rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:dateValueHasStartMonth a owl:DatatypeProperty;
   knora-api:objectType xsd:integer;
-  knora-api:subjectType knora-api:DateValue;
+  knora-api:subjectType knora-api:DateBase;
   rdfs:comment "Represents the start month of a date value.";
   rdfs:label "Date value has start month";
   rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:dateValueHasStartYear a owl:DatatypeProperty;
   knora-api:objectType xsd:integer;
-  knora-api:subjectType knora-api:DateValue;
+  knora-api:subjectType knora-api:DateBase;
   rdfs:comment "Represents the start year of a date value.";
   rdfs:label "Date value has start year";
   rdfs:subPropertyOf knora-api:valueHas .
@@ -1025,7 +1025,7 @@ knora-api:DateValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -1053,7 +1053,7 @@ knora-api:DecimalBase a owl:Class;
 
 knora-api:decimalValueAsDecimal a owl:DatatypeProperty;
   knora-api:objectType xsd:decimal;
-  knora-api:subjectType knora-api:DecimalValue;
+  knora-api:subjectType knora-api:DecimalBase;
   rdfs:comment "Represents the literal decimal value of a DecimalValue.";
   rdfs:label "Decimal value as decimal";
   rdfs:subPropertyOf knora-api:valueHas .
@@ -1087,7 +1087,7 @@ knora-api:DecimalValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -1139,7 +1139,7 @@ knora-api:DocumentFileValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -1211,7 +1211,7 @@ knora-api:DocumentRepresentation a owl:Class;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -1298,7 +1298,7 @@ knora-api:ForbiddenResource a owl:Class;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -1350,7 +1350,7 @@ knora-api:GeomValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -1404,7 +1404,7 @@ knora-api:GeonameValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -1439,7 +1439,7 @@ knora-api:IntBase a owl:Class;
 
 knora-api:intValueAsInt a owl:DatatypeProperty;
   knora-api:objectType xsd:integer;
-  knora-api:subjectType knora-api:IntValue;
+  knora-api:subjectType knora-api:IntBase;
   rdfs:comment "Represents the literal integer value of an IntValue.";
   rdfs:label "Integer value as integer";
   rdfs:subPropertyOf knora-api:valueHas .
@@ -1473,7 +1473,7 @@ knora-api:IntValue a owl:Class;
       owl:onProperty knora-api:intValueAsInt
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -1501,6 +1501,20 @@ knora-api:IntervalBase a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:intervalValueHasStart
     ] .
+
+knora-api:intervalValueHasEnd a owl:DatatypeProperty;
+  knora-api:objectType xsd:decimal;
+  knora-api:subjectType knora-api:IntervalBase;
+  rdfs:comment "Represents the end position of an interval.";
+  rdfs:label "interval value has end";
+  rdfs:subPropertyOf knora-api:valueHas .
+
+knora-api:intervalValueHasStart a owl:DatatypeProperty;
+  knora-api:objectType xsd:decimal;
+  knora-api:subjectType knora-api:IntervalBase;
+  rdfs:comment "Represents the start position of an interval.";
+  rdfs:label "interval value has start";
+  rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:IntervalValue a owl:Class;
   knora-api:isValueClass true;
@@ -1535,7 +1549,7 @@ knora-api:IntervalValue a owl:Class;
       owl:onProperty knora-api:intervalValueHasStart
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -1616,7 +1630,7 @@ knora-api:LinkObj a owl:Class;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -1685,7 +1699,7 @@ knora-api:LinkValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -1748,7 +1762,7 @@ knora-api:ListValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       owl:cardinality 1;
@@ -1821,7 +1835,7 @@ knora-api:MovingImageFileValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       owl:cardinality 1;
@@ -1944,7 +1958,7 @@ knora-api:MovingImageRepresentation a owl:Class;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -2039,7 +2053,7 @@ knora-api:Region a owl:Class;
       owl:onProperty knora-api:hasStandoffLinkToValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       owl:cardinality 1;
@@ -2637,7 +2651,7 @@ knora-api:UriBase a owl:Class;
 
 knora-api:uriValueAsUri a owl:DatatypeProperty;
   knora-api:objectType xsd:anyURI;
-  knora-api:subjectType knora-api:UriValue;
+  knora-api:subjectType knora-api:UriBase;
   rdfs:comment "Represents the literal URI value of a UriValue.";
   rdfs:label "URI value as URI";
   rdfs:subPropertyOf knora-api:valueHas .
@@ -2675,7 +2689,7 @@ knora-api:StillImageFileValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       owl:cardinality 1;
@@ -2778,7 +2792,7 @@ knora-api:StillImageRepresentation a owl:Class;
       owl:onProperty knora-api:hasStillImageFileValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -2845,7 +2859,7 @@ knora-api:TextFileValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -2918,7 +2932,7 @@ knora-api:TextRepresentation a owl:Class;
       owl:onProperty knora-api:hasTextFileValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -2976,7 +2990,7 @@ knora-api:TextValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       owl:maxCardinality 1;
@@ -3071,7 +3085,7 @@ knora-api:UriValue a owl:Class;
       owl:onProperty knora-api:hasPermissions
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -3148,7 +3162,7 @@ knora-api:XSLTransformation a owl:Class;
       owl:onProperty knora-api:hasTextFileValue
     ], [ a owl:Restriction;
       knora-api:isInherited true;
-      owl:cardinality 1;
+      owl:maxCardinality 1;
       owl:onProperty knora-api:isDeleted
     ], [ a owl:Restriction;
       knora-api:isInherited true;
@@ -3185,6 +3199,11 @@ knora-api:canBeInstantiated a owl:AnnotationProperty;
   knora-api:subjectType owl:Class;
   rdfs:comment "Indicates whether a resource class can be instantiated via the Knora API.";
   rdfs:label "can be instantiated" .
+
+knora-api:error a owl:DatatypeProperty;
+  knora-api:objectType xsd:string;
+  rdfs:comment "Provides an error message";
+  rdfs:label "error" .
 
 knora-api:hasValue a owl:ObjectProperty;
   knora-api:isResourceProperty true;

--- a/webapi/src/test/scala/org/knora/webapi/E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/E2ESpec.scala
@@ -133,6 +133,12 @@ class E2ESpec(_system: ActorSystem) extends Core with KnoraService with StartupU
         Await.result(responseBodyFuture, 5.seconds)
     }
 
+    protected def doGetRequest(urlPath: String): String = {
+        val request = Get(s"$baseApiUrl$urlPath")
+        val response: HttpResponse = singleAwaitingRequest(request)
+        responseToString(response)
+    }
+
     protected def parseTurtle(turtleStr: String): Model = {
         Rio.parse(new StringReader(turtleStr), "", RDFFormat.TURTLE)
     }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/ExceptionHandlerR2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/ExceptionHandlerR2RSpec.scala
@@ -89,8 +89,6 @@ class ExceptionHandlerR2RSpec extends R2RSpec {
         "return correct status code and response for 'NotFoundException'" in {
             Get("/v1/nfe") ~> route ~> check {
 
-                //println(responseAs[String])
-
                 status should be(StatusCodes.NotFound)
 
                 responseAs[String] should be("{\"status\":9,\"error\":\"org.knora.webapi.NotFoundException: not found\"}")
@@ -98,16 +96,12 @@ class ExceptionHandlerR2RSpec extends R2RSpec {
 
             Get("/v2/nfe") ~> route ~> check {
 
-                //println(responseAs[String])
-
                 status should be(StatusCodes.NotFound)
 
-                responseAs[String] should be("{\"error\":\"org.knora.webapi.NotFoundException: not found\"}")
+                responseAs[String] should be("{\"knora-api:error\":\"org.knora.webapi.NotFoundException: not found\",\"@context\":{\"knora-api\":\"http://api.knora.org/ontology/knora-api/v2#\"}}")
             }
 
             Get("/admin/nfe") ~> route ~> check {
-
-                //println(responseAs[String])
 
                 status should be(StatusCodes.NotFound)
 
@@ -128,7 +122,7 @@ class ExceptionHandlerR2RSpec extends R2RSpec {
 
                 status should be(StatusCodes.Forbidden)
 
-                responseAs[String] should be("{\"error\":\"org.knora.webapi.ForbiddenException: forbidden\"}")
+                responseAs[String] should be("{\"knora-api:error\":\"org.knora.webapi.ForbiddenException: forbidden\",\"@context\":{\"knora-api\":\"http://api.knora.org/ontology/knora-api/v2#\"}}")
             }
 
             Get("/admin/fe") ~> route ~> check {
@@ -151,7 +145,7 @@ class ExceptionHandlerR2RSpec extends R2RSpec {
 
                 status should be(StatusCodes.BadRequest)
 
-                responseAs[String] should be("{\"error\":\"org.knora.webapi.DuplicateValueException: duplicate value\"}")
+                responseAs[String] should be("{\"knora-api:error\":\"org.knora.webapi.DuplicateValueException: duplicate value\",\"@context\":{\"knora-api\":\"http://api.knora.org/ontology/knora-api/v2#\"}}")
             }
 
             Get("/admin/dve") ~> route ~> check {
@@ -174,7 +168,7 @@ class ExceptionHandlerR2RSpec extends R2RSpec {
 
                 status should be(StatusCodes.BadRequest)
 
-                responseAs[String] should be("{\"error\":\"org.knora.webapi.OntologyConstraintException: ontology constraint\"}")
+                responseAs[String] should be("{\"knora-api:error\":\"org.knora.webapi.OntologyConstraintException: ontology constraint\",\"@context\":{\"knora-api\":\"http://api.knora.org/ontology/knora-api/v2#\"}}")
             }
 
             Get("/admin/oce") ~> route ~> check {
@@ -197,7 +191,7 @@ class ExceptionHandlerR2RSpec extends R2RSpec {
 
                 status should be(StatusCodes.Conflict)
 
-                responseAs[String] should be("{\"error\":\"org.knora.webapi.EditConflictException: edit conflict\"}")
+                responseAs[String] should be("{\"knora-api:error\":\"org.knora.webapi.EditConflictException: edit conflict\",\"@context\":{\"knora-api\":\"http://api.knora.org/ontology/knora-api/v2#\"}}")
             }
 
             Get("/admin/ece") ~> route ~> check {
@@ -220,7 +214,7 @@ class ExceptionHandlerR2RSpec extends R2RSpec {
 
                 status should be(StatusCodes.BadRequest)
 
-                responseAs[String] should be("{\"error\":\"org.knora.webapi.GravsearchException: sparql search\"}")
+                responseAs[String] should be("{\"knora-api:error\":\"org.knora.webapi.GravsearchException: sparql search\",\"@context\":{\"knora-api\":\"http://api.knora.org/ontology/knora-api/v2#\"}}")
             }
 
             Get("/admin/sse") ~> route ~> check {
@@ -243,7 +237,7 @@ class ExceptionHandlerR2RSpec extends R2RSpec {
 
                 status should be(StatusCodes.Conflict)
 
-                responseAs[String] should be("{\"error\":\"org.knora.webapi.UpdateNotPerformedException: update not performed\"}")
+                responseAs[String] should be("{\"knora-api:error\":\"org.knora.webapi.UpdateNotPerformedException: update not performed\",\"@context\":{\"knora-api\":\"http://api.knora.org/ontology/knora-api/v2#\"}}")
             }
 
             Get("/admin/unpe") ~> route ~> check {
@@ -266,7 +260,7 @@ class ExceptionHandlerR2RSpec extends R2RSpec {
 
                 status should be(StatusCodes.InternalServerError)
 
-                responseAs[String] should be("{\"error\":\"org.knora.webapi.AuthenticationException: authentication exception\"}")
+                responseAs[String] should be("{\"knora-api:error\":\"org.knora.webapi.AuthenticationException: authentication exception\",\"@context\":{\"knora-api\":\"http://api.knora.org/ontology/knora-api/v2#\"}}")
             }
 
             Get("/admin/ae") ~> route ~> check {

--- a/webapi/src/test/scala/org/knora/webapi/e2e/InstanceChecker.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/InstanceChecker.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.e2e
+
+import org.knora.webapi.messages.v2.responder.ontologymessages.{ReadClassInfoV2, ReadPropertyInfoV2}
+import org.knora.webapi.util.SmartIri
+import org.knora.webapi.util.jsonld._
+import org.knora.webapi.{IRI, OntologyConstants}
+import spray.json._
+
+/**
+  * A test utility for checking whether an instance of an RDF class returned in a Knora response corresponds to the
+  * the class definition.
+  *
+  * @param instanceInspector an [[InstanceInspector]] for working with instances in a particular format.
+  */
+class InstanceChecker(instanceInspector: InstanceInspector) {
+    /**
+      * Checks whether an instance of an RDF class returned in a Knora response corresponds to the
+      * * the class definition.
+      *
+      * @param classDef        the class definition.
+      * @param propertyDefs    the definitions of the properties used in the class.
+      * @param instanceElement an [[InstanceElement]] representing the instance to be checked.
+      */
+    def checkInstance(classDef: ReadClassInfoV2, propertyDefs: Map[SmartIri, ReadPropertyInfoV2], instanceElement: InstanceElement): Unit = {
+
+    }
+}
+
+/**
+  * Represents an instance of an RDF class, or an element of such an instance.
+  *
+  * @param elementType the element type. This is an opaque string that only the [[InstanceInspector]] needs
+  *                    to understand.
+  * @param children    a map of property names to child elements.
+  */
+case class InstanceElement(elementType: String, children: Map[String, Vector[InstanceElement]] = Map.empty)
+
+/**
+  * A trait for classes that help [[InstanceChecker]] check instances in different formats.
+  */
+trait InstanceInspector {
+    /**
+      * Converts a Knora response to an [[InstanceElement]].
+      */
+    def toElement(response: String): InstanceElement
+
+    /**
+      * Converts an RDF property IRI to the property name used in instances.
+      */
+    def propertyIriToInstancePropertyName(propertyIri: SmartIri): String
+
+    /**
+      * Checks, as far as possible, whether the type of an instance is compatible with the type IRI of its class.
+      */
+    def elementHasCompatibleType(element: InstanceElement, elementTypeIri: SmartIri): Boolean
+}
+
+/**
+  * Constants for working with instances parsed from JSON.
+  */
+object JsonInstanceInspector {
+    val STRING = "string"
+    val NUMBER = "number"
+    val BOOLEAN = "boolean"
+    val OBJECT = "object"
+
+    val LiteralTypeMap: Map[String, Set[IRI]] = Map(
+        STRING -> Set(OntologyConstants.Xsd.String, OntologyConstants.Xsd.DateTimeStamp, OntologyConstants.Xsd.Uri),
+        NUMBER -> Set(OntologyConstants.Xsd.Int, OntologyConstants.Xsd.Integer, OntologyConstants.Xsd.NonNegativeInteger, OntologyConstants.Xsd.Decimal),
+        BOOLEAN -> Set(OntologyConstants.Xsd.Boolean)
+    )
+
+    val LiteralTypeIris: Set[IRI] = LiteralTypeMap.values.flatten.toSet
+}
+
+/**
+  * An [[InstanceInspector]] that works with Knora responses in JSON format.
+  */
+class JsonInstanceInspector extends InstanceInspector {
+
+    import JsonInstanceInspector._
+
+    override def toElement(response: String): InstanceElement = {
+        jsObjectToElement(JsonParser(response).asJsObject)
+    }
+
+    private def jsValueToElements(jsValue: JsValue): Vector[InstanceElement] = {
+        jsValue match {
+            case jsObject: JsObject => Vector(jsObjectToElement(jsObject))
+            case jsArray: JsArray => jsArray.elements.flatMap(jsValue => jsValueToElements(jsValue))
+            case _: JsString => Vector(InstanceElement(STRING))
+            case _: JsNumber => Vector(InstanceElement(NUMBER))
+            case _: JsBoolean => Vector(InstanceElement(BOOLEAN))
+        }
+    }
+
+    private def jsObjectToElement(jsObject: JsObject): InstanceElement = {
+        val children = jsObject.fields.map {
+            case (key: String, jsValue: JsValue) => key -> jsValueToElements(jsValue)
+        }
+
+        InstanceElement(OBJECT, children)
+    }
+
+    override def propertyIriToInstancePropertyName(propertyIri: SmartIri): String = {
+        propertyIri.getEntityName
+    }
+
+    override def elementHasCompatibleType(element: InstanceElement, elementTypeIri: SmartIri): Boolean = {
+        LiteralTypeMap.get(element.elementType) match {
+            case Some(typeIris) => typeIris.contains(elementTypeIri.toString)
+            case None => !LiteralTypeIris.contains(elementTypeIri.toString)
+        }
+    }
+}
+
+/**
+  * An [[InstanceInspector]] that works with Knora responses in JSON-LD format.
+  */
+class JsonLDInstanceInspector extends InstanceInspector {
+    override def toElement(response: String): InstanceElement = {
+        jsonLDObjectToElement(JsonLDUtil.parseJsonLD(response).body)
+    }
+
+    private def jsonLDValueToElements(jsonLDValue: JsonLDValue): Vector[InstanceElement] = {
+        jsonLDValue match {
+            case jsonLDObject: JsonLDObject =>
+                if (jsonLDObject.isStringWithLang) {
+                    Vector(InstanceElement(OntologyConstants.Xsd.String))
+                } else if (jsonLDObject.isDatatypeValue) {
+                    Vector(InstanceElement(jsonLDObject.requireString(JsonLDConstants.TYPE)))
+                } else {
+                    Vector(jsonLDObjectToElement(jsonLDObject))
+                }
+
+            case jsonLDArray: JsonLDArray => jsonLDArray.value.flatMap(jsonLDValue => jsonLDValueToElements(jsonLDValue)).toVector
+
+            case _: JsonLDString => Vector(InstanceElement(OntologyConstants.Xsd.String))
+
+            case _: JsonLDInt => Vector(InstanceElement(OntologyConstants.Xsd.Integer))
+
+            case _: JsonLDBoolean => Vector(InstanceElement(OntologyConstants.Xsd.Boolean))
+        }
+    }
+
+    private def jsonLDObjectToElement(jsonLDObject: JsonLDObject): InstanceElement = {
+        val elementType = jsonLDObject.requireString(JsonLDConstants.TYPE)
+
+        val children = jsonLDObject.value.map {
+            case (key, jsonLDValue: JsonLDValue) => key -> jsonLDValueToElements(jsonLDValue)
+        }
+
+        InstanceElement(elementType, children)
+    }
+
+    override def propertyIriToInstancePropertyName(propertyIri: SmartIri): String = {
+        propertyIri.toString
+    }
+
+    override def elementHasCompatibleType(element: InstanceElement, elementTypeIri: SmartIri): Boolean = {
+        element.elementType == elementTypeIri.toString
+    }
+}

--- a/webapi/src/test/scala/org/knora/webapi/e2e/InstanceChecker.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/InstanceChecker.scala
@@ -170,7 +170,7 @@ class InstanceChecker(instanceInspector: InstanceInspector, log: LoggingAdapter)
                             }
                         } else if (!instanceInspector.elementIsIri(obj)) {
                             // It's a class that Knora doesn't serve. Accept the object only if it's an IRI.
-                            throwAndLogAssertionException(errorMsg)
+                            throwAndLogAssertionException(s"Property <$propertyIri> requires an IRI referring to an instance of <$objectType>, but object content was received instead")
                         }
                     } else {
                         // We're expecting a literal. Ask the element inspector if the object is compatible with

--- a/webapi/src/test/scala/org/knora/webapi/e2e/InstanceChecker.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/InstanceChecker.scala
@@ -102,7 +102,7 @@ class InstanceChecker(instanceInspector: InstanceInspector, log: LoggingAdapter)
       */
     private def checkRec(instanceElement: InstanceElement, classIri: SmartIri, definitions: Definitions): Unit = {
         if (!instanceInspector.elementHasCompatibleType(element = instanceElement, expectedType = classIri, definitions = definitions)) {
-            throwAndLogAssertionException(s"Element type ${instanceElement.elementType} is not compatible with expected class IRI <$classIri>")
+            throwAndLogAssertionException(s"Instance type ${instanceElement.elementType} is not compatible with expected class IRI $classIri")
         }
 
         val classDef: ClassInfoContentV2 = definitions.getClassDef(classIri, throwAndLogAssertionException)
@@ -141,7 +141,7 @@ class InstanceChecker(instanceInspector: InstanceInspector, log: LoggingAdapter)
                 // Get the expected type of the property's objects.
                 val objectType: SmartIri = if (propertyIri.isKnoraApiV2EntityIri) {
                     val propertyDef = definitions.getPropertyDef(propertyIri, throwAndLogAssertionException)
-                    getObjectType(propertyDef).getOrElse(throwAndLogAssertionException(s"Property <$propertyIri> has no knora-api:objectType"))
+                    getObjectType(propertyDef).getOrElse(throwAndLogAssertionException(s"Property $propertyIri has no knora-api:objectType"))
                 } else {
                     OntologyConstants.Xsd.String.toSmartIri
                 }
@@ -158,7 +158,7 @@ class InstanceChecker(instanceInspector: InstanceInspector, log: LoggingAdapter)
                         case None => ""
                     }
 
-                    val errorMsg = s"Element type ${obj.elementType}$literalContentMsg is not compatible with expected type <$objectType> for property <$propertyIri>"
+                    val errorMsg = s"Property $instancePropertyName has an object of type ${obj.elementType}$literalContentMsg, but type $objectType was expected"
 
                     // Are we expecting an instance of a Knora class that isn't a datatype?
                     if (objectType.isKnoraApiV2EntityIri && !objectTypeIsKnoraDatatype) {
@@ -170,7 +170,7 @@ class InstanceChecker(instanceInspector: InstanceInspector, log: LoggingAdapter)
                             }
                         } else if (!instanceInspector.elementIsIri(obj)) {
                             // It's a class that Knora doesn't serve. Accept the object only if it's an IRI.
-                            throwAndLogAssertionException(s"Property <$propertyIri> requires an IRI referring to an instance of <$objectType>, but object content was received instead")
+                            throwAndLogAssertionException(s"Property $propertyIri requires an IRI referring to an instance of $objectType, but object content was received instead")
                         }
                     } else {
                         // We're expecting a literal. Ask the element inspector if the object is compatible with
@@ -397,12 +397,12 @@ trait InstanceInspector {
   * Constants for working with instances parsed from JSON.
   */
 object JsonInstanceInspector {
-    val STRING = "string"
-    val IRI = "iri"
-    val INTEGER = "integer"
-    val DECIMAL = "decimal"
-    val BOOLEAN = "boolean"
-    val OBJECT = "object"
+    val STRING = "String"
+    val IRI = "IRI"
+    val INTEGER = "Integer"
+    val DECIMAL = "Decimal"
+    val BOOLEAN = "Boolean"
+    val OBJECT = "Object"
 
     val LiteralTypeMap: Map[String, Set[IRI]] = Map(
         STRING ->
@@ -601,12 +601,12 @@ case class Definitions(classDefs: Map[SmartIri, ClassInfoContentV2] = Map.empty,
                        subClassOf: Map[SmartIri, Set[SmartIri]] = Map.empty) {
     def getClassDef(classIri: SmartIri,
                     errorFun: String => Nothing): ClassInfoContentV2 = {
-        classDefs.getOrElse(classIri, errorFun(s"No definition for class <$classIri>"))
+        classDefs.getOrElse(classIri, errorFun(s"No definition for class $classIri"))
     }
 
     def getPropertyDef(propertyIri: SmartIri,
                        errorFun: String => Nothing): PropertyInfoContentV2 = {
-        propertyDefs.getOrElse(propertyIri, errorFun(s"No definition for property <$propertyIri>"))
+        propertyDefs.getOrElse(propertyIri, errorFun(s"No definition for property $propertyIri"))
     }
 
     def getBaseClasses(classIri: SmartIri): Set[SmartIri] = {

--- a/webapi/src/test/scala/org/knora/webapi/e2e/InstanceCheckerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/InstanceCheckerSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.e2e
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.testkit.RouteTestTimeout
+import org.knora.webapi.E2ESpec
+import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.util.StringFormatter
+
+import scala.concurrent.ExecutionContextExecutor
+
+/**
+  * Tests [[InstanceChecker]].
+  */
+class InstanceCheckerSpec extends E2ESpec {
+    private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
+
+    implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(settings.defaultTimeout)
+
+    implicit val ec: ExecutionContextExecutor = system.dispatcher
+
+    override lazy val rdfDataObjects: List[RdfDataObject] = List(
+        RdfDataObject(path = "_test_data/all_data/anything-data.ttl", name = "http://www.knora.org/data/0001/anything")
+
+    )
+
+    private val instanceChecker: InstanceChecker = InstanceChecker.getJsonLDChecker
+
+    "The InstanceChecker" should {
+
+    }
+}

--- a/webapi/src/test/scala/org/knora/webapi/e2e/InstanceCheckerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/InstanceCheckerSpec.scala
@@ -44,41 +44,71 @@ class InstanceCheckerSpec extends E2ESpec(InstanceCheckerSpec.config) {
     private val instanceChecker: InstanceChecker = InstanceChecker.getJsonLDChecker(log)
 
     "The InstanceChecker" should {
-        "reject a JSON-LD instance with an extra property" in {
+        "reject a JSON-LD instance of anything:Thing (in the complex schema) with an extra property" in {
             assertThrows[AssertionException] {
                 instanceChecker.check(
-                    instanceResponse = InstanceCheckerSpec.thingWithExtraProperty,
+                    instanceResponse = InstanceCheckerSpec.complexThingWithExtraProperty,
                     expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
                     knoraRouteGet = doGetRequest
                 )
             }
         }
 
-        "reject a JSON-LD instance with an extra property object" in {
+        "reject a JSON-LD instance of anything:Thing (in the complex schema) with an extra property object" in {
             assertThrows[AssertionException] {
                 instanceChecker.check(
-                    instanceResponse = InstanceCheckerSpec.thingWithExtraPropertyObject,
+                    instanceResponse = InstanceCheckerSpec.complexThingWithExtraPropertyObject,
                     expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
                     knoraRouteGet = doGetRequest
                 )
             }
         }
 
-        "reject a JSON-LD instance with an invalid literal type" in {
+        "reject a JSON-LD instance of anything:Thing (in the complex schema) with an invalid literal type" in {
             assertThrows[AssertionException] {
                 instanceChecker.check(
-                    instanceResponse = InstanceCheckerSpec.thingWithInvalidLiteralType,
+                    instanceResponse = InstanceCheckerSpec.complexThingWithInvalidLiteralType,
                     expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
                     knoraRouteGet = doGetRequest
                 )
             }
         }
 
-        "reject a JSON-LD instance with an invalid object type" in {
+        "reject a JSON-LD instance of anything:Thing (in the complex schema) with an invalid object type" in {
             assertThrows[AssertionException] {
                 instanceChecker.check(
-                    instanceResponse = InstanceCheckerSpec.thingWithInvalidObjectType,
+                    instanceResponse = InstanceCheckerSpec.complexThingWithInvalidObjectType,
                     expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
+                    knoraRouteGet = doGetRequest
+                )
+            }
+        }
+
+        "reject a JSON-LD instance of anything:Thing (in the complex schema) with object content where an IRI is required" in {
+            assertThrows[AssertionException] {
+                instanceChecker.check(
+                    instanceResponse = InstanceCheckerSpec.complexThingWithInvalidUseOfObjectInsteadOfIri,
+                    expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
+                    knoraRouteGet = doGetRequest
+                )
+            }
+        }
+
+        "reject a JSON-LD instance of anything:Thing (in the simple schema) with an invalid datatype" in {
+            assertThrows[AssertionException] {
+                instanceChecker.check(
+                    instanceResponse = InstanceCheckerSpec.simpleThingWithInvalidDatatype,
+                    expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
+                    knoraRouteGet = doGetRequest
+                )
+            }
+        }
+
+        "reject a JSON-LD instance of anything:Thing (in the simple schema) without an rdfs:label" in {
+            assertThrows[AssertionException] {
+                instanceChecker.check(
+                    instanceResponse = InstanceCheckerSpec.simpleThingWithMissingLabel,
+                    expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
                     knoraRouteGet = doGetRequest
                 )
             }
@@ -93,7 +123,7 @@ object InstanceCheckerSpec {
           akka.stdout-loglevel = "DEBUG"
         """.stripMargin)
 
-    val thingWithExtraProperty: String =
+    val complexThingWithExtraProperty: String =
         """{
           |  "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg",
           |  "@type" : "anything:Thing",
@@ -142,7 +172,7 @@ object InstanceCheckerSpec {
           |}
         """.stripMargin
 
-    val thingWithExtraPropertyObject: String =
+    val complexThingWithExtraPropertyObject: String =
         """{
           |  "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg",
           |  "@type" : "anything:Thing",
@@ -204,7 +234,7 @@ object InstanceCheckerSpec {
           |}
         """.stripMargin
 
-    val thingWithInvalidLiteralType: String =
+    val complexThingWithInvalidLiteralType: String =
         """{
           |  "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg",
           |  "@type" : "anything:Thing",
@@ -253,7 +283,7 @@ object InstanceCheckerSpec {
           |}
         """.stripMargin
 
-    val thingWithInvalidObjectType: String =
+    val complexThingWithInvalidObjectType: String =
         """{
           |  "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg",
           |  "@type" : "anything:Thing",
@@ -307,206 +337,10 @@ object InstanceCheckerSpec {
           |}
         """.stripMargin
 
-    val correctThingInstance: String =
+    val complexThingWithInvalidUseOfObjectInsteadOfIri: String =
         """{
           |  "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg",
           |  "@type" : "anything:Thing",
-          |  "anything:hasBoolean" : {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/o-j0jdxMQvanmAdpAIOcFA",
-          |    "@type" : "knora-api:BooleanValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:booleanValueAsBoolean" : true,
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    }
-          |  },
-          |  "anything:hasColor" : {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/mZzh9KauSMeA3J0jE3WW3w",
-          |    "@type" : "knora-api:ColorValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:colorValueAsColor" : "#ff3333",
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    }
-          |  },
-          |  "anything:hasDate" : {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/lj35qx3vRUa6s1Q8s5Z5SA",
-          |    "@type" : "knora-api:DateValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:dateValueHasCalendar" : "GREGORIAN",
-          |    "knora-api:dateValueHasEndEra" : "CE",
-          |    "knora-api:dateValueHasEndYear" : 1489,
-          |    "knora-api:dateValueHasStartEra" : "CE",
-          |    "knora-api:dateValueHasStartYear" : 1489,
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueAsString" : "GREGORIAN:1489 CE",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    }
-          |  },
-          |  "anything:hasDecimal" : {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/Zp50VNGbTmKvgPBRykZeng",
-          |    "@type" : "knora-api:DecimalValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:decimalValueAsDecimal" : {
-          |      "@type" : "xsd:decimal",
-          |      "@value" : "100000000000000.000000000000001"
-          |    },
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    }
-          |  },
-          |  "anything:hasGeometry" : {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/vaJ1MeVmRIWK3cTrc5wVEA",
-          |    "@type" : "knora-api:GeomValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:geometryValueAsGeometry" : "{\"status\":\"active\",\"lineColor\":\"#ff3333\",\"lineWidth\":2,\"points\":[{\"x\":0.08098591549295775,\"y\":0.16741071428571427},{\"x\":0.7394366197183099,\"y\":0.7299107142857143}],\"type\":\"rectangle\",\"original_index\":0}",
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    }
-          |  },
-          |  "anything:hasGeoname" : {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/U_Dw08FDSHWYOvqlvZi3WA",
-          |    "@type" : "knora-api:GeonameValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:geonameValueAsGeonameCode" : "2661604",
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    }
-          |  },
-          |  "anything:hasInteger" : [ {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/QGfE8jxJSqumzvYn37Rsng",
-          |    "@type" : "knora-api:IntValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|V http://rdfh.ch/groups/0001/thing-searcher",
-          |    "knora-api:intValueAsInt" : 5,
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    },
-          |    "knora-api:valueHasComment" : "this is the number five"
-          |  }, {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/e5YJ_1dlRiKsHD8ERNYP4A",
-          |    "@type" : "knora-api:IntValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          |    "knora-api:intValueAsInt" : 6,
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    }
-          |  } ],
-          |  "anything:hasInterval" : {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/ELr-bNGqRRCRJeSjfnNSuA",
-          |    "@type" : "knora-api:IntervalValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          |    "knora-api:intervalValueHasEnd" : {
-          |      "@type" : "xsd:decimal",
-          |      "@value" : "3.4"
-          |    },
-          |    "knora-api:intervalValueHasStart" : {
-          |      "@type" : "xsd:decimal",
-          |      "@value" : "1.2"
-          |    },
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    }
-          |  },
-          |  "anything:hasListItem" : {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/uxIWvgVySRiVZOQUk8ggaA",
-          |    "@type" : "knora-api:ListValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          |    "knora-api:listValueAsListNode" : {
-          |      "@id" : "http://rdfh.ch/lists/0001/treeList03"
-          |    },
-          |    "knora-api:listValueAsListNodeLabel" : "Tree list node 03",
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    }
-          |  },
-          |  "anything:hasOtherThingValue" : {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/fvrSWN1CQWWeTZTABM_NHQ",
-          |    "@type" : "knora-api:LinkValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          |    "knora-api:linkValueHasTarget" : {
-          |      "@id" : "http://rdfh.ch/0001/a-thing",
-          |      "@type" : "anything:Thing",
-          |      "knora-api:arkUrl" : {
-          |        "@type" : "xsd:anyURI",
-          |        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thingO"
-          |      },
-          |      "knora-api:attachedToProject" : {
-          |        "@id" : "http://rdfh.ch/projects/0001"
-          |      },
-          |      "knora-api:attachedToUser" : {
-          |        "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |      },
-          |      "knora-api:creationDate" : {
-          |        "@type" : "xsd:dateTimeStamp",
-          |        "@value" : "2016-03-02T15:05:10Z"
-          |      },
-          |      "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:UnknownUser",
-          |      "knora-api:userHasPermission" : "CR",
-          |      "knora-api:versionArkUrl" : {
-          |        "@type" : "xsd:anyURI",
-          |        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thingO.20160302T150510Z"
-          |      },
-          |      "rdfs:label" : "A thing"
-          |    },
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    }
-          |  },
           |  "anything:hasRichtext" : {
           |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/VY4XodOeSaOdttZ6rEkFPg",
           |    "@type" : "knora-api:TextValue",
@@ -516,38 +350,12 @@ object InstanceCheckerSpec {
           |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
           |    "knora-api:textValueAsXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<text><p><strong>this is</strong> text</p> with standoff</text>",
           |    "knora-api:textValueHasMapping" : {
-          |      "@id" : "http://rdfh.ch/standoff/mappings/StandardMapping"
-          |    },
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    }
-          |  },
-          |  "anything:hasText" : {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/CeOBKM0qSX2KBOy7Yjx_TA",
-          |    "@type" : "knora-api:TextValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          |    "knora-api:userHasPermission" : "CR",
-          |    "knora-api:valueAsString" : "this is text without standoff",
-          |    "knora-api:valueCreationDate" : {
-          |      "@type" : "xsd:dateTimeStamp",
-          |      "@value" : "2019-04-10T08:41:45.353992Z"
-          |    }
-          |  },
-          |  "anything:hasUri" : {
-          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/8FT4QZnJQ2KNtdGpOaUgPw",
-          |    "@type" : "knora-api:UriValue",
-          |    "knora-api:attachedToUser" : {
-          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
-          |    },
-          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
-          |    "knora-api:uriValueAsUri" : {
-          |      "@type" : "xsd:anyURI",
-          |      "@value" : "https://www.knora.org"
+          |      "@id" : "http://rdfh.ch/standoff/mappings/StandardMapping",
+          |      "@type" : "knora-api:XMLToStandoffMapping",
+          |      "knora-api:hasMappingElement" : {
+          |        "@type" : "knora-base:MappingElement",
+          |	       "knora-api:mappingHasXMLTagname" : "p"
+          |      }
           |    },
           |    "knora-api:userHasPermission" : "CR",
           |    "knora-api:valueCreationDate" : {
@@ -582,6 +390,49 @@ object InstanceCheckerSpec {
           |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
           |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
           |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+          |  }
+          |}
+        """.stripMargin
+
+    val simpleThingWithInvalidDatatype: String =
+        """
+          |{
+          |  "@id" : "http://rdfh.ch/0001/oGI65x9pQkK6JhsoqavTGA",
+          |  "@type" : "anything:Thing",
+          |  "anything:hasDecimal" : {
+          |    "@type" : "knora-api:Date",
+          |    "@value" : "GREGORIAN:1489 CE"
+          |  },
+          |  "knora-api:arkUrl" : {
+          |    "@type" : "xsd:anyURI",
+          |    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/oGI65x9pQkK6JhsoqavTGAE"
+          |  },
+          |  "knora-api:versionArkUrl" : {
+          |    "@type" : "xsd:anyURI",
+          |    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/oGI65x9pQkK6JhsoqavTGAE.20190410T124515840198Z"
+          |  },
+          |  "rdfs:label" : "test thing",
+          |  "@context" : {
+          |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+          |    "knora-api" : "http://api.knora.org/ontology/knora-api/simple/v2#",
+          |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+          |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+          |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#"
+          |  }
+          |}
+        """.stripMargin
+
+    val simpleThingWithMissingLabel: String =
+        """
+          |{
+          |  "@id" : "http://rdfh.ch/0001/oGI65x9pQkK6JhsoqavTGA",
+          |  "@type" : "anything:Thing",
+          |  "@context" : {
+          |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+          |    "knora-api" : "http://api.knora.org/ontology/knora-api/simple/v2#",
+          |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+          |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+          |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#"
           |  }
           |}
         """.stripMargin

--- a/webapi/src/test/scala/org/knora/webapi/e2e/InstanceCheckerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/InstanceCheckerSpec.scala
@@ -20,9 +20,11 @@
 package org.knora.webapi.e2e
 
 import akka.actor.ActorSystem
+import akka.event.LoggingAdapter
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import org.knora.webapi.E2ESpec
-import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import com.typesafe.config.{Config, ConfigFactory}
+import org.knora.webapi.{AssertionException, E2ESpec}
+import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.StringFormatter
 
 import scala.concurrent.ExecutionContextExecutor
@@ -30,21 +32,361 @@ import scala.concurrent.ExecutionContextExecutor
 /**
   * Tests [[InstanceChecker]].
   */
-class InstanceCheckerSpec extends E2ESpec {
+class InstanceCheckerSpec extends E2ESpec(InstanceCheckerSpec.config) {
     private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
     implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(settings.defaultTimeout)
+    implicit override lazy val log: LoggingAdapter = akka.event.Logging(system, this.getClass)
 
     implicit val ec: ExecutionContextExecutor = system.dispatcher
 
-    override lazy val rdfDataObjects: List[RdfDataObject] = List(
-        RdfDataObject(path = "_test_data/all_data/anything-data.ttl", name = "http://www.knora.org/data/0001/anything")
-
-    )
-
-    private val instanceChecker: InstanceChecker = InstanceChecker.getJsonLDChecker
+    private val instanceChecker: InstanceChecker = InstanceChecker.getJsonLDChecker(log)
 
     "The InstanceChecker" should {
-
+        "reject an instance with an extra property" in {
+            assertThrows[AssertionException] {
+                instanceChecker.check(
+                    instanceResponse = InstanceCheckerSpec.thingWithExtraProperty,
+                    expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
+                    knoraRouteGet = doGetRequest
+                )
+            }
+        }
     }
+}
+
+object InstanceCheckerSpec {
+    val config: Config = ConfigFactory.parseString(
+        """
+          akka.loglevel = "DEBUG"
+          akka.stdout-loglevel = "DEBUG"
+        """.stripMargin)
+
+    val thingWithExtraProperty: String =
+        """{
+          |  "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg",
+          |  "@type" : "anything:Thing",
+          |  "anything:hasExtraProperty" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/o-j0jdxMQvanmAdpAIOcFA",
+          |    "@type" : "knora-api:BooleanValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:booleanValueAsBoolean" : true,
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "knora-api:arkUrl" : {
+          |    "@type" : "xsd:anyURI",
+          |    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/cUnhrC1DT821lwVWQSwEgg0"
+          |  },
+          |  "knora-api:attachedToProject" : {
+          |    "@id" : "http://rdfh.ch/projects/0001"
+          |  },
+          |  "knora-api:attachedToUser" : {
+          |    "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |  },
+          |  "knora-api:creationDate" : {
+          |    "@type" : "xsd:dateTimeStamp",
+          |    "@value" : "2019-04-10T08:41:45.353992Z"
+          |  },
+          |  "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |  "knora-api:userHasPermission" : "CR",
+          |  "knora-api:versionArkUrl" : {
+          |    "@type" : "xsd:anyURI",
+          |    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/cUnhrC1DT821lwVWQSwEgg0.20190410T084145353992Z"
+          |  },
+          |  "rdfs:label" : "test thing",
+          |  "@context" : {
+          |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+          |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+          |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+          |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+          |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+          |  }
+          |}
+        """.stripMargin
+
+    val correctThingInstance: String =
+        """{
+          |  "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg",
+          |  "@type" : "anything:Thing",
+          |  "anything:hasExtraProperty" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/o-j0jdxMQvanmAdpAIOcFA",
+          |    "@type" : "knora-api:BooleanValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:booleanValueAsBoolean" : true,
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "anything:hasColor" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/mZzh9KauSMeA3J0jE3WW3w",
+          |    "@type" : "knora-api:ColorValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:colorValueAsColor" : "#ff3333",
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "anything:hasDate" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/lj35qx3vRUa6s1Q8s5Z5SA",
+          |    "@type" : "knora-api:DateValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:dateValueHasCalendar" : "GREGORIAN",
+          |    "knora-api:dateValueHasEndEra" : "CE",
+          |    "knora-api:dateValueHasEndYear" : 1489,
+          |    "knora-api:dateValueHasStartEra" : "CE",
+          |    "knora-api:dateValueHasStartYear" : 1489,
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueAsString" : "GREGORIAN:1489 CE",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "anything:hasDecimal" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/Zp50VNGbTmKvgPBRykZeng",
+          |    "@type" : "knora-api:DecimalValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:decimalValueAsDecimal" : {
+          |      "@type" : "xsd:decimal",
+          |      "@value" : "100000000000000.000000000000001"
+          |    },
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "anything:hasGeometry" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/vaJ1MeVmRIWK3cTrc5wVEA",
+          |    "@type" : "knora-api:GeomValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:geometryValueAsGeometry" : "{\"status\":\"active\",\"lineColor\":\"#ff3333\",\"lineWidth\":2,\"points\":[{\"x\":0.08098591549295775,\"y\":0.16741071428571427},{\"x\":0.7394366197183099,\"y\":0.7299107142857143}],\"type\":\"rectangle\",\"original_index\":0}",
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "anything:hasGeoname" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/U_Dw08FDSHWYOvqlvZi3WA",
+          |    "@type" : "knora-api:GeonameValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:geonameValueAsGeonameCode" : "2661604",
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "anything:hasInteger" : [ {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/QGfE8jxJSqumzvYn37Rsng",
+          |    "@type" : "knora-api:IntValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|V http://rdfh.ch/groups/0001/thing-searcher",
+          |    "knora-api:intValueAsInt" : 5,
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    },
+          |    "knora-api:valueHasComment" : "this is the number five"
+          |  }, {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/e5YJ_1dlRiKsHD8ERNYP4A",
+          |    "@type" : "knora-api:IntValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:intValueAsInt" : 6,
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  } ],
+          |  "anything:hasInterval" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/ELr-bNGqRRCRJeSjfnNSuA",
+          |    "@type" : "knora-api:IntervalValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:intervalValueHasEnd" : {
+          |      "@type" : "xsd:decimal",
+          |      "@value" : "3.4"
+          |    },
+          |    "knora-api:intervalValueHasStart" : {
+          |      "@type" : "xsd:decimal",
+          |      "@value" : "1.2"
+          |    },
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "anything:hasListItem" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/uxIWvgVySRiVZOQUk8ggaA",
+          |    "@type" : "knora-api:ListValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:listValueAsListNode" : {
+          |      "@id" : "http://rdfh.ch/lists/0001/treeList03"
+          |    },
+          |    "knora-api:listValueAsListNodeLabel" : "Tree list node 03",
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "anything:hasOtherThingValue" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/fvrSWN1CQWWeTZTABM_NHQ",
+          |    "@type" : "knora-api:LinkValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:linkValueHasTarget" : {
+          |      "@id" : "http://rdfh.ch/0001/a-thing",
+          |      "@type" : "anything:Thing",
+          |      "knora-api:arkUrl" : {
+          |        "@type" : "xsd:anyURI",
+          |        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thingO"
+          |      },
+          |      "knora-api:attachedToProject" : {
+          |        "@id" : "http://rdfh.ch/projects/0001"
+          |      },
+          |      "knora-api:attachedToUser" : {
+          |        "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |      },
+          |      "knora-api:creationDate" : {
+          |        "@type" : "xsd:dateTimeStamp",
+          |        "@value" : "2016-03-02T15:05:10Z"
+          |      },
+          |      "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:UnknownUser",
+          |      "knora-api:userHasPermission" : "CR",
+          |      "knora-api:versionArkUrl" : {
+          |        "@type" : "xsd:anyURI",
+          |        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/a=thingO.20160302T150510Z"
+          |      },
+          |      "rdfs:label" : "A thing"
+          |    },
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "anything:hasRichtext" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/VY4XodOeSaOdttZ6rEkFPg",
+          |    "@type" : "knora-api:TextValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:textValueAsXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<text><p><strong>this is</strong> text</p> with standoff</text>",
+          |    "knora-api:textValueHasMapping" : {
+          |      "@id" : "http://rdfh.ch/standoff/mappings/StandardMapping"
+          |    },
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "anything:hasText" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/CeOBKM0qSX2KBOy7Yjx_TA",
+          |    "@type" : "knora-api:TextValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueAsString" : "this is text without standoff",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "anything:hasUri" : {
+          |    "@id" : "http://rdfh.ch/0001/cUnhrC1DT821lwVWQSwEgg/values/8FT4QZnJQ2KNtdGpOaUgPw",
+          |    "@type" : "knora-api:UriValue",
+          |    "knora-api:attachedToUser" : {
+          |      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |    },
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |    "knora-api:uriValueAsUri" : {
+          |      "@type" : "xsd:anyURI",
+          |      "@value" : "https://www.knora.org"
+          |    },
+          |    "knora-api:userHasPermission" : "CR",
+          |    "knora-api:valueCreationDate" : {
+          |      "@type" : "xsd:dateTimeStamp",
+          |      "@value" : "2019-04-10T08:41:45.353992Z"
+          |    }
+          |  },
+          |  "knora-api:arkUrl" : {
+          |    "@type" : "xsd:anyURI",
+          |    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/cUnhrC1DT821lwVWQSwEgg0"
+          |  },
+          |  "knora-api:attachedToProject" : {
+          |    "@id" : "http://rdfh.ch/projects/0001"
+          |  },
+          |  "knora-api:attachedToUser" : {
+          |    "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+          |  },
+          |  "knora-api:creationDate" : {
+          |    "@type" : "xsd:dateTimeStamp",
+          |    "@value" : "2019-04-10T08:41:45.353992Z"
+          |  },
+          |  "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+          |  "knora-api:userHasPermission" : "CR",
+          |  "knora-api:versionArkUrl" : {
+          |    "@type" : "xsd:anyURI",
+          |    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/cUnhrC1DT821lwVWQSwEgg0.20190410T084145353992Z"
+          |  },
+          |  "rdfs:label" : "test thing",
+          |  "@context" : {
+          |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+          |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+          |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+          |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+          |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+          |  }
+          |}
+        """.stripMargin
 }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
@@ -10,7 +10,7 @@ import akka.http.scaladsl.model.headers.{Accept, BasicHttpCredentials}
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import org.knora.webapi._
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
-import org.knora.webapi.messages.v2.responder.ontologymessages.InputOntologyV2
+import org.knora.webapi.messages.v2.responder.ontologymessages.{InputOntologyV2, TestResponseParsingModeV2}
 import org.knora.webapi.routing.v2.OntologiesRouteV2
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util._
@@ -325,7 +325,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.properties should ===(paramsAsInput.properties)
 
                 // Check that the ontology's last modification date was updated.
@@ -375,7 +375,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects should ===(paramsAsInput.properties.head._2.predicates.head._2.objects)
 
                 // Check that the ontology's last modification date was updated.
@@ -425,7 +425,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects should ===(paramsAsInput.properties.head._2.predicates.head._2.objects)
 
                 // Check that the ontology's last modification date was updated.
@@ -522,7 +522,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.classes should ===(paramsAsInput.classes)
 
                 // Check that cardinalities were inherited from anything:Thing.
@@ -591,7 +591,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.classes should ===(paramsAsInput.classes)
 
                 // Check that cardinalities were inherited from knora-api:Resource.
@@ -641,7 +641,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.classes.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects should ===(paramsAsInput.classes.head._2.predicates.head._2.objects)
 
                 // Check that the ontology's last modification date was updated.
@@ -688,7 +688,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.classes.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects should ===(paramsAsInput.classes.head._2.predicates.head._2.objects)
 
                 // Check that the ontology's last modification date was updated.
@@ -745,7 +745,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.properties should ===(paramsAsInput.properties)
 
                 // Check that the ontology's last modification date was updated.
@@ -822,7 +822,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.classes.head._2.directCardinalities should ===(paramsWithAddedLinkValueCardinality.classes.head._2.directCardinalities)
 
                 // Check that cardinalities were inherited from knora-api:Resource.
@@ -877,7 +877,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.classes.head._2.directCardinalities.isEmpty should ===(true)
 
                 // Check that cardinalities were inherited from knora-api:Resource.
@@ -951,7 +951,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.properties should ===(paramsAsInput.properties)
 
                 // Check that the ontology's last modification date was updated.
@@ -1014,7 +1014,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.classes.head._2.directCardinalities should ===(paramsAsInput.classes.head._2.directCardinalities)
 
                 // Check that cardinalities were inherited from knora-api:Resource.
@@ -1074,7 +1074,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.properties should ===(paramsAsInput.properties)
 
                 // Check that the ontology's last modification date was updated.
@@ -1137,7 +1137,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.classes.head._2.directCardinalities should ===(paramsAsInput.classes.head._2.directCardinalities)
 
                 // Check that cardinalities were inherited from knora-api:Resource.
@@ -1206,7 +1206,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.classes.head._2.directCardinalities.isEmpty should ===(true)
 
                 // Check that cardinalities were inherited from knora-api:Resource.
@@ -1321,7 +1321,7 @@ class OntologyV2R2RSpec extends R2RSpec {
                 val responseJsonDoc = responseToJsonLDDocument(response)
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
-                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, ignoreExtraData = true).unescape
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
                 responseAsInput.properties should ===(paramsAsInput.properties)
 
                 // Check that the ontology's last modification date was updated.

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -563,14 +563,25 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             val resourceIri: IRI = responseJsonDoc.body.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.validateAndEscapeIri)
             assert(resourceIri.toSmartIri.isKnoraDataIri)
 
-            // Request the newly created resource, and check that it matches the ontology.
-            val resourceGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(resourceIri, "UTF-8")}") ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
-            val resourceGetResponse: HttpResponse = singleAwaitingRequest(resourceGetRequest)
-            val resourceGetResponseAsString = responseToString(resourceGetResponse)
+            // Request the newly created resource in the complex schema, and check that it matches the ontology.
+            val resourceComplexGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(resourceIri, "UTF-8")}") ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
+            val resourceComplexGetResponse: HttpResponse = singleAwaitingRequest(resourceComplexGetRequest)
+            val resourceComplexGetResponseAsString = responseToString(resourceComplexGetResponse)
 
             instanceChecker.check(
-                instanceResponse = resourceGetResponseAsString,
+                instanceResponse = resourceComplexGetResponseAsString,
                 expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
+                knoraRouteGet = doGetRequest
+            )
+
+            // Request the newly created resource in the simple schema, and check that it matches the ontology.
+            val resourceSimpleGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(resourceIri, "UTF-8")}").addHeader(new SchemaHeader(RouteUtilV2.SIMPLE_SCHEMA_NAME)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
+            val resourceSimpleGetResponse: HttpResponse = singleAwaitingRequest(resourceSimpleGetRequest)
+            val resourceSimpleGetResponseAsString = responseToString(resourceSimpleGetResponse)
+
+            instanceChecker.check(
+                instanceResponse = resourceSimpleGetResponseAsString,
+                expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
                 knoraRouteGet = doGetRequest
             )
         }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -29,6 +29,7 @@ import akka.http.scaladsl.model.{HttpEntity, HttpResponse, MediaRange, StatusCod
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import com.typesafe.config.{Config, ConfigFactory}
 import org.knora.webapi._
+import org.knora.webapi.e2e.InstanceChecker
 import org.knora.webapi.e2e.v2.ResponseCheckerR2RV2._
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.routing.RouteUtilV2
@@ -62,6 +63,8 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
 
     )
 
+    private val instanceChecker: InstanceChecker = InstanceChecker.getJsonLDChecker
+
     "The resources v2 endpoint" should {
 
         "perform a resource request for the book 'Reise ins Heilige Land' using the complex schema in JSON-LD" in {
@@ -71,6 +74,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLand.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
+            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri, knoraRouteGet = doGetRequest)
         }
 
         "perform a resource request for the book 'Reise ins Heilige Land' using the complex schema in Turtle" in {
@@ -163,6 +167,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithBCEDate.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
+            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
         }
 
         "perform a full resource request for a resource with a date property that represents a period going from BCE to CE" in {

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -66,7 +66,6 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
     private val instanceChecker: InstanceChecker = InstanceChecker.getJsonLDChecker
 
     "The resources v2 endpoint" should {
-
         "perform a resource request for the book 'Reise ins Heilige Land' using the complex schema in JSON-LD" in {
             val request = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode("http://rdfh.ch/0803/2a6221216701", "UTF-8")}")
             val response: HttpResponse = singleAwaitingRequest(request)
@@ -118,6 +117,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLandSimple.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
+            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#book".toSmartIri, knoraRouteGet = doGetRequest)
         }
 
         "perform a resource request for the book 'Reise ins Heilige Land' using the simple schema in Turtle" in {
@@ -177,6 +177,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithBCEDate2.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
+            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
         }
 
         "perform a full resource request for a resource with a list value" ignore { // disabled because the language in which the label is returned is not deterministic
@@ -186,6 +187,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithListValue.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
+            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
         }
 
         "perform a full resource request for a resource with a link (in the complex schema)" in {
@@ -195,6 +197,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithLinkComplex.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
+            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
         }
 
         "perform a full resource request for a resource with a link (in the simple schema)" in {
@@ -204,6 +207,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithLinkSimple.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
+            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
         }
 
         "perform a full resource request for a resource with a Text language (in the complex schema)" in {
@@ -213,6 +217,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithTextLangComplex.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
+            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
         }
 
         "perform a full resource request for a resource with a Text language (in the simple schema)" in {
@@ -222,6 +227,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithTextLangSimple.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
+            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
         }
 
         "perform a full resource request for a past version of a resource, using a URL-encoded xsd:dateTimeStamp" in {

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -63,7 +63,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
 
     )
 
-    private val instanceChecker: InstanceChecker = InstanceChecker.getJsonLDChecker
+    private val instanceChecker: InstanceChecker = InstanceChecker.getJsonLDChecker(log)
 
     "The resources v2 endpoint" should {
         "perform a resource request for the book 'Reise ins Heilige Land' using the complex schema in JSON-LD" in {
@@ -73,7 +73,13 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLand.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
-            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri, knoraRouteGet = doGetRequest)
+
+            // Check that the resource corresponds to the ontology.
+            instanceChecker.check(
+                instanceResponse = responseAsString,
+                expectedClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/v2#book".toSmartIri,
+                knoraRouteGet = doGetRequest
+            )
         }
 
         "perform a resource request for the book 'Reise ins Heilige Land' using the complex schema in Turtle" in {
@@ -117,7 +123,13 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/BookReiseInsHeiligeLandSimple.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
-            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#book".toSmartIri, knoraRouteGet = doGetRequest)
+
+            // Check that the resource corresponds to the ontology.
+            instanceChecker.check(
+                instanceResponse = responseAsString,
+                expectedClassIri = "http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#book".toSmartIri,
+                knoraRouteGet = doGetRequest
+            )
         }
 
         "perform a resource request for the book 'Reise ins Heilige Land' using the simple schema in Turtle" in {
@@ -167,7 +179,13 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithBCEDate.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
-            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
+
+            // Check that the resource corresponds to the ontology.
+            instanceChecker.check(
+                instanceResponse = responseAsString,
+                expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
+                knoraRouteGet = doGetRequest
+            )
         }
 
         "perform a full resource request for a resource with a date property that represents a period going from BCE to CE" in {
@@ -177,7 +195,13 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithBCEDate2.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
-            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
+
+            // Check that the resource corresponds to the ontology.
+            instanceChecker.check(
+                instanceResponse = responseAsString,
+                expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
+                knoraRouteGet = doGetRequest
+            )
         }
 
         "perform a full resource request for a resource with a list value" ignore { // disabled because the language in which the label is returned is not deterministic
@@ -187,7 +211,13 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithListValue.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
-            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
+
+            // Check that the resource corresponds to the ontology.
+            instanceChecker.check(
+                instanceResponse = responseAsString,
+                expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
+                knoraRouteGet = doGetRequest
+            )
         }
 
         "perform a full resource request for a resource with a link (in the complex schema)" in {
@@ -197,7 +227,13 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithLinkComplex.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
-            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
+
+            // Check that the resource corresponds to the ontology.
+            instanceChecker.check(
+                instanceResponse = responseAsString,
+                expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
+                knoraRouteGet = doGetRequest
+            )
         }
 
         "perform a full resource request for a resource with a link (in the simple schema)" in {
@@ -207,7 +243,13 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithLinkSimple.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
-            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
+
+            // Check that the resource corresponds to the ontology.
+            instanceChecker.check(
+                instanceResponse = responseAsString,
+                expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
+                knoraRouteGet = doGetRequest
+            )
         }
 
         "perform a full resource request for a resource with a Text language (in the complex schema)" in {
@@ -217,7 +259,13 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithTextLangComplex.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
-            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
+
+            // Check that the resource corresponds to the ontology.
+            instanceChecker.check(
+                instanceResponse = responseAsString,
+                expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
+                knoraRouteGet = doGetRequest
+            )
         }
 
         "perform a full resource request for a resource with a Text language (in the simple schema)" in {
@@ -227,7 +275,13 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(response.status == StatusCodes.OK, responseAsString)
             val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithTextLangSimple.jsonld"), writeTestDataFiles)
             compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
-            instanceChecker.check(instanceResponse = responseAsString, expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri, knoraRouteGet = doGetRequest)
+
+            // Check that the resource corresponds to the ontology.
+            instanceChecker.check(
+                instanceResponse = responseAsString,
+                expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
+                knoraRouteGet = doGetRequest
+            )
         }
 
         "perform a full resource request for a past version of a resource, using a URL-encoded xsd:dateTimeStamp" in {
@@ -508,6 +562,17 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)
             val resourceIri: IRI = responseJsonDoc.body.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.validateAndEscapeIri)
             assert(resourceIri.toSmartIri.isKnoraDataIri)
+
+            // Request the newly created resource, and check that it matches the ontology.
+            val resourceGetRequest = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode(resourceIri, "UTF-8")}") ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
+            val resourceGetResponse: HttpResponse = singleAwaitingRequest(resourceGetRequest)
+            val resourceGetResponseAsString = responseToString(resourceGetResponse)
+
+            instanceChecker.check(
+                instanceResponse = resourceGetResponseAsString,
+                expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
+                knoraRouteGet = doGetRequest
+            )
         }
 
         "create a resource with a custom creation date" in {

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/NonTriplestoreSpecificGravsearchToCountPrequeryGeneratorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/NonTriplestoreSpecificGravsearchToCountPrequeryGeneratorSpec.scala
@@ -80,7 +80,7 @@ class NonTriplestoreSpecificGravsearchToCountPrequeryGeneratorSpec extends CoreS
 
     }
 
-    val inputQueryWithDecimalOptionalSortCriterionAndFilter =
+    val inputQueryWithDecimalOptionalSortCriterionAndFilter: String =
         """
           |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/simple/v2#>
           |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>


### PR DESCRIPTION
This PR adds a utility, `InstanceChecker`, for use in E2E tests. It checks an instance of a class in a Knora response, by ensuring that the instance corresponds to the class definition returned by Knora. It works with instances in:

* the API v2 complex schema
* the API v2 simple schema
* plain JSON, for use in testing the admin API

`ResourcesRouteV2E2ESpec` now uses `InstanceChecker`. There is also an `InstanceCheckerSpec` for testing `InstanceChecker` itself.

Also:

- [x] Fix inconsistencies that `InstanceChecker` found in ontologies:
  - [x] In `knora-admin`:
    - [x] Add `knora-base:objectDatatypeConstraint` to `knora-admin:givenName` and `knora-admin:familyName`.
  - [x] In `knora-api` in the complex schema:
    - [x] Fix properties that should have `*Base` instead of `*Value` as their `knora-api:subjectType`.
    - [x] Remove `rdf:subject`, `rdf:predicate`, and `rdf:object` from the cardinalities of `knora-api:LinkValue`, and add `knora-api:linkValueHasSource`, `knora-api:linkValueHasSourceIri`, `knora-api:linkValueHasTarget`, and `knora-api:linkValueHasTargetIri`.
    - [x] Add `knora-api:intervalValueHasStart` and `knora-api:intervalValueHasEnd`.
    - [x] In `knora-api:Resource` and `knora-api:Value`, give `knora-api:isDeleted` a cardinality of 0-1 instead of 1.
  - [x] In `knora-api` in the simple schema:
    - [x] Remove `knora-api:creationDate` and `knora-api:lastModificationDate`.
- [x] Include some ontology response parsing functionality from #1259, so we can parse the full contents of ontology responses.
- [x] Change error responses in API v2 to use JSON-LD instead of plain JSON, because otherwise a JSON-LD parser can't parse them **(this may need a change in Knora-ui)**.

Resolves #1290.