### PR TITLE
Handle List Nodes in Response

### DIFF
--- a/docs/src/paradox/00-release-notes/next.md
+++ b/docs/src/paradox/00-release-notes/next.md
@@ -26,3 +26,5 @@ Also, please change the **HINT** to the appropriate level:
   Existing repositories must be updated; see `upgrade/1263-knora-admin` for instructions.
   
 - FEATURE: Add support for searching for specific list values in Gravsearch for both the simple and complex schema (@github[#1314](#1314)).  
+
+- REFACTOR: List value responses contain the list node's label in the simple schema only (@github[#1321](#1321))

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -893,7 +893,6 @@ object OntologyConstants {
         val BooleanValueAsBoolean: IRI = KnoraApiV2PrefixExpansion + "booleanValueAsBoolean"
 
         val ListValueAsListNode: IRI = KnoraApiV2PrefixExpansion + "listValueAsListNode"
-        val ListValueAsListNodeLabel: IRI = KnoraApiV2PrefixExpansion + "listValueAsListNodeLabel"
 
         val ColorValueAsColor: IRI = KnoraApiV2PrefixExpansion + "colorValueAsColor"
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraBaseToApiV2ComplexTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraBaseToApiV2ComplexTransformationRules.scala
@@ -1160,28 +1160,6 @@ object KnoraBaseToApiV2ComplexTransformationRules extends OntologyTransformation
         )
     )
 
-    private val ListValueAsListNodeLabel: ReadPropertyInfoV2 = makeProperty(
-        propertyIri = OntologyConstants.KnoraApiV2Complex.ListValueAsListNodeLabel,
-        propertyType = OntologyConstants.Owl.ObjectProperty,
-        subPropertyOf = Set(OntologyConstants.KnoraApiV2Complex.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2Complex.ListValue),
-        objectType = Some(OntologyConstants.Xsd.String),
-        predicates = Seq(
-            makePredicate(
-                predicateIri = OntologyConstants.Rdfs.Label,
-                objectsWithLang = Map(
-                    LanguageCodes.EN -> "Hierarchical list value as list node name"
-                )
-            ),
-            makePredicate(
-                predicateIri = OntologyConstants.Rdfs.Comment,
-                objectsWithLang = Map(
-                    LanguageCodes.EN -> "Represents the name of the list node pointed to."
-                )
-            )
-        )
-    )
-
     private val ColorValueAsColor: ReadPropertyInfoV2 = makeProperty(
         propertyIri = OntologyConstants.KnoraApiV2Complex.ColorValueAsColor,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
@@ -1569,8 +1547,7 @@ object KnoraBaseToApiV2ComplexTransformationRules extends OntologyTransformation
     )
 
     private val ListValueCardinalities = Map(
-        OntologyConstants.KnoraApiV2Complex.ListValueAsListNode -> Cardinality.MustHaveOne,
-        OntologyConstants.KnoraApiV2Complex.ListValueAsListNodeLabel -> Cardinality.MustHaveOne
+        OntologyConstants.KnoraApiV2Complex.ListValueAsListNode -> Cardinality.MustHaveOne
     )
 
     private val GeonameValueCardinalities = Map(
@@ -1774,7 +1751,6 @@ object KnoraBaseToApiV2ComplexTransformationRules extends OntologyTransformation
         BooleanValueAsBoolean,
         GeometryValueAsGeometry,
         ListValueAsListNode,
-        ListValueAsListNodeLabel,
         ColorValueAsColor,
         UriValueAsUri,
         GeonameValueAsGeonameCode,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -67,7 +67,7 @@ sealed trait ResourcesResponderRequestV2 extends KnoraRequestV2 {
 case class ResourcesGetRequestV2(resourceIris: Seq[IRI],
                                  propertyIri: Option[SmartIri] = None,
                                  versionDate: Option[Instant] = None,
-                                 targetSchema: ApiV2Schema = ApiV2Complex,
+                                 targetSchema: ApiV2Schema,
                                  schemaOptions: Set[SchemaOption] = Set.empty,
                                  requestingUser: UserADM) extends ResourcesResponderRequestV2
 
@@ -78,7 +78,7 @@ case class ResourcesGetRequestV2(resourceIris: Seq[IRI],
   * @param targetSchema   the schema of the response.
   * @param requestingUser the user making the request.
   */
-case class ResourcesPreviewGetRequestV2(resourceIris: Seq[IRI], targetSchema: ApiV2Schema = ApiV2Complex, requestingUser: UserADM) extends ResourcesResponderRequestV2
+case class ResourcesPreviewGetRequestV2(resourceIris: Seq[IRI], targetSchema: ApiV2Schema, requestingUser: UserADM) extends ResourcesResponderRequestV2
 
 /**
   * Requests the version history of the values of a resource.

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/resourcemessages/ResourceMessagesV2.scala
@@ -75,9 +75,10 @@ case class ResourcesGetRequestV2(resourceIris: Seq[IRI],
   * Requests a preview of one or more resources. A successful response will be a [[ReadResourcesSequenceV2]].
   *
   * @param resourceIris   the IRIs of the resources to obtain a preview for.
+  * @param targetSchema   the schema of the response.
   * @param requestingUser the user making the request.
   */
-case class ResourcesPreviewGetRequestV2(resourceIris: Seq[IRI], requestingUser: UserADM) extends ResourcesResponderRequestV2
+case class ResourcesPreviewGetRequestV2(resourceIris: Seq[IRI], targetSchema: ApiV2Schema = ApiV2Complex, requestingUser: UserADM) extends ResourcesResponderRequestV2
 
 /**
   * Requests the version history of the values of a resource.

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/searchmessages/SearchMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/searchmessages/SearchMessagesV2.scala
@@ -116,12 +116,14 @@ case class SearchResourceByLabelCountRequestV2(searchValue: String,
   * @param offset               the offset to be used for paging.
   * @param limitToProject       limit search to given project.
   * @param limitToResourceClass limit search to given resource class.
+  * @param targetSchema         the schema of the response.
   * @param requestingUser       the user making the request.
   */
 case class SearchResourceByLabelRequestV2(searchValue: String,
                                           offset: Int,
                                           limitToProject: Option[IRI],
                                           limitToResourceClass: Option[SmartIri],
+                                          targetSchema: ApiV2Schema = ApiV2Complex,
                                           requestingUser: UserADM) extends SearchResponderRequestV2
 
 /**
@@ -147,6 +149,7 @@ case class ResourceCountV2(numberOfResources: Int) extends KnoraResponseV2 {
   * @param resourceClass   the IRI of the resource class, in the complex schema.
   * @param orderByProperty the IRI of the property that the resources are to be ordered by, in the complex schema.
   * @param page            the page number of the results page to be returned.
+  * @param targetSchema    the schema of the response.
   * @param schemaOptions   the schema options submitted with the request.
   * @param requestingUser  the user making the request.
   */
@@ -154,5 +157,6 @@ case class SearchResourcesByProjectAndClassRequestV2(projectIri: SmartIri,
                                                      resourceClass: SmartIri,
                                                      orderByProperty: Option[SmartIri],
                                                      page: Int,
+                                                     targetSchema: ApiV2Schema = ApiV2Complex,
                                                      schemaOptions: Set[SchemaOption],
                                                      requestingUser: UserADM) extends SearchResponderRequestV2

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/searchmessages/SearchMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/searchmessages/SearchMessagesV2.scala
@@ -91,7 +91,7 @@ case class GravsearchCountRequestV2(constructQuery: ConstructQuery,
   * @param requestingUser the user making the request.
   */
 case class GravsearchRequestV2(constructQuery: ConstructQuery,
-                               targetSchema: ApiV2Schema = ApiV2Complex,
+                               targetSchema: ApiV2Schema,
                                schemaOptions: Set[SchemaOption] = Set.empty[SchemaOption],
                                requestingUser: UserADM) extends SearchResponderRequestV2
 
@@ -123,7 +123,7 @@ case class SearchResourceByLabelRequestV2(searchValue: String,
                                           offset: Int,
                                           limitToProject: Option[IRI],
                                           limitToResourceClass: Option[SmartIri],
-                                          targetSchema: ApiV2Schema = ApiV2Complex,
+                                          targetSchema: ApiV2Schema,
                                           requestingUser: UserADM) extends SearchResponderRequestV2
 
 /**
@@ -157,6 +157,6 @@ case class SearchResourcesByProjectAndClassRequestV2(projectIri: SmartIri,
                                                      resourceClass: SmartIri,
                                                      orderByProperty: Option[SmartIri],
                                                      page: Int,
-                                                     targetSchema: ApiV2Schema = ApiV2Complex,
+                                                     targetSchema: ApiV2Schema,
                                                      schemaOptions: Set[SchemaOption],
                                                      requestingUser: UserADM) extends SearchResponderRequestV2

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/standoffmessages/StandoffMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/standoffmessages/StandoffMessagesV2.scala
@@ -50,7 +50,7 @@ sealed trait StandoffResponderRequestV2 extends KnoraRequestV2
   * @param targetSchema   the schema of the response.
   * @param requestingUser the user making the request.
   */
-case class GetStandoffPageRequestV2(resourceIri: IRI, valueIri: IRI, offset: Int, targetSchema: ApiV2Schema = ApiV2Complex, requestingUser: UserADM) extends StandoffResponderRequestV2
+case class GetStandoffPageRequestV2(resourceIri: IRI, valueIri: IRI, offset: Int, targetSchema: ApiV2Schema, requestingUser: UserADM) extends StandoffResponderRequestV2
 
 /**
   * Requests all the standoff markup from a text value, except for the first page. A successful response will be a [[GetStandoffResponseV2]].

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/standoffmessages/StandoffMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/standoffmessages/StandoffMessagesV2.scala
@@ -44,11 +44,13 @@ sealed trait StandoffResponderRequestV2 extends KnoraRequestV2
 /**
   * Requests a page of standoff markup from a text value. A successful response will be a [[GetStandoffResponseV2]].
   *
-  * @param resourceIri the IRI of the resource containing the value.
-  * @param valueIri    the IRI of the value.
-  * @param offset      the start index of the first standoff tag to be returned.
+  * @param resourceIri    the IRI of the resource containing the value.
+  * @param valueIri       the IRI of the value.
+  * @param offset         the start index of the first standoff tag to be returned.
+  * @param targetSchema   the schema of the response.
+  * @param requestingUser the user making the request.
   */
-case class GetStandoffPageRequestV2(resourceIri: IRI, valueIri: IRI, offset: Int, requestingUser: UserADM) extends StandoffResponderRequestV2
+case class GetStandoffPageRequestV2(resourceIri: IRI, valueIri: IRI, offset: Int, targetSchema: ApiV2Schema = ApiV2Complex, requestingUser: UserADM) extends StandoffResponderRequestV2
 
 /**
   * Requests all the standoff markup from a text value, except for the first page. A successful response will be a [[GetStandoffResponseV2]].

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -1985,7 +1985,7 @@ case class HierarchicalListValueContentV2(ontologySchema: OntologySchema,
                 JsonLDObject(
                     Map(
                         OntologyConstants.KnoraApiV2Complex.ListValueAsListNode -> JsonLDUtil.iriToJsonLDObject(valueHasListNode)
-                    ) ++ listNodeLabel.map(labelStr => OntologyConstants.KnoraApiV2Complex.ListValueAsListNodeLabel -> JsonLDString(labelStr))
+                    )
                 )
         }
     }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -72,7 +72,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
       */
     def receive(msg: ResourcesResponderRequestV2) = msg match {
         case ResourcesGetRequestV2(resIris, propertyIri, versionDate, targetSchema, schemaOptions, requestingUser) => getResourcesV2(resIris, propertyIri, versionDate, targetSchema, schemaOptions, requestingUser)
-        case ResourcesPreviewGetRequestV2(resIris, requestingUser) => getResourcePreviewV2(resIris, requestingUser)
+        case ResourcesPreviewGetRequestV2(resIris, targetSchema, requestingUser) => getResourcePreviewV2(resIris, targetSchema, requestingUser)
         case ResourceTEIGetRequestV2(resIri, textProperty, mappingIri, gravsearchTemplateIri, headerXSLTIri, requestingUser) => getResourceAsTeiV2(resIri, textProperty, mappingIri, gravsearchTemplateIri, headerXSLTIri, requestingUser)
         case createResourceRequestV2: CreateResourceRequestV2 => createResourceV2(createResourceRequestV2)
         case updateResourceMetadataRequestV2: UpdateResourceMetadataRequestV2 => updateResourceMetadataV2(updateResourceMetadataRequestV2)
@@ -254,6 +254,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
                 // Get the metadata of the resource to be updated.
                 resourcesSeq: ReadResourcesSequenceV2 <- getResourcePreviewV2(
                     resourceIris = Seq(updateResourceMetadataRequestV2.resourceIri),
+                    targetSchema = ApiV2Complex,
                     requestingUser = updateResourceMetadataRequestV2.requestingUser
                 )
 
@@ -309,6 +310,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
 
                 updatedResourcesSeq: ReadResourcesSequenceV2 <- getResourcePreviewV2(
                     resourceIris = Seq(updateResourceMetadataRequestV2.resourceIri),
+                    targetSchema = ApiV2Complex,
                     requestingUser = updateResourceMetadataRequestV2.requestingUser
                 )
 
@@ -358,6 +360,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
                 // Get the metadata of the resource to be updated.
                 resourcesSeq: ReadResourcesSequenceV2 <- getResourcePreviewV2(
                     resourceIris = Seq(deleteResourceV2.resourceIri),
+                    targetSchema = ApiV2Complex,
                     requestingUser = deleteResourceV2.requestingUser
                 )
 
@@ -567,6 +570,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
             // Get information about the existing resources that are targets of links.
             existingTargets: ReadResourcesSequenceV2 <- getResourcePreviewV2(
                 resourceIris = existingTargets.toSeq,
+                targetSchema = ApiV2Complex,
                 requestingUser = requestingUser
             )
 
@@ -1034,6 +1038,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
                         versionDate = versionDate,
                         responderManager = responderManager,
                         knoraIdUtil = knoraIdUtil,
+                        targetSchema = targetSchema,
                         settings = settings,
                         requestingUser = requestingUser
                     )
@@ -1052,7 +1057,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
       * @param requestingUser the the client making the request.
       * @return a [[ReadResourcesSequenceV2]].
       */
-    private def getResourcePreviewV2(resourceIris: Seq[IRI], requestingUser: UserADM): Future[ReadResourcesSequenceV2] = {
+    private def getResourcePreviewV2(resourceIris: Seq[IRI], targetSchema: ApiV2Schema, requestingUser: UserADM): Future[ReadResourcesSequenceV2] = {
 
         // eliminate duplicate Iris
         val resourceIrisDistinct: Seq[IRI] = resourceIris.distinct
@@ -1077,6 +1082,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
                         versionDate = None,
                         responderManager = responderManager,
                         knoraIdUtil = knoraIdUtil,
+                        targetSchema = targetSchema,
                         settings = settings,
                         requestingUser = requestingUser
                     )
@@ -1359,7 +1365,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
         if (targetResourceIris.isEmpty) {
             FastFuture.successful(())
         } else {
-            getResourcePreviewV2(targetResourceIris.toSeq, requestingUser).map(_ => ())
+            getResourcePreviewV2(targetResourceIris.toSeq, targetSchema = ApiV2Complex, requestingUser).map(_ => ())
         }
     }
 
@@ -1677,6 +1683,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
 
             resourcePreviewResponse: ReadResourcesSequenceV2 <- getResourcePreviewV2(
                 resourceIris = Seq(resourceHistoryRequest.resourceIri),
+                targetSchema = ApiV2Complex,
                 requestingUser = resourceHistoryRequest.requestingUser
             )
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -1034,6 +1034,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
                         versionDate = versionDate,
                         responderManager = responderManager,
                         knoraIdUtil = knoraIdUtil,
+                        settings = settings,
                         requestingUser = requestingUser
                     )
             }.toVector
@@ -1076,6 +1077,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
                         versionDate = None,
                         responderManager = responderManager,
                         knoraIdUtil = knoraIdUtil,
+                        settings = settings,
                         requestingUser = requestingUser
                     )
             }.toVector

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -65,7 +65,7 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
         case GravsearchCountRequestV2(query, requestingUser) => gravsearchCountV2(inputQuery = query, requestingUser = requestingUser)
         case GravsearchRequestV2(query, targetSchema, schemaOptions, requestingUser) => gravsearchV2(inputQuery = query, targetSchema = targetSchema, schemaOptions = schemaOptions, requestingUser = requestingUser)
         case SearchResourceByLabelCountRequestV2(searchValue, limitToProject, limitToResourceClass, requestingUser) => searchResourcesByLabelCountV2(searchValue, limitToProject, limitToResourceClass, requestingUser)
-        case SearchResourceByLabelRequestV2(searchValue, offset, limitToProject, limitToResourceClass, requestingUser) => searchResourcesByLabelV2(searchValue, offset, limitToProject, limitToResourceClass, requestingUser)
+        case SearchResourceByLabelRequestV2(searchValue, offset, limitToProject, limitToResourceClass, targetSchema, requestingUser) => searchResourcesByLabelV2(searchValue, offset, limitToProject, limitToResourceClass, targetSchema, requestingUser)
         case resourcesInProjectGetRequestV2: SearchResourcesByProjectAndClassRequestV2 => searchResourcesByProjectAndClassV2(resourcesInProjectGetRequestV2)
         case other => handleUnexpectedMessage(other, log, this.getClass.getName)
     }
