### PR TITLE
fix(api-v2): Remove INFORMATION SEPARATOR TWO from text in the simple schema

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -1113,16 +1113,19 @@ case class TextValueContentV2(ontologySchema: OntologySchema,
     override def toJsonLDValue(targetSchema: ApiV2Schema, projectADM: ProjectADM, settings: SettingsImpl): JsonLDValue = {
         targetSchema match {
             case ApiV2Simple =>
+                // Remove INFORMATION SEPARATOR TWO, which is used only internally.
+                val textForSimpleSchema = valueHasString.replace(StringFormatter.INFORMATION_SEPARATOR_TWO.toString, "")
+
                 valueHasLanguage match {
                     case Some(lang) =>
                         // In the simple schema, if this text value specifies a language, return it using a JSON-LD
                         // @language key as per <https://json-ld.org/spec/latest/json-ld/#string-internationalization>.
                         JsonLDUtil.objectWithLangToJsonLDObject(
-                            obj = valueHasString,
+                            obj = textForSimpleSchema,
                             lang = lang
                         )
 
-                    case None => JsonLDString(valueHasString)
+                    case None => JsonLDString(textForSimpleSchema)
                 }
 
             case ApiV2WithValueObjects =>

--- a/webapi/src/main/scala/org/knora/webapi/util/standoff/XMLToStandoffUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/standoff/XMLToStandoffUtil.scala
@@ -497,7 +497,7 @@ class XMLToStandoffUtil(xmlNamespaces: Map[String, IRI] = Map.empty[IRI, String]
             case (acc, hierarchicalTag: HierarchicalStandoffTag) =>
                 acc :+ hierarchicalTag
 
-            // It seems as if the following line should work, but it doesn't. See https://issues.scala-lang.org/browse/SI-10100
+            // It seems as if the following line should work, but it doesn't. See https://github.com/scala/bug/issues/10100
             // case (_, clixTag: ClixMilestoneTag) => throw AssertionException(s"CLIX tag $clixTag cannot be in TextWithStandoff") // This should never happen
 
             // Workaround:

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -584,6 +584,11 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
                 expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
                 knoraRouteGet = doGetRequest
             )
+
+            // Check that the text value with standoff is correct in the simple schema.
+            val resourceSimpleAsJsonLD: JsonLDDocument = JsonLDUtil.parseJsonLD(resourceSimpleGetResponseAsString)
+            val text: String = resourceSimpleAsJsonLD.body.requireString("http://0.0.0.0:3333/ontology/0001/anything/simple/v2#hasRichtext")
+            assert(text == "this is text with standoff")
         }
 
         "create a resource with a custom creation date" in {


### PR DESCRIPTION
Fixes #1298.