### PR TITLE
Support list nodes in Gravsearch

### DIFF
--- a/docs/src/paradox/00-release-notes/next.md
+++ b/docs/src/paradox/00-release-notes/next.md
@@ -24,3 +24,5 @@ Also, please change the **HINT** to the appropriate level:
 
 - MAJOR: Separate the `knora-admin` ontology from `knora-api` (@github[#1263](#1263)).
   Existing repositories must be updated; see `upgrade/1263-knora-admin` for instructions.
+  
+- FEATURE: Add support for searching for specific list values in Gravsearch for both the simple and complex schema (@github[#1314](#1314)).  

--- a/docs/src/paradox/03-apis/api-v2/query-language.md
+++ b/docs/src/paradox/03-apis/api-v2/query-language.md
@@ -90,8 +90,8 @@ The response to a count query request is an object with one predicate,
 A Gravsearch query can be written in either of the two
 @ref:[Knora API v2 schemas](introduction.md#api-schema). The simple schema
 is easier to work with, and is sufficient if you don't need to query
-anything below the level of a Knora value. If your query needs to refer to
-list nodes or standoff markup, you must use the complex schema. Each query must use a single
+anything below the level of a Knora value. If your query needs to refer to 
+standoff markup, you must use the complex schema. Each query must use a single
 schema, with one exception (see @ref:[Date Comparisons](#date-comparisons)).
 
 Gravsearch query results can be requested in the simple or complex schema;
@@ -277,6 +277,12 @@ expressions in the simple schema:
 - Decimal values (`xsd:decimal`)
 - Boolean values (`xsd:boolean`)
 - Date values (`knora-api:Date`)
+- List values (`knora-api:ListNode`)
+
+List values can only be searched for using the equal operator (`=`), 
+performing an exact match on a list node's label. Labels can be given in different languages for a specific list node.
+If one of the given list node labels matches, it is considered a match.
+Note that in the simple schema, uniqueness is not guaranteed (as opposed to the complex schema). 
 
 A Knora value may not be represented as the literal object of a predicate;
 for example, this is not allowed:
@@ -785,7 +791,9 @@ PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
 
 ### Searching for a List Value Referring to a Particular List Node
 
-This is possible only in the complex schema:
+Since list nodes are represented by their Iri in the complex schema, 
+uniqueness is guranteed (as opposed to the simple schema).
+Also all the subnodes of the given list node are considered a match.
 
 ```
 PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -952,6 +952,7 @@ object OntologyConstants {
         val Color: IRI = KnoraApiV2PrefixExpansion + "Color"
         val Interval: IRI = KnoraApiV2PrefixExpansion + "Interval"
         val Geoname: IRI = KnoraApiV2PrefixExpansion + "Geoname"
+        val ListNode: IRI = KnoraApiV2PrefixExpansion + "ListNode"
 
         val Resource: IRI = KnoraApiV2PrefixExpansion + "Resource"
         val ForbiddenResource: IRI = KnoraApiV2PrefixExpansion + "ForbiddenResource"
@@ -1016,7 +1017,7 @@ object OntologyConstants {
             KnoraBase.DateValue -> KnoraApiV2Simple.Date,
             KnoraBase.ColorValue -> KnoraApiV2Simple.Color,
             KnoraBase.GeomValue -> KnoraApiV2Simple.Geom,
-            KnoraBase.ListValue -> Xsd.String,
+            KnoraBase.ListValue -> KnoraApiV2Simple.ListNode,
             KnoraBase.IntervalValue -> KnoraApiV2Simple.Interval,
             KnoraBase.GeonameValue -> KnoraApiV2Simple.Geoname,
             KnoraBase.FileValue -> KnoraApiV2Simple.File,
@@ -1069,7 +1070,8 @@ object OntologyConstants {
             KnoraApiV2Simple.HasAudioFile -> KnoraBase.HasAudioFileValue,
             KnoraApiV2Simple.HasDDDFile -> KnoraBase.HasDDDFileValue,
             KnoraApiV2Simple.HasTextFile -> KnoraBase.HasTextFileValue,
-            KnoraApiV2Simple.HasDocumentFile -> KnoraBase.HasDocumentFileValue
+            KnoraApiV2Simple.HasDocumentFile -> KnoraBase.HasDocumentFileValue,
+            KnoraApiV2Simple.ListNode -> KnoraBase.ListValue
 
         ),
         (ApiV2Complex, InternalSchema) -> Map(

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -985,8 +985,11 @@ object OntologyConstants {
 
         val File: IRI = KnoraApiV2PrefixExpansion + "File"
 
+        // The set of custom datatypes defined in knora-api in the simple schema. InstanceChecker relies on
+        // this.
         val KnoraDatatypes: Set[IRI] = Set(
             Date,
+            ListNode,
             Geom,
             Color,
             Interval,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraBaseToApiV2SimpleTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraBaseToApiV2SimpleTransformationRules.scala
@@ -318,6 +318,25 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
         )
     )
 
+    private val ListNode: ReadClassInfoV2 = makeDatatype(
+        datatypeIri = OntologyConstants.KnoraApiV2Simple.ListNode,
+        xsdStringRestrictionPattern = Some(".+"),
+        predicates = Seq(
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Label,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "List Node"
+                )
+            ),
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Comment,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "Represents a list node."
+                )
+            )
+        )
+    )
+
     private val HasIncomingLink: ReadPropertyInfoV2 = makeProperty(
         propertyIri = OntologyConstants.KnoraApiV2Simple.HasIncomingLink,
         propertyType = OntologyConstants.Owl.ObjectProperty,
@@ -499,7 +518,8 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
         Color,
         Interval,
         Geoname,
-        Geom
+        Geom,
+        ListNode
     ).map {
         classInfo => classInfo.entityInfoContent.classIri -> classInfo
     }.toMap

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -1903,7 +1903,10 @@ case class HierarchicalListValueContentV2(ontologySchema: OntologySchema,
         targetSchema match {
             case ApiV2Simple =>
                 listNodeLabel match {
-                    case Some(labelStr) => JsonLDString(labelStr)
+                    case Some(labelStr) => JsonLDUtil.datatypeValueToJsonLDObject(
+                        value = labelStr,
+                        datatype = OntologyConstants.KnoraApiV2Simple.ListNode.toSmartIri
+                    )
                     case None => throw AssertionException("Can't convert list value to simple schema because it has no list node label")
 
                 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/SparqlQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/SparqlQuery.scala
@@ -380,6 +380,15 @@ case class SubStrFunction(textLiteralVar: QueryVariable, startExpression: Expres
 }
 
 /**
+  * Represents the SPARQL `str` function.
+  *
+  * @param textLiteralVar the variable containing the string literal possibly with a language tag from which the string is to be taken.
+  */
+case class StrFunction(textLiteralVar: QueryVariable) extends Expression {
+    override def toSparql: String = s"""str(${textLiteralVar.toSparql})"""
+}
+
+/**
   * Represents a function call in a filter.
   *
   * @param functionIri the IRI of the function.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
@@ -916,6 +916,10 @@ abstract class AbstractPrequeryGenerator(typeInspectionResult: GravsearchTypeIns
 
                                     handleDateQueryVar(queryVar = queryVar, comparisonOperator = compareExpression.operator, dateValueExpression = compareExpression.rightArg)
 
+                                case OntologyConstants.KnoraApiV2Simple.ListNode =>
+
+                                    throw NotImplementedException(s"Value type ${OntologyConstants.KnoraApiV2Simple.ListNode} will be implemented in this PR :-)")
+
                                 case other => throw NotImplementedException(s"Value type $other not supported in FilterExpression")
 
                             }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
@@ -626,7 +626,7 @@ abstract class AbstractPrequeryGenerator(typeInspectionResult: GravsearchTypeIns
       *
       * @param queryVar           the query variable to be handled.
       * @param comparisonOperator the comparison operator used in the filter pattern.
-      * @param listNodeLabel      the label to match against.
+      * @param literalValueExpression      the label to match against.
       */
     private def handleListQueryVar(queryVar: QueryVariable, comparisonOperator: CompareExpressionOperator.Value, literalValueExpression: Expression): TransformedFilterPattern = {
 
@@ -636,6 +636,12 @@ abstract class AbstractPrequeryGenerator(typeInspectionResult: GravsearchTypeIns
 
             case other => throw GravsearchException(s"Invalid type for literal ${OntologyConstants.KnoraApiV2Simple.ListNode}")
         }
+
+        val validComparisonOperators = Set(CompareExpressionOperator.EQUALS)
+
+        // check if comparison operator is supported
+        if (!validComparisonOperators.contains(comparisonOperator))
+            throw GravsearchException(s"Invalid operator '$comparisonOperator' in expression (allowed operators in this context are ${validComparisonOperators.map(op => "'" + op + "'").mkString(", ")})")
 
         // Generate a variable name representing the list node pointed to by the list value object
         val listNodeVar: QueryVariable = SparqlTransformer.createUniqueVariableNameFromEntityAndProperty(

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/GravsearchTypeInspectionUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/GravsearchTypeInspectionUtil.scala
@@ -84,6 +84,7 @@ object GravsearchTypeInspectionUtil {
         OntologyConstants.KnoraApiV2Simple.Interval,
         OntologyConstants.KnoraApiV2Simple.Color,
         OntologyConstants.KnoraApiV2Simple.File,
+        OntologyConstants.KnoraApiV2Simple.ListNode,
         OntologyConstants.KnoraApiV2WithValueObjects.Resource,
         OntologyConstants.KnoraApiV2WithValueObjects.StandoffTag,
         OntologyConstants.KnoraApiV2WithValueObjects.BooleanValue,

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.jsonld
@@ -348,6 +348,20 @@
       }
     } ]
   }, {
+    "@id" : "knora-api:ListNode",
+    "@type" : "rdfs:Datatype",
+    "rdfs:comment" : "Represents a list node.",
+    "rdfs:label" : "List Node",
+    "rdfs:subClassOf" : {
+      "@type" : "rdfs:Datatype",
+      "owl:onDatatype" : {
+        "@id" : "xsd:string"
+      },
+      "owl:withRestrictions" : {
+        "xsd:pattern" : ".+"
+      }
+    }
+  }, {
     "@id" : "knora-api:MovingImageRepresentation",
     "@type" : "owl:Class",
     "rdfs:comment" : "A resource containing moving image data",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.rdf
@@ -12,24 +12,24 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic class for representing annotations</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b6"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Resource">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents something in the world, or an abstract thing</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Resource</rdfs:label>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b68"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b73"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b0">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b0">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl">
@@ -39,7 +39,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b1">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b1">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasComment">
@@ -51,7 +51,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b2">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b2">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink">
@@ -63,7 +63,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b3">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b3">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo">
@@ -75,7 +75,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b4">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b4">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#isAnnotationOf">
@@ -86,7 +86,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b5">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b5">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl">
@@ -96,7 +96,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b6">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b6">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -104,29 +104,29 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containing audio data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Audio)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b12"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Representation">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can store a file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b62"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b63"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b63"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b68"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b7">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b7">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b8">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b8">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasAudioFile">
@@ -138,19 +138,19 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b9">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b9">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b10">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b10">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b11">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b11">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b12">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b12">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -158,10 +158,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Color literal</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b13">
+		<rdfs:Datatype rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b13">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b14">
+				<rdf:Description rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b14">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">#([0-9a-fA-F]{3}){1,2}</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -172,18 +172,18 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containg 3D data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (3D)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b20"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b15">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b15">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b16">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b16">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasDDDFile">
@@ -195,19 +195,19 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b17">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b17">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b18">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b18">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b19">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b19">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b20">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b20">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -215,10 +215,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date as a period with different possible precisions.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date literal</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b21">
+		<rdfs:Datatype rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b21">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b22">
+				<rdf:Description rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b22">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(GREGORIAN|JULIAN):\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?(:\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?)?</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -228,18 +228,18 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#DocumentRepresentation">
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Document)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b28"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b23">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b23">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b24">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b24">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasDocumentFile">
@@ -251,19 +251,19 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b25">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b25">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b26">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b26">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b27">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b27">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b28">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b28">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -276,34 +276,34 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b34"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b29">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b29">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b30">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b30">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b31">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b31">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b32">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b32">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b33">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b33">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b34">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b34">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -316,10 +316,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Geoname code.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Geoname code</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b35">
+		<rdfs:Datatype rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b35">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b36">
+				<rdf:Description rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b36">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">\d{1,8}</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -330,10 +330,10 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an interval.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interprivate val literal</rdfs:label>
 	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b37">
+		<rdfs:Datatype rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b37">
 			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b38">
+				<rdf:Description rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b38">
 					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">\d+(\.\d+)?,\d+(\.\d+)?</xsd:pattern>
 				</rdf:Description>
 			</owl:withRestrictions>
@@ -345,27 +345,27 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a generic link object</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link Object</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b45"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b39">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b39">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b40">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b40">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b41">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b41">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b42">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b42">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasLinkTo">
@@ -377,38 +377,52 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b43">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b43">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b44">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b44">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b45">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b45">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
+<rdfs:Datatype rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#ListNode">
+	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a list node.</rdfs:comment>
+	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">List Node</rdfs:label>
+	<rdfs:subClassOf>
+		<rdfs:Datatype rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b46">
+			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+			<owl:withRestrictions>
+				<rdf:Description rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b47">
+					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">.+</xsd:pattern>
+				</rdf:Description>
+			</owl:withRestrictions>
+		</rdfs:Datatype>
+	</rdfs:subClassOf>
+</rdfs:Datatype>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#MovingImageRepresentation">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing moving image data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Movie)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b53"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b46">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b48">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b47">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b49">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b48">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b50">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasMovingImageFile">
@@ -420,15 +434,15 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b49">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b51">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b50">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b52">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b51">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b53">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -437,21 +451,21 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometric region of a resource. The geometry is represented currently as JSON string.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b62"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b52">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b54">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b53">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b55">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasColor">
@@ -463,11 +477,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b54">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b56">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b55">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b57">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasGeometry">
@@ -479,15 +493,15 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b56">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b58">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b57">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b59">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b58">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b60">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#isRegionOf">
@@ -499,19 +513,19 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b59">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b61">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b60">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b62">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b61">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b63">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b62">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b64">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasFile">
@@ -523,39 +537,39 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b63">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b65">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b64">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b66">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b65">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b67">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b66">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b68">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b67">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b69">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b68">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b70">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b69">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b71">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b70">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b72">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b71">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b73">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -563,26 +577,26 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can contain a two-dimensional still image file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Image)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b74"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b79"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b72">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b74">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b73">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b75">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b74">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b76">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b75">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b77">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasStillImageFile">
@@ -594,11 +608,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b76">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b78">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b77">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b79">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -606,26 +620,26 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing a text file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Text)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b79"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b81"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b85"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b78">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b80">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b79">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b81">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b80">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b82">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b81">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b83">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasTextFile">
@@ -637,11 +651,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b82">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b84">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b83">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b85">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -649,34 +663,34 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff.  The transformation's result is ecptected to be HTML.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff. The transformation's result is ecptected to be HTML.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#TextRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b84"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b85"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b86"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b87"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b89"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b86"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b87"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b88"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b89"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b90"/>
+	<rdfs:subClassOf rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b91"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b84">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b86">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b85">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b87">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b86">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b88">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b87">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b89">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasTextFile"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b88">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b90">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-fc397bb412dc413ca2889a7726469585-b89">
+<owl:Restriction rdf:nodeID="genid-09ee7caf866849afa4cf01675b009dd2-b91">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.ttl
@@ -309,6 +309,16 @@ knora-api:hasLinkTo a owl:ObjectProperty;
   rdfs:label "has Link to";
   rdfs:subPropertyOf knora-api:resourceProperty .
 
+knora-api:ListNode a rdfs:Datatype;
+  rdfs:comment "Represents a list node.";
+  rdfs:label "List Node";
+  rdfs:subClassOf [ a rdfs:Datatype;
+      owl:onDatatype xsd:string;
+      owl:withRestrictions [
+          xsd:pattern ".+"
+        ]
+    ] .
+
 knora-api:MovingImageRepresentation a owl:Class;
   rdfs:comment "A resource containing moving image data";
   rdfs:label "Representation (Movie)";

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithListNodeLabel.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithListNodeLabel.jsonld
@@ -1,0 +1,49 @@
+{
+  "@id" : "http://rdfh.ch/0001/thing_with_list_value",
+  "@type" : "anything:Thing",
+  "anything:hasListItem" : {
+    "@id" : "http://rdfh.ch/0001/thing_with_list_value/list_value",
+    "@type" : "knora-api:ListValue",
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+    },
+    "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+    "knora-api:listValueAsListNode" : {
+      "@id" : "http://rdfh.ch/lists/0001/treeList02"
+    },
+    "knora-api:listValueAsListNodeLabel" : "Baumlistenknoten 02",
+    "knora-api:userHasPermission" : "V",
+    "knora-api:valueCreationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-01-31T15:05:10Z"
+    }
+  },
+  "knora-api:arkUrl" : {
+    "@type" : "xsd:anyURI",
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO"
+  },
+  "knora-api:attachedToProject" : {
+    "@id" : "http://rdfh.ch/projects/0001"
+  },
+  "knora-api:attachedToUser" : {
+    "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+  },
+  "knora-api:creationDate" : {
+    "@type" : "xsd:dateTimeStamp",
+    "@value" : "2018-01-31T15:05:10Z"
+  },
+  "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+  "knora-api:userHasPermission" : "V",
+  "knora-api:versionArkUrl" : {
+    "@type" : "xsd:anyURI",
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO.20180131T150510Z"
+  },
+  "rdfs:label" : "A thing that has a list value",
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+  }
+}

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithListValue.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithListValue.jsonld
@@ -5,10 +5,39 @@
     "anything:hasListItem" : {
       "@id" : "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/XAhEeE3kSVqM4JPGdLt4Ew",
       "@type" : "knora-api:ListValue",
+      "knora-api:attachedToUser" : {
+        "@id" : "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+      },
+      "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
       "knora-api:listValueAsListNode" : {
         "@id" : "http://rdfh.ch/lists/0001/treeList01"
       },
-      "knora-api:listValueAsListNodeLabel" : "Tree list node 01"
+      "knora-api:listValueAsListNodeLabel" : "Tree list node 01",
+      "knora-api:userHasPermission" : "M",
+      "knora-api:valueCreationDate" : {
+        "@type" : "xsd:dateTimeStamp",
+        "@value" : "2018-05-28T15:52:03.897Z"
+      }
+    },
+    "knora-api:arkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
+    },
+    "knora-api:attachedToProject" : {
+      "@id" : "http://rdfh.ch/projects/0001"
+    },
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+    },
+    "knora-api:creationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-05-28T15:52:03.897Z"
+    },
+    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+    "knora-api:userHasPermission" : "M",
+    "knora-api:versionArkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk.20180528T155203897Z"
     },
     "rdfs:label" : "testding"
   }, {
@@ -17,10 +46,39 @@
     "anything:hasListItem" : {
       "@id" : "http://rdfh.ch/0001/thing_with_list_value/list_value",
       "@type" : "knora-api:ListValue",
+      "knora-api:attachedToUser" : {
+        "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+      },
+      "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
       "knora-api:listValueAsListNode" : {
         "@id" : "http://rdfh.ch/lists/0001/treeList02"
       },
-      "knora-api:listValueAsListNodeLabel" : "Tree list node 02"
+      "knora-api:listValueAsListNodeLabel" : "Baumlistenknoten 02",
+      "knora-api:userHasPermission" : "M",
+      "knora-api:valueCreationDate" : {
+        "@type" : "xsd:dateTimeStamp",
+        "@value" : "2018-01-31T15:05:10Z"
+      }
+    },
+    "knora-api:arkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO"
+    },
+    "knora-api:attachedToProject" : {
+      "@id" : "http://rdfh.ch/projects/0001"
+    },
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+    },
+    "knora-api:creationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-01-31T15:05:10Z"
+    },
+    "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+    "knora-api:userHasPermission" : "M",
+    "knora-api:versionArkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO.20180131T150510Z"
     },
     "rdfs:label" : "A thing that has a list value"
   }, {
@@ -29,17 +87,47 @@
     "anything:hasListItem" : {
       "@id" : "http://rdfh.ch/0001/thing_with_two_list_values/first_list_value",
       "@type" : "knora-api:ListValue",
+      "knora-api:attachedToUser" : {
+        "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+      },
+      "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
       "knora-api:listValueAsListNode" : {
         "@id" : "http://rdfh.ch/lists/0001/treeList01"
       },
-      "knora-api:listValueAsListNodeLabel" : "Tree list node 01"
+      "knora-api:listValueAsListNodeLabel" : "Tree list node 01",
+      "knora-api:userHasPermission" : "M",
+      "knora-api:valueCreationDate" : {
+        "@type" : "xsd:dateTimeStamp",
+        "@value" : "2018-01-31T15:05:10Z"
+      }
+    },
+    "knora-api:arkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_two_list_valuesx"
+    },
+    "knora-api:attachedToProject" : {
+      "@id" : "http://rdfh.ch/projects/0001"
+    },
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+    },
+    "knora-api:creationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-01-31T15:05:10Z"
+    },
+    "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+    "knora-api:userHasPermission" : "M",
+    "knora-api:versionArkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_two_list_valuesx.20180131T150510Z"
     },
     "rdfs:label" : "A thing that has two list values"
   } ],
   "@context" : {
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
     "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
     "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
   }
 }

--- a/webapi/src/test/resources/test-data/searchR2RV2/thingNotReferringToSpecificListNode.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/thingNotReferringToSpecificListNode.jsonld
@@ -1,0 +1,92 @@
+{
+  "@graph" : [ {
+    "@id" : "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw",
+    "@type" : "anything:Thing",
+    "anything:hasListItem" : {
+      "@id" : "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/XAhEeE3kSVqM4JPGdLt4Ew",
+      "@type" : "knora-api:ListValue",
+      "knora-api:attachedToUser" : {
+        "@id" : "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+      },
+      "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+      "knora-api:listValueAsListNode" : {
+        "@id" : "http://rdfh.ch/lists/0001/treeList01"
+      },
+      "knora-api:listValueAsListNodeLabel" : "Tree list node 01",
+      "knora-api:userHasPermission" : "V",
+      "knora-api:valueCreationDate" : {
+        "@type" : "xsd:dateTimeStamp",
+        "@value" : "2018-05-28T15:52:03.897Z"
+      }
+    },
+    "knora-api:arkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
+    },
+    "knora-api:attachedToProject" : {
+      "@id" : "http://rdfh.ch/projects/0001"
+    },
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+    },
+    "knora-api:creationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-05-28T15:52:03.897Z"
+    },
+    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+    "knora-api:userHasPermission" : "V",
+    "knora-api:versionArkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk.20180528T155203897Z"
+    },
+    "rdfs:label" : "testding"
+  }, {
+    "@id" : "http://rdfh.ch/0001/thing_with_two_list_values",
+    "@type" : "anything:Thing",
+    "anything:hasListItem" : {
+      "@id" : "http://rdfh.ch/0001/thing_with_two_list_values/first_list_value",
+      "@type" : "knora-api:ListValue",
+      "knora-api:attachedToUser" : {
+        "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+      },
+      "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+      "knora-api:listValueAsListNode" : {
+        "@id" : "http://rdfh.ch/lists/0001/treeList01"
+      },
+      "knora-api:listValueAsListNodeLabel" : "Tree list node 01",
+      "knora-api:userHasPermission" : "V",
+      "knora-api:valueCreationDate" : {
+        "@type" : "xsd:dateTimeStamp",
+        "@value" : "2018-01-31T15:05:10Z"
+      }
+    },
+    "knora-api:arkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_two_list_valuesx"
+    },
+    "knora-api:attachedToProject" : {
+      "@id" : "http://rdfh.ch/projects/0001"
+    },
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+    },
+    "knora-api:creationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-01-31T15:05:10Z"
+    },
+    "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+    "knora-api:userHasPermission" : "V",
+    "knora-api:versionArkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_two_list_valuesx.20180131T150510Z"
+    },
+    "rdfs:label" : "A thing that has two list values"
+  } ],
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+  }
+}

--- a/webapi/src/test/resources/test-data/searchR2RV2/thingReferringToSpecificListNode.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/thingReferringToSpecificListNode.jsonld
@@ -4,16 +4,46 @@
   "anything:hasListItem" : {
     "@id" : "http://rdfh.ch/0001/thing_with_list_value/list_value",
     "@type" : "knora-api:ListValue",
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+    },
+    "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
     "knora-api:listValueAsListNode" : {
       "@id" : "http://rdfh.ch/lists/0001/treeList02"
     },
-    "knora-api:listValueAsListNodeLabel" : "Tree list node 02"
+    "knora-api:listValueAsListNodeLabel" : "Baumlistenknoten 02",
+    "knora-api:userHasPermission" : "V",
+    "knora-api:valueCreationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-01-31T15:05:10Z"
+    }
+  },
+  "knora-api:arkUrl" : {
+    "@type" : "xsd:anyURI",
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO"
+  },
+  "knora-api:attachedToProject" : {
+    "@id" : "http://rdfh.ch/projects/0001"
+  },
+  "knora-api:attachedToUser" : {
+    "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+  },
+  "knora-api:creationDate" : {
+    "@type" : "xsd:dateTimeStamp",
+    "@value" : "2018-01-31T15:05:10Z"
+  },
+  "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+  "knora-api:userHasPermission" : "V",
+  "knora-api:versionArkUrl" : {
+    "@type" : "xsd:anyURI",
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO.20180131T150510Z"
   },
   "rdfs:label" : "A thing that has a list value",
   "@context" : {
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
     "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
     "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
   }
 }

--- a/webapi/src/test/resources/test-data/searchR2RV2/thingReferringToSpecificListNodeWithSubnodes.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/thingReferringToSpecificListNodeWithSubnodes.jsonld
@@ -1,0 +1,133 @@
+{
+  "@graph" : [ {
+    "@id" : "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw",
+    "@type" : "anything:Thing",
+    "anything:hasListItem" : {
+      "@id" : "http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw/values/XAhEeE3kSVqM4JPGdLt4Ew",
+      "@type" : "knora-api:ListValue",
+      "knora-api:attachedToUser" : {
+        "@id" : "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+      },
+      "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+      "knora-api:listValueAsListNode" : {
+        "@id" : "http://rdfh.ch/lists/0001/treeList01"
+      },
+      "knora-api:listValueAsListNodeLabel" : "Tree list node 01",
+      "knora-api:userHasPermission" : "V",
+      "knora-api:valueCreationDate" : {
+        "@type" : "xsd:dateTimeStamp",
+        "@value" : "2018-05-28T15:52:03.897Z"
+      }
+    },
+    "knora-api:arkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk"
+    },
+    "knora-api:attachedToProject" : {
+      "@id" : "http://rdfh.ch/projects/0001"
+    },
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/BhkfBc3hTeS_IDo-JgXRbQ"
+    },
+    "knora-api:creationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-05-28T15:52:03.897Z"
+    },
+    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+    "knora-api:userHasPermission" : "V",
+    "knora-api:versionArkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/H6gBWUuJSuuO=CilHV8kQwk.20180528T155203897Z"
+    },
+    "rdfs:label" : "testding"
+  }, {
+    "@id" : "http://rdfh.ch/0001/thing_with_list_value",
+    "@type" : "anything:Thing",
+    "anything:hasListItem" : {
+      "@id" : "http://rdfh.ch/0001/thing_with_list_value/list_value",
+      "@type" : "knora-api:ListValue",
+      "knora-api:attachedToUser" : {
+        "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+      },
+      "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+      "knora-api:listValueAsListNode" : {
+        "@id" : "http://rdfh.ch/lists/0001/treeList02"
+      },
+      "knora-api:listValueAsListNodeLabel" : "Baumlistenknoten 02",
+      "knora-api:userHasPermission" : "V",
+      "knora-api:valueCreationDate" : {
+        "@type" : "xsd:dateTimeStamp",
+        "@value" : "2018-01-31T15:05:10Z"
+      }
+    },
+    "knora-api:arkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO"
+    },
+    "knora-api:attachedToProject" : {
+      "@id" : "http://rdfh.ch/projects/0001"
+    },
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+    },
+    "knora-api:creationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-01-31T15:05:10Z"
+    },
+    "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+    "knora-api:userHasPermission" : "V",
+    "knora-api:versionArkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO.20180131T150510Z"
+    },
+    "rdfs:label" : "A thing that has a list value"
+  }, {
+    "@id" : "http://rdfh.ch/0001/thing_with_two_list_values",
+    "@type" : "anything:Thing",
+    "anything:hasListItem" : {
+      "@id" : "http://rdfh.ch/0001/thing_with_two_list_values/first_list_value",
+      "@type" : "knora-api:ListValue",
+      "knora-api:attachedToUser" : {
+        "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+      },
+      "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+      "knora-api:listValueAsListNode" : {
+        "@id" : "http://rdfh.ch/lists/0001/treeList01"
+      },
+      "knora-api:listValueAsListNodeLabel" : "Tree list node 01",
+      "knora-api:userHasPermission" : "V",
+      "knora-api:valueCreationDate" : {
+        "@type" : "xsd:dateTimeStamp",
+        "@value" : "2018-01-31T15:05:10Z"
+      }
+    },
+    "knora-api:arkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_two_list_valuesx"
+    },
+    "knora-api:attachedToProject" : {
+      "@id" : "http://rdfh.ch/projects/0001"
+    },
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+    },
+    "knora-api:creationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-01-31T15:05:10Z"
+    },
+    "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+    "knora-api:userHasPermission" : "V",
+    "knora-api:versionArkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_two_list_valuesx.20180131T150510Z"
+    },
+    "rdfs:label" : "A thing that has two list values"
+  } ],
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+  }
+}

--- a/webapi/src/test/scala/org/knora/webapi/e2e/InstanceChecker.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/InstanceChecker.scala
@@ -413,7 +413,8 @@ object JsonInstanceInspector {
                 OntologyConstants.KnoraApiV2Simple.Geom,
                 OntologyConstants.KnoraApiV2Simple.Color,
                 OntologyConstants.KnoraApiV2Simple.Interval,
-                OntologyConstants.KnoraApiV2Simple.Geoname),
+                OntologyConstants.KnoraApiV2Simple.Geoname,
+                OntologyConstants.KnoraApiV2Simple.ListNode),
 
         IRI -> Set(OntologyConstants.Xsd.Uri, OntologyConstants.KnoraApiV2Simple.File),
         INTEGER -> Set(OntologyConstants.Xsd.Integer, OntologyConstants.Xsd.NonNegativeInteger),

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -5227,21 +5227,19 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             val gravsearchQuery =
                 """
                   |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
-                  |PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
+                  |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/simple/v2#>
                   |
                   |CONSTRUCT {
                   |
                   |?mainRes knora-api:isMainResource true .
                   |
-                  |?mainRes beol:hasSubject ?propVal0 .
+                  |?mainRes anything:hasListItem ?propVal0 .
                   |
                   |} WHERE {
                   |
-                  |?mainRes a beol:letter .
+                  |?mainRes anything:hasListItem ?propVal0 .
                   |
-                  |?mainRes beol:hasSubject ?propVal0 .
-                  |
-                  |FILTER(?propval = "Algebraic equations"^^knora-api:ListNode)
+                  |FILTER(?propVal0 = "Tree list node 02"^^knora-api:ListNode)
                   |
                   |}
                   |
@@ -5252,10 +5250,8 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
                 assert(status == StatusCodes.OK, response.toString)
 
-                println(responseAs[String])
-
-                // val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/ProjectsWithOptionalPersonOrBiblio.jsonld"), writeTestDataFiles)
-                // compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
+                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/ThingWithListNodeLabel.jsonld"), writeTestDataFiles)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
 
             }
         }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -7295,7 +7295,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             }
         }
 
-        "search for a list value that refers to a particular list node (submitting the complex schema)" ignore { // ignored because the list node label returned is not deterministic
+        "search for a list value that refers to a particular list node (submitting the complex schema)" in {
             val gravsearchQuery =
                 """
                   |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
@@ -7319,6 +7319,34 @@ class SearchRouteV2R2RSpec extends R2RSpec {
                 assert(status == StatusCodes.OK, response.toString)
 
                 val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/thingReferringToSpecificListNode.jsonld"), writeTestDataFiles)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
+            }
+        }
+
+        "search for a list value that refers to a particular list node that has subnodes (submitting the complex schema)" in {
+            val gravsearchQuery =
+                """
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+                  |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/v2#>
+                  |
+                  |    CONSTRUCT {
+                  |        ?thing knora-api:isMainResource true .
+                  |
+                  |        ?thing anything:hasListItem ?listItem .
+                  |
+                  |    } WHERE {
+                  |        ?thing anything:hasListItem ?listItem .
+                  |
+                  |        ?listItem knora-api:listValueAsListNode <http://rdfh.ch/lists/0001/treeList> .
+                  |
+                  |    }
+                """.stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> addCredentials(BasicHttpCredentials(incunabulaUserEmail, password)) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/thingReferringToSpecificListNodeWithSubnodes.jsonld"), writeTestDataFiles)
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
             }
         }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -7356,6 +7356,38 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             }
         }
 
+        "search for a list value that does not refer to a particular list node (submitting the complex schema)" in {
+            val gravsearchQuery =
+                """
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+                  |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/v2#>
+                  |
+                  |    CONSTRUCT {
+                  |        ?thing knora-api:isMainResource true .
+                  |
+                  |        ?thing anything:hasListItem ?listItem .
+                  |
+                  |    } WHERE {
+                  |        ?thing anything:hasListItem ?listItem .
+                  |
+                  |        FILTER NOT EXISTS {
+                  |
+                  |         ?listItem knora-api:listValueAsListNode <http://rdfh.ch/lists/0001/treeList02> .
+                  |
+                  |        }
+                  |
+                  |    }
+                """.stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> addCredentials(BasicHttpCredentials(incunabulaUserEmail, password)) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/thingNotReferringToSpecificListNode.jsonld"), writeTestDataFiles)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
+            }
+        }
+
         "search for a list value that refers to a particular list node that has subnodes (submitting the complex schema)" in {
             val gravsearchQuery =
                 """

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -5223,6 +5223,43 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             }
         }
 
+        "do a Gravsearch query that searches for a list node (with type inference)" in {
+            val gravsearchQuery =
+                """
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+                  |PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
+                  |
+                  |CONSTRUCT {
+                  |
+                  |?mainRes knora-api:isMainResource true .
+                  |
+                  |?mainRes beol:hasSubject ?propVal0 .
+                  |
+                  |} WHERE {
+                  |
+                  |?mainRes a beol:letter .
+                  |
+                  |?mainRes beol:hasSubject ?propVal0 .
+                  |
+                  |FILTER(?propval = "Algebraic equations"^^knora-api:ListNode)
+                  |
+                  |}
+                  |
+                  |OFFSET 0
+                """.stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+
+                assert(status == StatusCodes.OK, response.toString)
+
+                println(responseAs[String])
+
+                // val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/ProjectsWithOptionalPersonOrBiblio.jsonld"), writeTestDataFiles)
+                // compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
+
+            }
+        }
+
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Queries that submit the complex schema
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -1983,7 +1983,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
         }
 
-        "search for an anything:Thing with a list value" ignore { // ignored because the list node label returned is not deterministic
+        "search for an anything:Thing with a list value" in {
 
             val gravsearchQuery =
                 """
@@ -2000,9 +2000,9 @@ class SearchRouteV2R2RSpec extends R2RSpec {
                   |
                   |        ?thing anything:hasListItem ?listItem .
                   |
-                  |        anything:hasListItem knora-api:objectType xsd:string .
+                  |        anything:hasListItem knora-api:objectType knora-api:ListNode .
                   |
-                  |        ?listItem a xsd:string .
+                  |        ?listItem a knora-api:ListNode .
                   |
                   |    } OFFSET 0
                 """.stripMargin
@@ -4636,7 +4636,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
         }
 
-        "search for an anything:Thing with a list value (with type inference)" ignore { // ignored because the list node label returned is not deterministic
+        "search for an anything:Thing with a list value (with type inference)" in {
 
             val gravsearchQuery =
                 """
@@ -6665,7 +6665,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
         }
 
-        "search for an anything:Thing with a list value (submitting the complex schema)" ignore { // ignored because the list node label returned is not deterministic
+        "search for an anything:Thing with a list value (submitting the complex schema)" in {
 
             val gravsearchQuery =
                 """


### PR DESCRIPTION
This PR supports list nodes in Gravsearch:
- [x] complex schema: match given list node or any of its subnodes
- [x] simple schema: perform an exact match for the list node's label (without subnodes)

In a future PR I will do some refactoring so the list node label (simple schema) is returned in a deterministic way (user's preferred language), using the list responder (see #1317 ).

closes #1312 