@@ -312,6 +312,7 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
                 responderManager = responderManager,
                 knoraIdUtil = knoraIdUtil,
                 settings = settings,
+                targetSchema = targetSchema,
                 requestingUser = requestingUser
             )
 
@@ -592,6 +593,7 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
                 responderManager = responderManager,
                 knoraIdUtil = knoraIdUtil,
                 settings = settings,
+                targetSchema = targetSchema,
                 requestingUser = requestingUser
             )
 
@@ -734,6 +736,7 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
                         forbiddenResource = forbiddenResourceOption,
                         responderManager = responderManager,
                         knoraIdUtil = knoraIdUtil,
+                        targetSchema = resourcesInProjectGetRequestV2.targetSchema,
                         settings = settings,
                         requestingUser = resourcesInProjectGetRequestV2.requestingUser
                     )
@@ -799,6 +802,7 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
       * @param offset               the offset to be used for paging.
       * @param limitToProject       limit search to given project.
       * @param limitToResourceClass limit search to given resource class.
+      * @param targetSchema         the schema of the response.
       * @param requestingUser       the the client making the request.
       * @return a [[ReadResourcesSequenceV2]] representing the resources that have been found.
       */
@@ -806,6 +810,7 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
                                          offset: Int,
                                          limitToProject: Option[IRI],
                                          limitToResourceClass: Option[SmartIri],
+                                         targetSchema: ApiV2Schema,
                                          requestingUser: UserADM): Future[ReadResourcesSequenceV2] = {
 
         val searchPhrase: MatchStringWhileTyping = MatchStringWhileTyping(searchValue)
@@ -866,6 +871,7 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
                 forbiddenResource = forbiddenResourceOption,
                 responderManager = responderManager,
                 knoraIdUtil = knoraIdUtil,
+                targetSchema = targetSchema,
                 settings = settings,
                 requestingUser = requestingUser
             )

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -311,6 +311,7 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
                 forbiddenResource = forbiddenResourceOption,
                 responderManager = responderManager,
                 knoraIdUtil = knoraIdUtil,
+                settings = settings,
                 requestingUser = requestingUser
             )
 
@@ -590,6 +591,7 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
                 forbiddenResource = forbiddenResourceOption,
                 responderManager = responderManager,
                 knoraIdUtil = knoraIdUtil,
+                settings = settings,
                 requestingUser = requestingUser
             )
 
@@ -732,6 +734,7 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
                         forbiddenResource = forbiddenResourceOption,
                         responderManager = responderManager,
                         knoraIdUtil = knoraIdUtil,
+                        settings = settings,
                         requestingUser = resourcesInProjectGetRequestV2.requestingUser
                     )
                 } yield searchResponse
@@ -863,6 +866,7 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
                 forbiddenResource = forbiddenResourceOption,
                 responderManager = responderManager,
                 knoraIdUtil = knoraIdUtil,
+                settings = settings,
                 requestingUser = requestingUser
             )
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
@@ -117,6 +117,7 @@ class StandoffResponderV2(responderData: ResponderData) extends Responder(respon
                 versionDate = None,
                 responderManager = responderManager,
                 knoraIdUtil = knoraIdUtil,
+                targetSchema = getStandoffRequestV2.targetSchema,
                 settings = settings,
                 requestingUser = getStandoffRequestV2.requestingUser
             )

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
@@ -117,6 +117,7 @@ class StandoffResponderV2(responderData: ResponderData) extends Responder(respon
                 versionDate = None,
                 responderManager = responderManager,
                 knoraIdUtil = knoraIdUtil,
+                settings = settings,
                 requestingUser = getStandoffRequestV2.requestingUser
             )
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/StandoffResponderV2.scala
@@ -159,6 +159,7 @@ class StandoffResponderV2(responderData: ResponderData) extends Responder(respon
 
             textRepresentationResponseV2: ReadResourcesSequenceV2 <- (responderManager ? ResourcesGetRequestV2(
                 resourceIris = Vector(xslTransformationIri),
+                targetSchema = ApiV2Complex,
                 requestingUser = requestingUser)).mapTo[ReadResourcesSequenceV2]
             resource = textRepresentationResponseV2.toResource(xslTransformationIri)
 
@@ -861,6 +862,7 @@ class StandoffResponderV2(responderData: ResponderData) extends Responder(respon
                         resourceIri = resourceIri,
                         valueIri = valueIri,
                         offset = offset,
+                        targetSchema = ApiV2Complex,
                         requestingUser = requestingUser)
                 )
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -1447,17 +1447,18 @@ class ValuesResponderV2(responderData: ResponderData) extends Responder(responde
       * Given a set of resource IRIs, checks that they point to Knora resources.
       * If not, throws an exception.
       *
-      * @param targeResourceIris the IRIs to be checked.
+      * @param targetResourceIris the IRIs to be checked.
       * @param requestingUser    the user making the request.
       */
-    private def checkResourceIris(targeResourceIris: Set[IRI], requestingUser: UserADM): Future[Unit] = {
-        if (targeResourceIris.isEmpty) {
+    private def checkResourceIris(targetResourceIris: Set[IRI], requestingUser: UserADM): Future[Unit] = {
+        if (targetResourceIris.isEmpty) {
             FastFuture.successful(())
         } else {
             for {
                 resourcePreviewRequest <- FastFuture.successful(
                     ResourcesPreviewGetRequestV2(
-                        resourceIris = targeResourceIris.toSeq,
+                        resourceIris = targetResourceIris.toSeq,
+                        targetSchema = ApiV2Complex,
                         requestingUser = requestingUser
                     )
                 )
@@ -1586,6 +1587,7 @@ class ValuesResponderV2(responderData: ResponderData) extends Responder(responde
             resourcePreviewRequest <- FastFuture.successful(
                 ResourcesPreviewGetRequestV2(
                     resourceIris = Seq(linkValueContent.referredResourceIri),
+                    targetSchema = ApiV2Complex,
                     requestingUser = requestingUser
                 )
             )

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/GravsearchQueryChecker.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/GravsearchQueryChecker.scala
@@ -162,7 +162,6 @@ object GravsearchQueryChecker {
         OntologyConstants.KnoraApiV2Complex.GeometryValueAsGeometry,
         OntologyConstants.KnoraApiV2Complex.LinkValueHasTarget,
         OntologyConstants.KnoraApiV2Complex.LinkValueHasTargetIri,
-        OntologyConstants.KnoraApiV2Complex.ListValueAsListNodeLabel,
         OntologyConstants.KnoraApiV2Complex.FileValueAsUrl,
         OntologyConstants.KnoraApiV2Complex.FileValueHasFilename,
         OntologyConstants.KnoraApiV2Complex.StillImageFileValueHasIIIFBaseUrl

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/mainquery/GravsearchMainQueryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/mainquery/GravsearchMainQueryGenerator.scala
@@ -258,28 +258,14 @@ object GravsearchMainQueryGenerator {
                 Seq.empty[StatementPattern]
             }
 
-            // WHERE patterns for list node pointed to by value objects (if any)
-            val wherePatternsForListNode = Seq(
-                mainAndDependentResourcesValueObjectsValuePattern,
-                StatementPattern.makeExplicit(subj = mainAndDependentResourceValueObject, pred = IriRef(OntologyConstants.Rdf.Type.toSmartIri), obj = IriRef(OntologyConstants.KnoraBase.ListValue.toSmartIri)),
-                StatementPattern.makeExplicit(subj = mainAndDependentResourceValueObject, pred = IriRef(OntologyConstants.KnoraBase.ValueHasListNode.toSmartIri), obj = listNode),
-                StatementPattern.makeExplicit(subj = listNode, pred = IriRef(OntologyConstants.Rdfs.Label.toSmartIri), obj = listNodeLabel)
-            )
-
-            // return list node assertions
-            val constructPatternsForListNode = Seq(
-                StatementPattern(subj = mainAndDependentResourceValueObject, pred = IriRef(OntologyConstants.KnoraBase.ValueHasListNode.toSmartIri), obj = listNode),
-                StatementPattern(subj = listNode, pred = IriRef(OntologyConstants.Rdfs.Label.toSmartIri), obj = listNodeLabel)
-            )
-
             ConstructQuery(
                 constructClause = ConstructClause(
-                    statements = constructPatternsForMainResource ++ constructPatternsForMainAndDependentResources ++ constructPatternsForMainAndDependentResourcesValues ++ constructPatternsForStandoff ++ constructPatternsForListNode
+                    statements = constructPatternsForMainResource ++ constructPatternsForMainAndDependentResources ++ constructPatternsForMainAndDependentResourcesValues ++ constructPatternsForStandoff
                 ),
                 whereClause = WhereClause(
                     Seq(
                         UnionPattern(
-                            Seq(wherePatternsForMainResource, wherePatternsForMainAndDependentResources, wherePatternsForMainAndDependentResourcesValues, wherePatternsForStandoff, wherePatternsForListNode).filter(_.nonEmpty)
+                            Seq(wherePatternsForMainResource, wherePatternsForMainAndDependentResources, wherePatternsForMainAndDependentResourcesValues, wherePatternsForStandoff).filter(_.nonEmpty)
                         )
                     )
                 )

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
@@ -220,6 +220,8 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
 
                     val schemaOptions: Set[SchemaOption] = RouteUtilV2.getSchemaOptions(requestContext)
 
+                    val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
+
                     val requestMessageFuture: Future[SearchResourcesByProjectAndClassRequestV2] = for {
                         requestingUser <- getUserADM(requestContext)
                     } yield SearchResourcesByProjectAndClassRequestV2(
@@ -227,6 +229,7 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
                         resourceClass = resourceClass.toOntologySchema(ApiV2Complex),
                         orderByProperty = maybeOrderByProperty,
                         page = page,
+                        targetSchema = targetSchema,
                         schemaOptions = schemaOptions,
                         requestingUser = requestingUser
                     )
@@ -333,9 +336,11 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
                             stringFormatter.validateAndEscapeIri(resIri, throw BadRequestException(s"Invalid resource IRI: <$resIri>"))
                     }
 
+                    val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
+
                     val requestMessageFuture: Future[ResourcesPreviewGetRequestV2] = for {
                         requestingUser <- getUserADM(requestContext)
-                    } yield ResourcesPreviewGetRequestV2(resourceIris = resourceIris, requestingUser = requestingUser)
+                    } yield ResourcesPreviewGetRequestV2(resourceIris = resourceIris, targetSchema = targetSchema, requestingUser = requestingUser)
 
                     RouteUtilV2.runRdfRouteWithFuture(
                         requestMessageF = requestMessageFuture,

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
@@ -379,6 +379,8 @@ class SearchRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
 
                     val limitToResourceClass: Option[SmartIri] = getResourceClassFromParams(params)
 
+                    val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
+
                     val requestMessage: Future[SearchResourceByLabelRequestV2] = for {
                         requestingUser <- getUserADM(requestContext)
                     } yield SearchResourceByLabelRequestV2(
@@ -386,6 +388,7 @@ class SearchRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
                         offset = offset,
                         limitToProject = limitToProject,
                         limitToResourceClass = limitToResourceClass,
+                        targetSchema = targetSchema,
                         requestingUser = requestingUser
                     )
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/StandoffRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/StandoffRouteV2.scala
@@ -31,7 +31,7 @@ import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData, Rout
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.SmartIri
 import org.knora.webapi.util.jsonld.JsonLDUtil
-import org.knora.webapi.{ApiV2Complex, BadRequestException, SchemaOption, SchemaOptions}
+import org.knora.webapi._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -63,12 +63,15 @@ class StandoffRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) w
                     val offset: Int = stringFormatter.validateInt(offsetStr, throw BadRequestException(s"Invalid offset: $offsetStr"))
                     val schemaOptions: Set[SchemaOption] = SchemaOptions.ForStandoffSeparateFromTextValues
 
+                    val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
+
                     val requestMessageFuture: Future[GetStandoffPageRequestV2] = for {
                         requestingUser <- getUserADM(requestContext)
                     } yield GetStandoffPageRequestV2(
                         resourceIri = resourceIri.toString,
                         valueIri = valueIri.toString,
                         offset = offset,
+                        targetSchema = targetSchema,
                         requestingUser = requestingUser
                     )
 

--- a/webapi/src/main/scala/org/knora/webapi/util/ConstructResponseUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/ConstructResponseUtilV2.scala
@@ -29,6 +29,7 @@ import org.knora.webapi._
 import org.knora.webapi.messages.admin.responder.projectsmessages.{ProjectGetRequestADM, ProjectGetResponseADM}
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.store.triplestoremessages.SparqlConstructResponse
+import org.knora.webapi.messages.v2.responder.listsmessages.{NodeGetRequestV2, NodeGetResponseV2}
 import org.knora.webapi.messages.v2.responder.ontologymessages.StandoffEntityInfoGetResponseV2
 import org.knora.webapi.messages.v2.responder.resourcemessages._
 import org.knora.webapi.messages.v2.responder.standoffmessages.{GetRemainingStandoffFromTextValueRequestV2, GetStandoffResponseV2, MappingXMLtoStandoff, StandoffTagV2}
@@ -58,7 +59,6 @@ object ConstructResponseUtilV2 {
       * @param userPermission   the permission that the requesting user has on the value.
       * @param assertions       the value objects assertions.
       * @param standoff         standoff assertions, if any.
-      * @param listNode         assertions about the referred list node, if the value points to a list node.
       */
     case class ValueRdfData(valueObjectIri: IRI,
                             valueObjectClass: IRI,
@@ -66,8 +66,7 @@ object ConstructResponseUtilV2 {
                             isIncomingLink: Boolean = false,
                             userPermission: EntityPermission,
                             assertions: Map[IRI, String],
-                            standoff: Map[IRI, Map[IRI, String]],
-                            listNode: Map[IRI, String])
+                            standoff: Map[IRI, Map[IRI, String]])
 
     /**
       * Represents a resource and its values.
@@ -247,8 +246,7 @@ object ConstructResponseUtilV2 {
                                         valueObjectClass = valueObjectClass,
                                         userPermission = valueRdfWithUserPermission.maybeUserPermission.get,
                                         assertions = predicateMapForValueAssertions,
-                                        standoff = Map.empty[IRI, Map[IRI, String]], // link value does not contain standoff
-                                        listNode = Map.empty[IRI, String] // link value cannot point to a list node
+                                        standoff = Map.empty[IRI, Map[IRI, String]] // link value does not contain standoff
                                     ))
 
                                 } else {
@@ -262,10 +260,6 @@ object ConstructResponseUtilV2 {
                                         standoff = standoffAssertions.map {
                                             case (standoffNodeIri: IRI, standoffAssertions: Seq[(IRI, String)]) =>
                                                 (standoffNodeIri, standoffAssertions.toMap)
-                                        },
-                                        listNode = listNodeAssertions.flatMap {
-                                            case (listNodeIri: IRI, assertions: Seq[(IRI, String)]) =>
-                                                assertions.toMap
                                         }))
                                 }
                         }
@@ -627,6 +621,7 @@ object ConstructResponseUtilV2 {
       * @param versionDate               if defined, represents the requested time in the the resources' version history.
       * @param responderManager          the Knora responder manager.
       * @param knoraIdUtil               a [[KnoraIdUtil]].
+      * @param settings                  the application's settings.
       * @param requestingUser            the user making the request.
       * @return a [[LinkValueContentV2]].
       */
@@ -638,6 +633,7 @@ object ConstructResponseUtilV2 {
                                        versionDate: Option[Instant],
                                        responderManager: ActorRef,
                                        knoraIdUtil: KnoraIdUtil,
+                                       settings: SettingsImpl,
                                        requestingUser: UserADM)(implicit timeout: Timeout, executionContext: ExecutionContext): Future[LinkValueContentV2] = {
         val referredResourceIri: IRI = if (valueObject.isIncomingLink) {
             valueObject.assertions(OntologyConstants.Rdf.Subject)
@@ -668,6 +664,7 @@ object ConstructResponseUtilV2 {
                         versionDate = versionDate,
                         responderManager = responderManager,
                         requestingUser = requestingUser,
+                        settings = settings,
                         knoraIdUtil = knoraIdUtil
                     )
                 } yield linkValue.copy(
@@ -682,10 +679,14 @@ object ConstructResponseUtilV2 {
     /**
       * Given a [[ValueRdfData]], constructs a [[ValueContentV2]], considering the specific type of the given [[ValueRdfData]].
       *
-      * @param valueObject   the given [[ValueRdfData]].
-      * @param mappings      the mappings needed for standoff conversions and XSL transformations.
-      * @param queryStandoff if `true`, make separate queries to get the standoff for text values.
-      * @param versionDate   if defined, represents the requested time in the the resources' version history.
+      * @param valueObject      the given [[ValueRdfData]].
+      * @param mappings         the mappings needed for standoff conversions and XSL transformations.
+      * @param queryStandoff    if `true`, make separate queries to get the standoff for text values.
+      * @param versionDate      if defined, represents the requested time in the the resources' version history.
+      * @param responderManager the Knora responder manager.
+      * @param knoraIdUtil      a [[KnoraIdUtil]].
+      * @param settings         the application's settings.
+      * @param requestingUser   the user making the request.
       * @return a [[ValueContentV2]] representing a value.
       */
     private def createValueContentV2FromValueRdfData(resourceIri: IRI,
@@ -695,6 +696,7 @@ object ConstructResponseUtilV2 {
                                                      versionDate: Option[Instant] = None,
                                                      responderManager: ActorRef,
                                                      knoraIdUtil: KnoraIdUtil,
+                                                     settings: SettingsImpl,
                                                      requestingUser: UserADM)(implicit timeout: Timeout, executionContext: ExecutionContext): Future[ValueContentV2] = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -786,17 +788,17 @@ object ConstructResponseUtilV2 {
 
             case OntologyConstants.KnoraBase.ListValue =>
 
-                val listNodeLabel: String = valueObject.listNode.get(OntologyConstants.Rdfs.Label) match {
-                    case Some(nodeLabel: String) => nodeLabel
-                    case None => throw InconsistentTriplestoreDataException(s"Expected ${OntologyConstants.Rdfs.Label} in assertions for a value object of type list value.")
-                }
+                val listNodeIri: String = valueObject.assertions(OntologyConstants.KnoraBase.ValueHasListNode)
 
-                FastFuture.successful(HierarchicalListValueContentV2(
+                // TODO: only query the list node if the response is requested in the simple schema (label is required in the simple schema, but not in the complex schema)
+                for {
+                    nodeResponse <- (responderManager ? NodeGetRequestV2(listNodeIri, requestingUser)).mapTo[NodeGetResponseV2]
+                } yield HierarchicalListValueContentV2(
                     ontologySchema = InternalSchema,
-                    valueHasListNode = valueObject.assertions(OntologyConstants.KnoraBase.ValueHasListNode),
-                    listNodeLabel = Some(listNodeLabel),
+                    valueHasListNode = listNodeIri,
+                    listNodeLabel = nodeResponse.node.getLabelInPreferredLanguage(userLang = requestingUser.lang, fallbackLang = settings.fallbackLanguage),
                     comment = valueCommentOption
-                ))
+                )
 
             case OntologyConstants.KnoraBase.IntervalValue =>
                 FastFuture.successful(IntervalValueContentV2(
@@ -816,6 +818,7 @@ object ConstructResponseUtilV2 {
                     versionDate = versionDate,
                     responderManager = responderManager,
                     requestingUser = requestingUser,
+                    settings = settings,
                     knoraIdUtil = knoraIdUtil
                 )
 
@@ -843,6 +846,10 @@ object ConstructResponseUtilV2 {
       * @param mappings                 the mappings needed for standoff conversions and XSL transformations.
       * @param queryStandoff            if `true`, make separate queries to get the standoff for text values.
       * @param versionDate              if defined, represents the requested time in the the resources' version history.
+      * @param responderManager         the Knora responder manager.
+      * @param knoraIdUtil              a [[KnoraIdUtil]].
+      * @param settings                 the application's settings.
+      * @param requestingUser           the user making the request.
       * @return a [[ReadResourceV2]].
       */
     private def constructReadResourceV2(resourceIri: IRI,
@@ -852,6 +859,7 @@ object ConstructResponseUtilV2 {
                                         versionDate: Option[Instant],
                                         responderManager: ActorRef,
                                         knoraIdUtil: KnoraIdUtil,
+                                        settings: SettingsImpl,
                                         requestingUser: UserADM)(implicit timeout: Timeout, executionContext: ExecutionContext): Future[ReadResourceV2] = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -909,6 +917,7 @@ object ConstructResponseUtilV2 {
                                 queryStandoff = queryStandoff,
                                 responderManager = responderManager,
                                 requestingUser = requestingUser,
+                                settings = settings,
                                 knoraIdUtil = knoraIdUtil
                             )
 
@@ -992,11 +1001,15 @@ object ConstructResponseUtilV2 {
     /**
       * Creates a response to a full resource request.
       *
-      * @param resourceIri     the IRI of the requested resource.
-      * @param resourceRdfData the results returned by the triplestore.
-      * @param mappings        the mappings needed for standoff conversions and XSL transformations.
-      * @param queryStandoff   if `true`, make separate queries to get the standoff for text values.
-      * @param versionDate     if defined, represents the requested time in the the resources' version history.
+      * @param resourceIri      the IRI of the requested resource.
+      * @param resourceRdfData  the results returned by the triplestore.
+      * @param mappings         the mappings needed for standoff conversions and XSL transformations.
+      * @param queryStandoff    if `true`, make separate queries to get the standoff for text values.
+      * @param versionDate      if defined, represents the requested time in the the resources' version history.
+      * @param responderManager the Knora responder manager.
+      * @param knoraIdUtil      a [[KnoraIdUtil]].
+      * @param settings         the application's settings.
+      * @param requestingUser   the user making the request.
       * @return a [[ReadResourceV2]].
       */
     def createFullResourceResponse(resourceIri: IRI,
@@ -1006,6 +1019,7 @@ object ConstructResponseUtilV2 {
                                    versionDate: Option[Instant],
                                    responderManager: ActorRef,
                                    knoraIdUtil: KnoraIdUtil,
+                                   settings: SettingsImpl,
                                    requestingUser: UserADM)(implicit timeout: Timeout, executionContext: ExecutionContext): Future[ReadResourceV2] = {
 
         constructReadResourceV2(
@@ -1016,6 +1030,7 @@ object ConstructResponseUtilV2 {
             versionDate = versionDate,
             responderManager = responderManager,
             requestingUser = requestingUser,
+            settings = settings,
             knoraIdUtil = knoraIdUtil
         )
     }
@@ -1025,7 +1040,13 @@ object ConstructResponseUtilV2 {
       *
       * @param searchResults      the resources that matched the query and the client has permissions to see.
       * @param orderByResourceIri the order in which the resources should be returned.
+      * @param mappings           the mappings to convert standoff to XML, if any.
       * @param queryStandoff      if `true`, make separate queries to get the standoff for text values.
+      * @param forbiddenResource  the ForbiddenResource, if any.
+      * @param responderManager   the Knora responder manager.
+      * @param knoraIdUtil        a [[KnoraIdUtil]].
+      * @param settings           the application's settings.
+      * @param requestingUser     the user making the request.
       * @return a collection of [[ReadResourceV2]] representing the search results.
       */
     def createSearchResponse(searchResults: Map[IRI, ResourceWithValueRdfData],
@@ -1035,6 +1056,7 @@ object ConstructResponseUtilV2 {
                              forbiddenResource: Option[ReadResourceV2],
                              responderManager: ActorRef,
                              knoraIdUtil: KnoraIdUtil,
+                             settings: SettingsImpl,
                              requestingUser: UserADM)(implicit timeout: Timeout, executionContext: ExecutionContext): Future[Vector[ReadResourceV2]] = {
 
         if (orderByResourceIri.toSet != searchResults.keySet && forbiddenResource.isEmpty) throw AssertionException(s"Not all resources are visible, but forbiddenResource is None")
@@ -1057,6 +1079,7 @@ object ConstructResponseUtilV2 {
                             versionDate = None,
                             responderManager = responderManager,
                             knoraIdUtil = knoraIdUtil,
+                            settings = settings,
                             requestingUser = requestingUser
                         )
 

--- a/webapi/src/main/twirl/queries/sparql/v2/getResourcePropertiesAndValuesGraphDB.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/getResourcePropertiesAndValuesGraphDB.scala.txt
@@ -92,9 +92,6 @@ CONSTRUCT {
             knora-base:attachedToProject ?referredResourceProject  ;
             knora-base:creationDate ?referredResourceCreationDate ;
             knora-base:lastModificationDate ?referredResourceLastModificationDate .
-
-        ?valueObject knora-base:valueHasListNode ?listNode .
-        ?listNode rdfs:label ?listNodeLabel .
     }
 
 } WHERE {
@@ -252,12 +249,6 @@ CONSTRUCT {
             }
             @if(queryAllNonStandoff) {
                 UNION {
-                     GRAPH <http://www.ontotext.com/explicit> {
-                        ?valueObject a knora-base:ListValue .
-                        ?valueObject knora-base:valueHasListNode  ?listNode .
-                        ?listNode rdfs:label ?listNodeLabel .
-                     }
-                } UNION {
                     @*
 
                     If the value is a link value, get the referred resource, as long as it hasn't been

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
@@ -2254,12 +2254,6 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:listValueAsListNodeLabel"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
       "owl:cardinality" : 1,
       "owl:onProperty" : {
@@ -5788,20 +5782,6 @@
     },
     "rdfs:comment" : "Represents a reference to a hierarchical list node.",
     "rdfs:label" : "Hierarchical list value as list node",
-    "rdfs:subPropertyOf" : {
-      "@id" : "knora-api:valueHas"
-    }
-  }, {
-    "@id" : "knora-api:listValueAsListNodeLabel",
-    "@type" : "owl:ObjectProperty",
-    "knora-api:objectType" : {
-      "@id" : "xsd:string"
-    },
-    "knora-api:subjectType" : {
-      "@id" : "knora-api:ListValue"
-    },
-    "rdfs:comment" : "Represents the name of the list node pointed to.",
-    "rdfs:label" : "Hierarchical list value as list node name",
     "rdfs:subPropertyOf" : {
       "@id" : "knora-api:valueHas"
     }

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
@@ -18,50 +18,50 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic class for representing annotations</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b19"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Resource">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents something in the world, or an abstract thing</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Resource</rdfs:label>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b376"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b377"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b378"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b379"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b380"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b381"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b382"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b383"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b384"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b385"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b386"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b387"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b388"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b389"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b390"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b391"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b392"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b375"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b376"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b377"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b378"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b379"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b380"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b381"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b382"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b383"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b384"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b385"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b386"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b387"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b388"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b389"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b390"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b391"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b0">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -72,7 +72,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b1">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -83,7 +83,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b2">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -94,7 +94,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b3">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -105,7 +105,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b4">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -115,7 +115,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b5">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -125,7 +125,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b6">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -135,7 +135,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b7">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b7">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasComment">
@@ -150,7 +150,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b8">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -165,7 +165,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b9">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -174,7 +174,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b10">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -189,7 +189,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b11">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -204,7 +204,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b12">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b12">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOf">
@@ -218,7 +218,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b13">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b13">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOfValue">
@@ -231,7 +231,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b14">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b14">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -241,7 +241,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b15">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b15">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -250,7 +250,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b16">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b16">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -261,7 +261,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b17">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b17">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -272,7 +272,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b18">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b18">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -283,7 +283,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b19">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b19">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -292,42 +292,42 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an audio file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b32"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#FileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b175"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b176"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b177"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b178"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b179"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b180"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b181"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b182"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b183"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b184"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b185"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b186"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b175"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b176"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b177"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b178"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b179"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b180"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b181"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b182"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b183"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b184"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b185"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b186"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b20">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b20">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b21">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b21">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#audioFileValueHasDuration">
@@ -339,22 +339,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b22">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b22">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b23">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b23">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b24">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b24">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b25">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b25">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -367,7 +367,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b26">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b26">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -380,22 +380,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b27">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b27">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b28">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b28">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b29">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b29">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b30">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b30">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -406,7 +406,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b31">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b31">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -417,7 +417,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b32">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b32">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -434,85 +434,85 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containing audio data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Audio)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b50"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Representation">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can store a file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b358"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b359"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b360"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b361"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b362"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b363"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b364"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b365"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b366"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b367"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b368"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b369"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b370"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b371"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b372"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b373"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b374"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b375"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b357"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b358"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b359"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b360"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b361"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b362"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b363"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b364"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b365"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b366"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b367"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b368"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b369"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b370"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b371"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b372"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b373"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b374"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b33">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b33">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b34">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b34">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b35">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b35">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b36">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b36">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b37">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b37">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b38">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b38">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b39">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b39">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b40">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b40">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasAudioFileValue">
@@ -527,62 +527,62 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b41">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b41">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b42">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b42">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b43">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b43">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b44">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b44">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b45">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b45">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b46">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b46">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b47">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b47">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b48">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b48">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b49">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b49">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b50">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b50">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#BooleanBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b51"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b51">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b51">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean">
@@ -599,84 +599,84 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b62"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Value">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The base class of classes representing Knora values</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b613"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b614"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b615"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b616"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b617"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b618"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b619"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b620"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b621"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b622"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b612"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b613"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b614"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b615"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b616"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b617"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b618"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b619"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b620"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b621"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b52">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b52">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b53">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b53">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b54">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b54">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b55">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b55">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b56">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b56">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b57">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b57">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b58">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b58">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b59">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b59">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b60">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b60">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b61">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b61">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b62">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b62">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -684,7 +684,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ColorBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b63">
+		<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b63">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor">
@@ -703,69 +703,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in HTML format, e.g. "#33eeff"</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b66"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b68"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b71"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b74"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b64">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b64">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b65">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b65">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b66">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b66">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b67">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b67">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b68">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b68">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b69">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b69">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b70">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b70">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b71">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b71">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b72">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b72">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b73">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b73">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b74">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b74">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -774,75 +774,75 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This represents some 3D-object with mesh data, point cloud, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b77"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b79"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b81"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b83"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b84"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b85"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b86"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b85"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b86"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b75">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b75">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b76">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b76">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b77">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b77">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b78">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b78">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b79">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b79">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b80">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b80">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b81">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b81">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b82">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b82">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b83">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b83">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b84">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b84">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b85">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b85">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b86">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b86">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -852,61 +852,61 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containg 3D data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (3D)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b87"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b89"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b90"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b91"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b92"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b93"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b94"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b95"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b96"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b97"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b98"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b99"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b100"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b101"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b102"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b103"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b104"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b87"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b88"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b89"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b90"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b91"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b92"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b93"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b94"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b95"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b96"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b97"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b98"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b99"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b100"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b101"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b102"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b103"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b104"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b87">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b87">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b88">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b88">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b89">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b89">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b90">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b90">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b91">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b91">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b92">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b92">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b93">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b93">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b94">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b94">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDDDFileValue">
@@ -921,69 +921,69 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b95">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b95">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b96">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b96">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b97">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b97">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b98">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b98">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b99">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b99">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b100">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b100">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b101">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b101">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b102">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b102">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b103">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b103">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b104">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b104">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DateBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b105"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b106"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b107"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b108"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b109"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b110"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b111"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b112"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b113"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b105"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b106"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b107"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b108"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b109"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b110"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b111"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b112"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b113"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b105">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b105">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar">
@@ -995,7 +995,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b106">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b106">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay">
@@ -1007,7 +1007,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b107">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b107">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra">
@@ -1019,7 +1019,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b108">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b108">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth">
@@ -1031,7 +1031,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b109">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b109">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear">
@@ -1043,7 +1043,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b110">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b110">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay">
@@ -1055,7 +1055,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b111">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b111">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra">
@@ -1067,7 +1067,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b112">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b112">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth">
@@ -1079,7 +1079,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b113">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b113">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear">
@@ -1096,117 +1096,117 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Knora date value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b114"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b115"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b116"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b117"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b118"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b119"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b120"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b121"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b122"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b123"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b124"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b125"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b126"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b127"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b128"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b129"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b130"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b131"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b132"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b114"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b115"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b116"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b117"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b118"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b119"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b120"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b121"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b122"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b123"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b124"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b125"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b126"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b127"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b128"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b129"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b130"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b131"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b132"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b114">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b114">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b115">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b115">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b116">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b116">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b117">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b117">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b118">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b118">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b119">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b119">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b120">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b120">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b121">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b121">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b122">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b122">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b123">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b123">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b124">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b124">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b125">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b125">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b126">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b126">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b127">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b127">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b128">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b128">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b129">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b129">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b130">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b130">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b131">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b131">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b132">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b132">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1214,7 +1214,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DecimalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b133">
+		<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b133">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal">
@@ -1233,69 +1233,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary-precision decimal value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b134"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b135"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b136"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b137"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b138"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b139"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b140"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b141"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b142"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b143"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b144"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b134"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b135"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b136"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b137"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b138"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b139"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b140"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b141"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b142"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b143"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b144"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b134">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b134">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b135">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b135">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b136">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b136">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b137">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b137">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b138">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b138">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b139">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b139">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b140">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b140">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b141">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b141">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b142">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b142">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b143">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b143">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b144">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b144">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1303,75 +1303,75 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DocumentFileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b145"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b146"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b147"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b148"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b149"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b150"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b151"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b152"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b153"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b154"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b155"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b156"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b145"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b146"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b147"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b148"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b149"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b150"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b151"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b152"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b153"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b154"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b155"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b156"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b145">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b145">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b146">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b146">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b147">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b147">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b148">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b148">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b149">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b149">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b150">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b150">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b151">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b151">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b152">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b152">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b153">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b153">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b154">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b154">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b155">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b155">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b156">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b156">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1380,61 +1380,61 @@
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Document)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b157"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b158"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b159"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b160"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b161"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b162"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b163"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b164"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b165"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b166"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b167"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b168"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b169"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b170"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b171"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b172"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b173"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b174"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b157"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b158"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b159"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b160"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b161"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b162"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b163"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b164"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b165"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b166"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b167"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b168"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b169"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b170"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b171"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b172"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b173"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b174"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b157">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b157">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b158">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b158">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b159">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b159">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b160">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b160">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b161">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b161">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b162">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b162">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b163">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b163">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b164">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b164">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDocumentFileValue">
@@ -1449,110 +1449,110 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b165">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b165">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b166">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b166">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b167">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b167">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b168">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b168">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b169">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b169">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b170">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b170">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b171">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b171">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b172">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b172">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b173">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b173">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b174">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b174">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b175">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b175">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b176">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b176">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b177">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b177">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b178">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b178">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b179">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b179">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b180">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b180">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b181">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b181">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b182">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b182">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b183">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b183">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b184">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b184">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b185">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b185">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b186">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b186">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1562,110 +1562,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b187"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b188"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b189"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b190"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b191"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b192"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b193"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b194"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b195"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b196"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b197"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b198"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b199"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b200"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b201"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b202"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b203"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b204"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b187"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b188"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b189"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b190"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b191"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b192"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b193"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b194"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b195"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b196"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b197"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b198"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b199"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b200"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b201"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b202"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b203"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b204"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b187">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b187">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b188">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b188">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b189">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b189">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b190">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b190">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b191">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b191">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b192">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b192">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b193">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b193">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b194">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b194">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b195">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b195">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b196">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b196">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b197">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b197">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b198">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b198">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b199">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b199">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b200">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b200">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b201">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b201">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b202">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b202">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b203">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b203">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b204">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b204">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -1674,39 +1674,39 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometrical objects as JSON string</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b205"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b206"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b207"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b208"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b209"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b210"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b211"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b212"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b213"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b214"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b215"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b205"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b206"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b207"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b208"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b209"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b210"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b211"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b212"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b213"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b214"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b215"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b205">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b205">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b206">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b206">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b207">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b207">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b208">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b208">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b209">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b209">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geometryValueAsGeometry">
@@ -1718,32 +1718,32 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b210">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b210">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b211">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b211">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b212">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b212">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b213">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b213">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b214">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b214">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b215">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b215">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1751,39 +1751,39 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#GeonameValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b216"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b217"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b218"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b219"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b220"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b221"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b222"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b223"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b224"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b225"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b226"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b216"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b217"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b218"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b219"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b220"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b221"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b222"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b223"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b224"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b225"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b226"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b216">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b216">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b217">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b217">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b218">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b218">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b219">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b219">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b220">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b220">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geonameValueAsGeonameCode">
@@ -1795,32 +1795,32 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b221">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b221">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b222">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b222">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b223">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b223">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b224">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b224">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b225">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b225">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b226">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b226">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1828,7 +1828,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b227">
+		<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b227">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intValueAsInt">
@@ -1847,79 +1847,79 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b228"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b229"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b230"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b231"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b232"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b233"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b234"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b235"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b236"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b237"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b238"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b228"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b229"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b230"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b231"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b232"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b233"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b234"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b235"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b236"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b237"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b238"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b228">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b228">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b229">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b229">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b230">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b230">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b231">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b231">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b232">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b232">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b233">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b233">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b234">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b234">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b235">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b235">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b236">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b236">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b237">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b237">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b238">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b238">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntervalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b239"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b240"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b239"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b240"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b239">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b239">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd">
@@ -1931,7 +1931,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b240">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b240">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart">
@@ -1948,75 +1948,75 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a time interval, e.g. in an audio recording</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b241"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b242"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b243"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b244"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b245"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b246"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b247"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b248"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b249"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b250"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b251"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b252"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b241"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b242"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b243"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b244"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b245"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b246"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b247"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b248"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b249"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b250"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b251"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b252"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b241">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b241">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b242">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b242">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b243">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b243">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b244">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b244">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b245">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b245">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b246">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b246">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b247">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b247">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b248">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b248">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b249">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b249">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b250">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b250">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b251">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b251">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b252">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b252">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2028,72 +2028,72 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a generic link object</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link Object</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b253"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b254"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b255"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b256"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b257"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b258"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b259"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b260"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b261"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b262"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b263"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b264"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b265"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b266"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b267"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b268"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b269"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b270"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b271"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b272"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b253"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b254"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b255"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b256"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b257"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b258"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b259"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b260"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b261"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b262"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b263"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b264"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b265"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b266"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b267"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b268"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b269"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b270"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b271"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b272"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b253">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b253">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b254">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b254">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b255">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b255">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b256">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b256">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b257">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b257">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b258">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b258">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b259">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b259">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b260">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b260">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b261">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b261">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b262">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b262">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkTo">
@@ -2108,7 +2108,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b263">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b263">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkToValue">
@@ -2123,47 +2123,47 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b264">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b264">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b265">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b265">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b266">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b266">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b267">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b267">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b268">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b268">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b269">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b269">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b270">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b270">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b271">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b271">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b272">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b272">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -2173,52 +2173,52 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A reification node that describes direct links between resources</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
 	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b273"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b274"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b275"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b276"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b277"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b278"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b279"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b280"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b281"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b282"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b283"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b284"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b285"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b286"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b273"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b274"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b275"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b276"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b277"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b278"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b279"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b280"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b281"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b282"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b283"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b284"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b285"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b286"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b273">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b273">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b274">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b274">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b275">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b275">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b276">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b276">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b277">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b277">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b278">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b278">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b279">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b279">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasSource">
@@ -2230,7 +2230,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b280">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b280">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasSourceIri">
@@ -2242,7 +2242,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b281">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b281">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasTarget">
@@ -2254,7 +2254,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b282">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b282">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasTargetIri">
@@ -2266,86 +2266,85 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b283">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b283">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b284">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b284">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b285">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b285">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b286">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b286">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListNode">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a flat or hierarchical list</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b287"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b288"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b287"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b288"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b287">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b287">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b288">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b288">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b289"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b290"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b291"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b292"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b293"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b294"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b295"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b296"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b297"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b298"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b299"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b300"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b289"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b290"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b291"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b292"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b293"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b294"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b295"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b296"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b297"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b298"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b299"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b289">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b289">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b290">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b290">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b291">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b291">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b292">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b292">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b293">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b293">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b294">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b294">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b295">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b295">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#listValueAsListNode">
@@ -2357,34 +2356,22 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b296">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty>
-		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#listValueAsListNodeLabel">
-			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#ListValue"/>
-			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents the name of the list node pointed to.</rdfs:comment>
-			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hierarchical list value as list node name</rdfs:label>
-			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
-		</owl:ObjectProperty>
-	</owl:onProperty>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b297">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b296">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b298">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b297">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b299">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b298">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b300">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b299">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2393,65 +2380,65 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a moving image file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b301"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b302"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b303"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b304"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b305"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b306"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b307"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b308"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b309"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b310"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b311"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b312"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b313"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b314"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b315"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b316"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b317"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b300"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b301"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b302"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b303"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b304"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b305"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b306"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b307"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b308"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b309"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b310"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b311"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b312"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b313"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b314"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b315"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b316"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b301">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b300">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b302">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b301">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b303">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b302">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b304">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b303">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b305">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b304">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b306">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b305">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b307">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b306">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b308">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b307">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b309">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b308">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimX">
@@ -2463,7 +2450,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b310">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b309">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimY">
@@ -2475,7 +2462,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b311">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b310">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDuration">
@@ -2487,7 +2474,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b312">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b311">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasFps">
@@ -2499,7 +2486,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b313">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b312">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasQualityLevel">
@@ -2511,22 +2498,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b314">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b313">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b315">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b314">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b316">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b315">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b317">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b316">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2536,66 +2523,66 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing moving image data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Movie)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b318"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b319"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b320"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b321"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b322"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b323"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b324"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b325"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b326"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b327"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b328"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b329"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b330"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b331"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b332"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b333"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b334"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b335"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b317"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b318"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b319"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b320"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b321"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b322"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b323"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b324"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b325"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b326"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b327"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b328"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b329"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b330"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b331"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b332"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b333"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b334"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b318">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b317">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b319">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b318">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b320">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b319">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b321">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b320">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b322">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b321">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b323">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b322">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b324">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b323">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b325">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b324">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b326">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b325">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasMovingImageFileValue">
@@ -2610,47 +2597,47 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b327">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b326">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b328">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b327">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b329">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b328">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b330">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b329">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b331">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b330">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b332">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b331">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b333">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b332">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b334">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b333">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b335">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b334">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -2662,65 +2649,65 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometric region of a resource. The geometry is represented currently as JSON string.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b336"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b337"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b338"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b339"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b340"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b341"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b342"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b343"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b344"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b345"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b346"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b347"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b348"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b349"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b350"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b351"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b352"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b353"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b354"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b355"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b356"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b357"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b335"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b336"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b337"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b338"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b339"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b340"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b341"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b342"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b343"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b344"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b345"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b346"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b347"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b348"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b349"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b350"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b351"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b352"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b353"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b354"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b355"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b356"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b336">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b335">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b337">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b336">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b338">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b337">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b339">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b338">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b340">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b339">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b341">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b340">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b342">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b341">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b343">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b342">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasColor">
@@ -2736,11 +2723,11 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b344">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b343">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b345">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b344">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasGeometry">
@@ -2755,32 +2742,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b346">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b345">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b347">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b346">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b348">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b347">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b349">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b348">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b350">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b349">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b351">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b350">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOf">
@@ -2795,7 +2782,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b352">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b351">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOfValue">
@@ -2810,67 +2797,67 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b353">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b352">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b354">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b353">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b355">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b354">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b356">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b355">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b357">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b356">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b358">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b357">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b359">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b358">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b360">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b359">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b361">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b360">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b362">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b361">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b363">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b362">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b364">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b363">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b365">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b364">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasFileValue">
@@ -2884,121 +2871,121 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b366">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b365">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b367">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b366">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b368">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b367">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b369">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b368">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b370">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b369">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b371">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b370">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b372">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b371">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b373">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b372">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b374">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b373">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b375">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b374">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b376">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b375">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b377">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b376">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b378">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b377">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b379">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b378">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b380">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b379">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b381">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b380">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b382">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b381">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b383">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b382">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b384">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b383">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b385">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b384">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b386">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b385">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b387">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b386">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b388">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b387">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b389">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b388">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b390">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b389">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b391">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b390">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b392">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b391">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -3007,39 +2994,39 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b393"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b394"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b395"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b396"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b397"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b398"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b399"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b400"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b401"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b402"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b403"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b392"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b393"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b394"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b395"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b396"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b397"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b398"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b399"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b400"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b401"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b402"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a knora-base value type in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b415"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b416"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b417"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b418"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b419"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b420"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b421"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b422"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b423"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b424"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b414"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b415"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b416"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b417"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b418"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b419"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b420"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b421"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b422"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b423"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b393">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b392">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b394">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b393">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3049,7 +3036,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b395">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b394">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3059,7 +3046,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b396">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b395">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3069,7 +3056,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b397">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b396">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3081,7 +3068,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b398">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b397">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3091,7 +3078,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b399">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b398">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3101,7 +3088,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b400">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b399">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3111,7 +3098,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b401">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b400">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3122,7 +3109,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b402">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b401">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3134,7 +3121,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b403">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b402">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3149,69 +3136,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b404"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b405"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b406"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b407"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b408"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b409"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b410"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b411"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b412"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b413"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b414"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b403"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b404"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b405"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b406"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b407"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b408"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b409"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b410"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b411"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b412"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b413"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b404">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b403">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b405">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b404">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b406">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b405">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b407">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b406">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b408">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b407">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b409">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b408">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b410">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b409">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b411">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b410">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b412">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b411">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b413">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b412">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b414">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b413">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3219,63 +3206,63 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a standoff markup tag</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b500"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b501"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b502"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b503"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b504"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b505"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b506"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b507"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b508"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b509"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b499"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b500"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b501"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b502"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b503"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b504"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b505"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b506"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b507"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b508"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b415">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b414">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b416">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b415">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b417">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b416">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b418">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b417">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b419">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b418">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b420">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b419">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b421">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b420">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b422">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b421">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b423">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b422">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b424">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b423">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3285,117 +3272,117 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b425"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b426"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b427"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b428"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b429"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b430"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b431"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b432"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b433"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b434"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b435"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b436"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b437"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b438"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b439"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b440"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b441"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b442"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b443"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b424"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b425"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b426"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b427"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b428"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b429"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b430"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b431"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b432"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b433"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b434"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b435"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b436"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b437"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b438"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b439"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b440"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b441"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b442"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b425">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b424">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b426">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b425">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b427">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b426">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b428">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b427">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b429">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b428">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b430">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b429">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b431">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b430">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b432">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b431">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b433">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b432">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b434">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b433">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b435">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b434">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b436">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b435">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b437">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b436">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b438">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b437">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b439">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b438">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b440">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b439">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b441">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b440">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b442">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b441">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b443">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b442">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3405,69 +3392,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a decimal (floating point) value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b444"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b445"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b446"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b447"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b448"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b449"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b450"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b451"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b452"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b453"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b454"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b443"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b444"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b445"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b446"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b447"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b448"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b449"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b450"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b451"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b452"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b453"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b444">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b443">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b445">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b444">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b446">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b445">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b447">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b446">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b448">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b447">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b449">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b448">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b450">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b449">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b451">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b450">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b452">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b451">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b453">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b452">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b454">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b453">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3477,69 +3464,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b455"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b456"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b457"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b458"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b459"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b460"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b461"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b462"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b463"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b464"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b465"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b454"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b455"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b456"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b457"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b458"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b459"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b460"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b461"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b462"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b463"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b464"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b455">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b454">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b456">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b455">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b457">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b456">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b458">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b457">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b459">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b458">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b460">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b459">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b461">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b460">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b462">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b461">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b463">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b462">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b464">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b463">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b465">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b464">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3549,39 +3536,39 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an internal reference in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b466"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b467"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b468"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b469"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b470"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b471"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b472"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b473"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b474"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b475"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b476"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b465"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b466"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b467"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b468"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b469"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b470"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b471"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b472"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b473"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b474"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b475"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b466">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b465">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b467">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b466">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b468">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b467">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b469">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b468">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b470">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b469">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasInternalReference">
@@ -3590,32 +3577,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b471">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b470">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b472">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b471">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b473">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b472">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b474">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b473">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b475">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b474">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b476">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b475">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3625,75 +3612,75 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an interval in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b477"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b478"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b479"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b480"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b481"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b482"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b483"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b484"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b485"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b486"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b487"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b488"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b476"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b477"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b478"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b479"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b480"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b481"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b482"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b483"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b484"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b485"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b486"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b487"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b477">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b476">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b478">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b477">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b479">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b478">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b480">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b479">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b481">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b480">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b482">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b481">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b483">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b482">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b484">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b483">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b485">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b484">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b486">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b485">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b487">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b486">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b488">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b487">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3702,39 +3689,39 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a reference to a Knora resource in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b489"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b490"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b491"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b492"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b493"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b494"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b495"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b496"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b497"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b498"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b499"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b488"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b489"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b490"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b491"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b492"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b493"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b494"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b495"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b496"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b497"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b498"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b489">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b488">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b490">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b489">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b491">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b490">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b492">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b491">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b493">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b492">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasLink">
@@ -3743,73 +3730,73 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b494">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b493">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b495">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b494">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b496">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b495">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b497">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b496">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b498">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b497">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b499">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b498">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b500">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b499">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b501">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b500">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b502">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b501">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b503">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b502">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b504">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b503">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b505">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b504">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b506">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b505">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b507">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b506">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b508">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b507">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b509">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b508">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
@@ -3818,73 +3805,73 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary URI in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b510"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b511"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b512"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b513"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b514"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b515"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b516"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b517"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b518"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b519"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b520"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b509"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b510"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b511"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b512"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b513"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b514"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b515"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b516"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b517"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b518"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b519"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#UriBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b601"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b600"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b510">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b509">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b511">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b510">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b512">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b511">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b513">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b512">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b514">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b513">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b515">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b514">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b516">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b515">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b517">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b516">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b518">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b517">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b519">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b518">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b520">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b519">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3901,63 +3888,63 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A file containing a two-dimensional still image</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b521"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b522"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b523"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b524"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b525"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b526"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b527"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b528"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b529"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b530"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b531"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b532"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b533"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b534"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b535"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b520"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b521"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b522"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b523"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b524"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b525"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b526"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b527"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b528"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b529"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b530"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b531"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b532"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b533"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b534"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b521">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b520">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b522">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b521">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b523">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b522">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b524">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b523">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b525">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b524">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b526">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b525">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b527">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b526">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b528">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b527">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b529">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b528">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimX">
@@ -3969,7 +3956,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b530">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b529">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimY">
@@ -3981,7 +3968,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b531">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b530">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasIIIFBaseUrl">
@@ -3993,22 +3980,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b532">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b531">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b533">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b532">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b534">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b533">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b535">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b534">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -4018,81 +4005,81 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can contain a two-dimensional still image file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Image)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b536"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b537"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b538"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b539"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b540"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b541"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b542"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b543"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b544"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b545"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b546"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b547"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b548"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b549"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b550"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b551"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b552"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b553"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b535"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b536"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b537"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b538"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b539"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b540"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b541"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b542"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b543"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b544"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b545"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b546"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b547"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b548"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b549"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b550"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b551"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b552"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b536">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b535">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b537">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b536">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b538">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b537">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b539">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b538">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b540">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b539">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b541">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b540">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b542">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b541">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b543">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b542">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b544">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b543">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b545">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b544">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b546">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b545">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b547">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b546">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue">
@@ -4107,32 +4094,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b548">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b547">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b549">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b548">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b550">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b549">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b551">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b550">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b552">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b551">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b553">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b552">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -4141,75 +4128,75 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A text file such as plain Unicode text, LaTeX, TEI/XML, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b554"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b555"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b556"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b557"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b558"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b559"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b560"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b561"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b562"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b563"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b564"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b565"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b553"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b554"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b555"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b556"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b557"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b558"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b559"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b560"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b561"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b562"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b563"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b564"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b554">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b553">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b555">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b554">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b556">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b555">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b557">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b556">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b558">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b557">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b559">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b558">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b560">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b559">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b561">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b560">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b562">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b561">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b563">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b562">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b564">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b563">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b565">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b564">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -4219,81 +4206,81 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing a text file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Text)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b566"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b567"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b568"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b569"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b570"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b571"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b572"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b573"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b574"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b575"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b576"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b577"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b578"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b579"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b580"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b581"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b582"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b583"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b565"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b566"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b567"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b568"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b569"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b570"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b571"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b572"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b573"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b574"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b575"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b576"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b577"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b578"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b579"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b580"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b581"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b582"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b566">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b565">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b567">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b566">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b568">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b567">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b569">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b568">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b570">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b569">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b571">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b570">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b572">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b571">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b573">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b572">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b574">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b573">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b575">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b574">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b576">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b575">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b577">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b576">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue">
@@ -4308,32 +4295,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b578">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b577">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b579">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b578">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b580">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b579">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b581">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b580">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b582">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b581">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b583">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b582">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -4341,55 +4328,55 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#TextValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b584"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b585"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b586"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b587"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b588"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b589"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b590"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b591"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b592"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b593"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b594"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b595"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b596"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b597"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b598"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b599"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b600"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b583"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b584"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b585"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b586"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b587"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b588"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b589"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b590"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b591"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b592"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b593"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b594"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b595"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b596"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b597"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b598"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b599"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b584">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b583">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b585">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b584">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b586">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b585">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b587">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b586">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b588">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b587">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b589">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b588">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b590">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b589">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsHtml">
@@ -4401,7 +4388,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b591">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b590">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsXml">
@@ -4413,7 +4400,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b592">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b591">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasLanguage">
@@ -4425,7 +4412,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b593">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b592">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMapping">
@@ -4437,7 +4424,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b594">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b593">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMarkup">
@@ -4449,7 +4436,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b595">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b594">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMaxStandoffStartIndex">
@@ -4461,7 +4448,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b596">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b595">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasStandoff">
@@ -4473,27 +4460,27 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b597">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b596">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b598">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b597">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b599">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b598">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b600">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b599">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b601">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b600">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
@@ -4502,110 +4489,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a URI</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b602"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b603"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b604"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b605"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b606"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b607"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b608"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b609"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b610"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b611"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b612"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b601"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b602"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b603"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b604"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b605"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b606"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b607"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b608"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b609"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b610"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b611"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b602">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b601">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b603">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b602">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b604">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b603">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b605">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b604">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b606">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b605">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b607">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b606">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b608">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b607">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b609">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b608">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b610">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b609">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b611">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b610">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b612">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b611">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b613">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b612">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b614">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b613">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b615">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b614">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b616">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b615">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b617">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b616">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b618">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b617">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b619">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b618">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b620">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b619">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b621">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b620">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b622">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b621">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
@@ -4614,110 +4601,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff.  The transformation's result is ecptected to be HTML.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff. The transformation's result is ecptected to be HTML.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#TextRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b623"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b624"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b625"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b626"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b627"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b628"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b629"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b630"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b631"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b632"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b633"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b634"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b635"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b636"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b637"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b638"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b639"/>
-	<rdfs:subClassOf rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b640"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b622"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b623"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b624"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b625"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b626"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b627"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b628"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b629"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b630"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b631"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b632"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b633"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b634"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b635"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b636"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b637"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b638"/>
+	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b639"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b623">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b622">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b624">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b623">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b625">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b624">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b626">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b625">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b627">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b626">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b628">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b627">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b629">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b628">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b630">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b629">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b631">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b630">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b632">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b631">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b633">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b632">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b634">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b633">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b635">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b634">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b636">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b635">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b637">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b636">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b638">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b637">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b639">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b638">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-8b5c14c4f85f4a50bddc520328fb8ff2-b640">
+<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b639">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
@@ -1799,9 +1799,6 @@ knora-api:ListValue a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:listValueAsListNode
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:listValueAsListNodeLabel
-    ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
       owl:onProperty knora-api:userHasPermission
@@ -1824,13 +1821,6 @@ knora-api:listValueAsListNode a owl:ObjectProperty;
   knora-api:subjectType knora-api:ListValue;
   rdfs:comment "Represents a reference to a hierarchical list node.";
   rdfs:label "Hierarchical list value as list node";
-  rdfs:subPropertyOf knora-api:valueHas .
-
-knora-api:listValueAsListNodeLabel a owl:ObjectProperty;
-  knora-api:objectType xsd:string;
-  knora-api:subjectType knora-api:ListValue;
-  rdfs:comment "Represents the name of the list node pointed to.";
-  rdfs:label "Hierarchical list value as list node name";
   rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:MovingImageFileValue a owl:Class;

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithListValue.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithListValue.jsonld
@@ -1,19 +1,48 @@
 {
-    "@id": "http://rdfh.ch/0001/thing_with_list_value",
-    "@type": "anything:Thing",
-    "anything:hasListItem": {
-        "@id": "http://rdfh.ch/0001/thing_with_list_value/list_value",
-        "@type": "knora-api:ListValue",
-        "knora-api:listValueAsListNode": {
-            "@id": "http://rdfh.ch/lists/0001/treeList02"
-        },
-        "knora-api:listValueAsListNodeLabel": "Tree list node 02"
+  "@id" : "http://rdfh.ch/0001/thing_with_list_value",
+  "@type" : "anything:Thing",
+  "anything:hasListItem" : {
+    "@id" : "http://rdfh.ch/0001/thing_with_list_value/list_value",
+    "@type" : "knora-api:ListValue",
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
     },
-    "rdfs:label": "A thing that has a list value",
-    "@context": {
-        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "knora-api": "http://api.knora.org/ontology/knora-api/v2#",
-        "anything": "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+    "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+    "knora-api:listValueAsListNode" : {
+      "@id" : "http://rdfh.ch/lists/0001/treeList02"
+    },
+    "knora-api:userHasPermission" : "V",
+    "knora-api:valueCreationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-01-31T15:05:10Z"
     }
+  },
+  "knora-api:arkUrl" : {
+    "@type" : "xsd:anyURI",
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO"
+  },
+  "knora-api:attachedToProject" : {
+    "@id" : "http://rdfh.ch/projects/0001"
+  },
+  "knora-api:attachedToUser" : {
+    "@id" : "http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q"
+  },
+  "knora-api:creationDate" : {
+    "@type" : "xsd:dateTimeStamp",
+    "@value" : "2018-01-31T15:05:10Z"
+  },
+  "knora-api:hasPermissions" : "V knora-admin:UnknownUser|M knora-admin:ProjectMember",
+  "knora-api:userHasPermission" : "V",
+  "knora-api:versionArkUrl" : {
+    "@type" : "xsd:anyURI",
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO.20180131T150510Z"
+  },
+  "rdfs:label" : "A thing that has a list value",
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+  }
 }

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithListValueSimple.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithListValueSimple.jsonld
@@ -1,0 +1,24 @@
+{
+  "@id" : "http://rdfh.ch/0001/thing_with_list_value",
+  "@type" : "anything:Thing",
+  "anything:hasListItem" : {
+    "@type" : "knora-api:ListNode",
+    "@value" : "Tree list node 02"
+  },
+  "knora-api:arkUrl" : {
+    "@type" : "xsd:anyURI",
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO"
+  },
+  "knora-api:versionArkUrl" : {
+    "@type" : "xsd:anyURI",
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0001/thing_with_list_valueO.20180131T150510Z"
+  },
+  "rdfs:label" : "A thing that has a list value",
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/simple/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#"
+  }
+}

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithListNodeLabel.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithListNodeLabel.jsonld
@@ -11,7 +11,6 @@
     "knora-api:listValueAsListNode" : {
       "@id" : "http://rdfh.ch/lists/0001/treeList02"
     },
-    "knora-api:listValueAsListNodeLabel" : "Baumlistenknoten 02",
     "knora-api:userHasPermission" : "V",
     "knora-api:valueCreationDate" : {
       "@type" : "xsd:dateTimeStamp",

--- a/webapi/src/test/resources/test-data/searchR2RV2/ThingWithListValue.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ThingWithListValue.jsonld
@@ -12,7 +12,6 @@
       "knora-api:listValueAsListNode" : {
         "@id" : "http://rdfh.ch/lists/0001/treeList01"
       },
-      "knora-api:listValueAsListNodeLabel" : "Tree list node 01",
       "knora-api:userHasPermission" : "M",
       "knora-api:valueCreationDate" : {
         "@type" : "xsd:dateTimeStamp",
@@ -53,7 +52,6 @@
       "knora-api:listValueAsListNode" : {
         "@id" : "http://rdfh.ch/lists/0001/treeList02"
       },
-      "knora-api:listValueAsListNodeLabel" : "Baumlistenknoten 02",
       "knora-api:userHasPermission" : "M",
       "knora-api:valueCreationDate" : {
         "@type" : "xsd:dateTimeStamp",
@@ -94,7 +92,6 @@
       "knora-api:listValueAsListNode" : {
         "@id" : "http://rdfh.ch/lists/0001/treeList01"
       },
-      "knora-api:listValueAsListNodeLabel" : "Tree list node 01",
       "knora-api:userHasPermission" : "M",
       "knora-api:valueCreationDate" : {
         "@type" : "xsd:dateTimeStamp",

--- a/webapi/src/test/resources/test-data/searchR2RV2/letterWithSubject.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/letterWithSubject.jsonld
@@ -11,7 +11,6 @@
     "knora-api:listValueAsListNode" : {
       "@id" : "http://rdfh.ch/lists/0801/logarithmic_curves"
     },
-    "knora-api:listValueAsListNodeLabel" : "Logarithmic curves",
     "knora-api:userHasPermission" : "V",
     "knora-api:valueCreationDate" : {
       "@type" : "xsd:dateTimeStamp",

--- a/webapi/src/test/resources/test-data/searchR2RV2/thingNotReferringToSpecificListNode.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/thingNotReferringToSpecificListNode.jsonld
@@ -12,7 +12,6 @@
       "knora-api:listValueAsListNode" : {
         "@id" : "http://rdfh.ch/lists/0001/treeList01"
       },
-      "knora-api:listValueAsListNodeLabel" : "Tree list node 01",
       "knora-api:userHasPermission" : "V",
       "knora-api:valueCreationDate" : {
         "@type" : "xsd:dateTimeStamp",
@@ -53,7 +52,6 @@
       "knora-api:listValueAsListNode" : {
         "@id" : "http://rdfh.ch/lists/0001/treeList01"
       },
-      "knora-api:listValueAsListNodeLabel" : "Tree list node 01",
       "knora-api:userHasPermission" : "V",
       "knora-api:valueCreationDate" : {
         "@type" : "xsd:dateTimeStamp",

--- a/webapi/src/test/resources/test-data/searchR2RV2/thingReferringToSpecificListNode.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/thingReferringToSpecificListNode.jsonld
@@ -11,7 +11,6 @@
     "knora-api:listValueAsListNode" : {
       "@id" : "http://rdfh.ch/lists/0001/treeList02"
     },
-    "knora-api:listValueAsListNodeLabel" : "Baumlistenknoten 02",
     "knora-api:userHasPermission" : "V",
     "knora-api:valueCreationDate" : {
       "@type" : "xsd:dateTimeStamp",

--- a/webapi/src/test/resources/test-data/searchR2RV2/thingReferringToSpecificListNodeWithSubnodes.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/thingReferringToSpecificListNodeWithSubnodes.jsonld
@@ -12,7 +12,6 @@
       "knora-api:listValueAsListNode" : {
         "@id" : "http://rdfh.ch/lists/0001/treeList01"
       },
-      "knora-api:listValueAsListNodeLabel" : "Tree list node 01",
       "knora-api:userHasPermission" : "V",
       "knora-api:valueCreationDate" : {
         "@type" : "xsd:dateTimeStamp",
@@ -53,7 +52,6 @@
       "knora-api:listValueAsListNode" : {
         "@id" : "http://rdfh.ch/lists/0001/treeList02"
       },
-      "knora-api:listValueAsListNodeLabel" : "Baumlistenknoten 02",
       "knora-api:userHasPermission" : "V",
       "knora-api:valueCreationDate" : {
         "@type" : "xsd:dateTimeStamp",
@@ -94,7 +92,6 @@
       "knora-api:listValueAsListNode" : {
         "@id" : "http://rdfh.ch/lists/0001/treeList01"
       },
-      "knora-api:listValueAsListNodeLabel" : "Tree list node 01",
       "knora-api:userHasPermission" : "V",
       "knora-api:valueCreationDate" : {
         "@type" : "xsd:dateTimeStamp",

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -208,7 +208,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             )
         }
 
-        "perform a full resource request for a resource with a list value" ignore { // disabled because the language in which the label is returned is not deterministic
+        "perform a full resource request for a resource with a list value" in {
             val request = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode("http://rdfh.ch/0001/thing_with_list_value", "UTF-8")}")
             val response: HttpResponse = singleAwaitingRequest(request)
             val responseAsString = responseToString(response)
@@ -220,6 +220,22 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             instanceChecker.check(
                 instanceResponse = responseAsString,
                 expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing".toSmartIri,
+                knoraRouteGet = doGetRequest
+            )
+        }
+
+        "perform a full resource request for a resource with a list value (in the simple schema)" in {
+            val request = Get(s"$baseApiUrl/v2/resources/${URLEncoder.encode("http://rdfh.ch/0001/thing_with_list_value", "UTF-8")}").addHeader(new SchemaHeader(RouteUtilV2.SIMPLE_SCHEMA_NAME))
+            val response: HttpResponse = singleAwaitingRequest(request)
+            val responseAsString = responseToString(response)
+            assert(response.status == StatusCodes.OK, responseAsString)
+            val expectedAnswerJSONLD = readOrWriteTextFile(responseAsString, new File("src/test/resources/test-data/resourcesR2RV2/ThingWithListValueSimple.jsonld"), writeTestDataFiles)
+            compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAsString)
+
+            // Check that the resource corresponds to the ontology.
+            instanceChecker.check(
+                instanceResponse = responseAsString,
+                expectedClassIri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
                 knoraRouteGet = doGetRequest
             )
         }

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -522,7 +522,7 @@ class ResourcesResponderV2Spec extends CoreSpec() with ImplicitSender {
 
         "return a preview descriptions of the book 'Zeitglöcklein des Lebens und Leidens Christi' in the Incunabula test data" in {
 
-            responderManager ! ResourcesPreviewGetRequestV2(Seq("http://rdfh.ch/0803/c5058f3a"), incunabulaUserProfile)
+            responderManager ! ResourcesPreviewGetRequestV2(Seq("http://rdfh.ch/0803/c5058f3a"), ApiV2Complex, incunabulaUserProfile)
 
             expectMsgPF(timeout) {
                 case response: ReadResourcesSequenceV2 =>
@@ -559,7 +559,7 @@ class ResourcesResponderV2Spec extends CoreSpec() with ImplicitSender {
 
         "return two preview descriptions of the book 'Zeitglöcklein des Lebens und Leidens Christi' and the book 'Reise ins Heilige Land' in the Incunabula test data" in {
 
-            responderManager ! ResourcesPreviewGetRequestV2(Seq("http://rdfh.ch/0803/c5058f3a", "http://rdfh.ch/0803/2a6221216701"), incunabulaUserProfile)
+            responderManager ! ResourcesPreviewGetRequestV2(Seq("http://rdfh.ch/0803/c5058f3a", "http://rdfh.ch/0803/2a6221216701"), ApiV2Complex, incunabulaUserProfile)
 
             expectMsgPF(timeout) {
                 case response: ReadResourcesSequenceV2 =>

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/ResourcesResponderV2Spec.scala
@@ -431,7 +431,7 @@ class ResourcesResponderV2Spec extends CoreSpec() with ImplicitSender {
     )
 
     private def getResource(resourceIri: IRI, requestingUser: UserADM): ReadResourceV2 = {
-        responderManager ! ResourcesGetRequestV2(resourceIris = Seq(resourceIri), requestingUser = anythingUserProfile)
+        responderManager ! ResourcesGetRequestV2(resourceIris = Seq(resourceIri), targetSchema = ApiV2Complex, requestingUser = anythingUserProfile)
 
         expectMsgPF(timeout) {
             case response: ReadResourcesSequenceV2 =>
@@ -510,6 +510,7 @@ class ResourcesResponderV2Spec extends CoreSpec() with ImplicitSender {
             responderManager ! ResourcesGetRequestV2(
                 resourceIris = Seq("http://rdfh.ch/0803/c5058f3a"),
                 versionDate = None,
+                targetSchema = ApiV2Complex,
                 requestingUser = incunabulaUserProfile
             )
 
@@ -536,6 +537,7 @@ class ResourcesResponderV2Spec extends CoreSpec() with ImplicitSender {
             responderManager ! ResourcesGetRequestV2(
                 resourceIris = Seq("http://rdfh.ch/0803/2a6221216701"),
                 versionDate = None,
+                targetSchema = ApiV2Complex,
                 requestingUser = incunabulaUserProfile
             )
 
@@ -548,7 +550,7 @@ class ResourcesResponderV2Spec extends CoreSpec() with ImplicitSender {
 
         "return two full description of the book 'Zeitglöcklein des Lebens und Leidens Christi' and the book 'Reise ins Heilige Land' in the Incunabula test data" in {
 
-            responderManager ! ResourcesGetRequestV2(resourceIris = Seq("http://rdfh.ch/0803/c5058f3a", "http://rdfh.ch/0803/2a6221216701"), versionDate = None, requestingUser = incunabulaUserProfile)
+            responderManager ! ResourcesGetRequestV2(resourceIris = Seq("http://rdfh.ch/0803/c5058f3a", "http://rdfh.ch/0803/2a6221216701"), versionDate = None, targetSchema = ApiV2Complex, requestingUser = incunabulaUserProfile)
 
             expectMsgPF(timeout) {
                 case response: ReadResourcesSequenceV2 =>
@@ -573,6 +575,7 @@ class ResourcesResponderV2Spec extends CoreSpec() with ImplicitSender {
             responderManager ! ResourcesGetRequestV2(
                 resourceIris = Seq("http://rdfh.ch/0803/2a6221216701", "http://rdfh.ch/0803/c5058f3a"),
                 versionDate = None,
+                targetSchema = ApiV2Complex,
                 requestingUser = incunabulaUserProfile
             )
 
@@ -588,6 +591,7 @@ class ResourcesResponderV2Spec extends CoreSpec() with ImplicitSender {
             responderManager ! ResourcesGetRequestV2(
                 resourceIris = Seq("http://rdfh.ch/0803/c5058f3a", "http://rdfh.ch/0803/c5058f3a", "http://rdfh.ch/0803/2a6221216701"),
                 versionDate = None,
+                targetSchema = ApiV2Complex,
                 requestingUser = incunabulaUserProfile
             )
 
@@ -642,6 +646,7 @@ class ResourcesResponderV2Spec extends CoreSpec() with ImplicitSender {
             responderManager ! ResourcesGetRequestV2(
                 resourceIris = Seq(resourceIri),
                 versionDate = Some(versionDate),
+                targetSchema = ApiV2Complex,
                 requestingUser = anythingUserProfile
             )
 
@@ -1688,7 +1693,7 @@ class ResourcesResponderV2Spec extends CoreSpec() with ImplicitSender {
 
             // We should now be unable to request the resource.
 
-            responderManager ! ResourcesGetRequestV2(resourceIris = Seq(aThingIri), requestingUser = SharedTestDataADM.anythingUser1)
+            responderManager ! ResourcesGetRequestV2(resourceIris = Seq(aThingIri), targetSchema = ApiV2Complex, requestingUser = SharedTestDataADM.anythingUser1)
 
             expectMsgPF(timeout) {
                 case msg: akka.actor.Status.Failure => msg.cause.isInstanceOf[NotFoundException] should ===(true)

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/SearchResponderV2Spec.scala
@@ -135,6 +135,7 @@ class SearchResponderV2Spec extends CoreSpec() with ImplicitSender {
                 offset = 0,
                 limitToProject = None,
                 limitToResourceClass = Some("http://www.knora.org/ontology/0803/incunabula#book".toSmartIri), // internal Iri!
+                targetSchema = ApiV2Complex,
                 requestingUser = SharedTestDataADM.anonymousUser
             )
 
@@ -152,6 +153,7 @@ class SearchResponderV2Spec extends CoreSpec() with ImplicitSender {
                 orderByProperty = Some("http://0.0.0.0:3333/ontology/0803/incunabula/v2#title".toSmartIri),
                 schemaOptions = SchemaOptions.ForStandoffWithTextValues,
                 page = 0,
+                targetSchema = ApiV2Complex,
                 requestingUser = SharedTestDataADM.incunabulaProjectAdminUser
             )
 

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/ValuesResponderV2Spec.scala
@@ -279,7 +279,7 @@ class ValuesResponderV2Spec extends CoreSpec() with ImplicitSender {
     }
 
     private def getResourceLastModificationDate(resourceIri: IRI, requestingUser: UserADM): Option[Instant] = {
-        responderManager ! ResourcesPreviewGetRequestV2(resourceIris = Seq(resourceIri), requestingUser = requestingUser)
+        responderManager ! ResourcesPreviewGetRequestV2(resourceIris = Seq(resourceIri), targetSchema = ApiV2Complex, requestingUser = requestingUser)
 
         expectMsgPF(timeout) {
             case previewResponse: ReadResourcesSequenceV2 =>


### PR DESCRIPTION
This PR changes the handling of list nodes:

- [x] remove list node label from list value response in the complex schema 
- [x] remove getting list node label from `webapi/src/main/twirl/queries/sparql/v2/getResourcePropertiesAndValuesGraphDB.scala.txt`
- [x] remove getting list node label from main query in Gravsearch
- [x] adapt logic in `org/knora/webapi/util/ConstructResponseUtilV2.scala`: make the node label optional and request it from the list responder if information is requested in the simple schema
- [x] adapt tests
- [x] remove default values for `targetSchema` from messages
- [x] add tests for list value responses in the simple schema
- [x] adapt Knora-ui core so it fetches the information from the list route: dhlab-basel/Knora-ui#233 (ready to be reviewed)
- [x] adapt ontology and response test data in Knora-ui
 
closes #1317 