### PR TITLE
fix(sipi): Don't try to read a file value in a deleted resource

### DIFF
--- a/webapi/_test_data/all_data/anything-data.ttl
+++ b/webapi/_test_data/all_data/anything-data.ttl
@@ -1328,6 +1328,33 @@
   knora-base:hasPermissions "V knora-admin:UnknownUser|M knora-admin:ProjectMember";
   knora-base:attachedToUser <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> .
 
+<http://rdfh.ch/0001/gjs0RTRkTZeYDT_37nbcCg/values/85et-o-STOmn2JcVqrGTCQ> a anything:ThingPicture ;
+  rdfs:label "A_100-1-A4_1_406 p. 405" ;
+  knora-base:isDeleted "true"^^xsd:boolean ;
+  knora-base:attachedToProject <http://rdfh.ch/projects/0001>;
+  knora-base:hasStillImageFileValue <http://rdfh.ch/0001/gjs0RTRkTZeYDT_37nbcCg/values/Dy-pWIujTIqdqKqrswwqfA> ;
+  knora-base:creationDate "2019-04-26T16:44:17.485Z"^^xsd:dateTime ;
+  knora-base:deleteDate "2019-05-22T21:21:00.507685Z"^^xsd:dateTime ;
+  knora-base:lastModificationDate "2019-05-22T21:21:00.507685Z"^^xsd:dateTime ;
+  knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:UnknownUser";
+  knora-base:attachedToUser <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> ;
+  knora-base:hasStillImageFileValue <http://rdfh.ch/0001/gjs0RTRkTZeYDT_37nbcCg/values/Dy-pWIujTIqdqKqrswwqfA>;
+  knora-base:deletedBy <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> .
+
+<http://rdfh.ch/0001/gjs0RTRkTZeYDT_37nbcCg/values/Dy-pWIujTIqdqKqrswwqfA> a knora-base:StillImageFileValue ;
+  knora-base:isDeleted "false"^^xsd:boolean ;
+  knora-base:dimX "3526"^^xsd:integer ;
+  knora-base:dimY "4219"^^xsd:integer ;
+  knora-base:internalFilename "9hxmmrWh0a7-CnRCq0650ro.jpx" ;
+  knora-base:internalMimeType "image/jp2" ;
+  knora-base:originalFilename "A_100-1-A4_1_406.JPG" ;
+  knora-base:originalMimeType "image/jpeg" ;
+  knora-base:valueCreationDate "2019-04-26T16:44:17.485Z"^^xsd:dateTime ;
+  knora-base:valueHasOrder "0"^^xsd:integer ;
+  knora-base:valueHasString "A_100-1-A4_1_406.JPG" ;
+  knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:UnknownUser";
+  knora-base:attachedToUser <http://rdfh.ch/users/9XBCrDV3SRa7kS1WwynB4Q> .
+
 <http://rdfh.ch/lists/0001/otherTreeList> a knora-base:ListNode;
   knora-base:isRootNode true;
   rdfs:label "Tree list root"@en;

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -882,7 +882,6 @@ object OntologyConstants {
         val MovingImageFileValueHasDimX: IRI = KnoraApiV2PrefixExpansion + "movingImageFileValueHasDimX"
         val MovingImageFileValueHasDimY: IRI = KnoraApiV2PrefixExpansion + "movingImageFileValueHasDimY"
         val MovingImageFileValueHasFps: IRI = KnoraApiV2PrefixExpansion + "movingImageFileValueHasFps"
-        val MovingImageFileValueHasQualityLevel: IRI = KnoraApiV2PrefixExpansion + "movingImageFileValueHasQualityLevel"
         val MovingImageFileValueHasDuration: IRI = KnoraApiV2PrefixExpansion + "movingImageFileValueHasDuration"
 
         val AudioFileValueHasDuration: IRI = KnoraApiV2PrefixExpansion + "audioFileValueHasDuration"

--- a/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/valuemessages/ValueMessagesV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v1/responder/valuemessages/ValueMessagesV1.scala
@@ -147,22 +147,6 @@ case class CreateFileV1(originalFilename: String,
 case class ReadFileV1(file: File, mimeType: String)
 
 /**
-  * Represents a quality level of a file value to added to a Knora resource.
-  *
-  * @param path     the path to the file.
-  * @param mimeType the mime type of the file.
-  * @param dimX     the x dimension of the file, if given (e.g. an image).
-  * @param dimY     the y dimension of the file, if given (e.g. an image).
-  */
-case class CreateFileQualityLevelV1(path: String,
-                                    mimeType: String,
-                                    dimX: Option[Int] = None,
-                                    dimY: Option[Int] = None) {
-
-    def toJsValue: JsValue = ApiValueV1JsonProtocol.createFileQualityLevelFormat.write(this)
-}
-
-/**
   * Represents an API request payload that asks the Knora API server to change a value of a resource property (i.e. to
   * update its version history).
   *
@@ -1616,7 +1600,6 @@ object ApiValueV1JsonProtocol extends SprayJsonSupport with DefaultJsonProtocol 
         def write(valueV1: ApiValueV1): JsValue = valueV1.toJsValue
     }
 
-    implicit val createFileQualityLevelFormat: RootJsonFormat[CreateFileQualityLevelV1] = jsonFormat4(CreateFileQualityLevelV1)
     implicit val createFileV1Format: RootJsonFormat[CreateFileV1] = jsonFormat3(CreateFileV1)
     implicit val valueGetResponseV1Format: RootJsonFormat[ValueGetResponseV1] = jsonFormat7(ValueGetResponseV1)
     implicit val dateValueV1Format: JsonFormat[DateValueV1] = jsonFormat5(DateValueV1)

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraBaseToApiV2ComplexTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraBaseToApiV2ComplexTransformationRules.scala
@@ -1402,28 +1402,6 @@ object KnoraBaseToApiV2ComplexTransformationRules extends OntologyTransformation
         )
     )
 
-    private val MovingImageFileValueHasQualityLevel: ReadPropertyInfoV2 = makeProperty(
-        propertyIri = OntologyConstants.KnoraApiV2Complex.MovingImageFileValueHasQualityLevel,
-        propertyType = OntologyConstants.Owl.DatatypeProperty,
-        subPropertyOf = Set(OntologyConstants.KnoraApiV2Complex.ValueHas),
-        subjectType = Some(OntologyConstants.KnoraApiV2Complex.MovingImageFileValue),
-        objectType = Some(OntologyConstants.Xsd.Integer),
-        predicates = Seq(
-            makePredicate(
-                predicateIri = OntologyConstants.Rdfs.Label,
-                objectsWithLang = Map(
-                    LanguageCodes.EN -> "Moving image file value has quality level"
-                )
-            ),
-            makePredicate(
-                predicateIri = OntologyConstants.Rdfs.Comment,
-                objectsWithLang = Map(
-                    LanguageCodes.EN -> "The quality level of a moving image file value."
-                )
-            )
-        )
-    )
-
     private val MovingImageFileValueHasDuration: ReadPropertyInfoV2 = makeProperty(
         propertyIri = OntologyConstants.KnoraApiV2Complex.MovingImageFileValueHasDuration,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
@@ -1569,7 +1547,6 @@ object KnoraBaseToApiV2ComplexTransformationRules extends OntologyTransformation
         OntologyConstants.KnoraApiV2Complex.MovingImageFileValueHasDimX -> Cardinality.MustHaveOne,
         OntologyConstants.KnoraApiV2Complex.MovingImageFileValueHasDimY -> Cardinality.MustHaveOne,
         OntologyConstants.KnoraApiV2Complex.MovingImageFileValueHasFps -> Cardinality.MustHaveOne,
-        OntologyConstants.KnoraApiV2Complex.MovingImageFileValueHasQualityLevel -> Cardinality.MustHaveOne,
         OntologyConstants.KnoraApiV2Complex.MovingImageFileValueHasDuration -> Cardinality.MustHaveOne
     )
 
@@ -1762,7 +1739,6 @@ object KnoraBaseToApiV2ComplexTransformationRules extends OntologyTransformation
         MovingImageFileValueHasDimX,
         MovingImageFileValueHasDimY,
         MovingImageFileValueHasFps,
-        MovingImageFileValueHasQualityLevel,
         MovingImageFileValueHasDuration,
         AudioFileValueHasDuration
     ).map {

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/SipiResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/SipiResponderADM.scala
@@ -69,6 +69,8 @@ class SipiResponderADM(responderData: ResponderData) extends Responder(responder
                 filename = request.filename
             ).toString())
 
+            // _ = println(sparqlQuery)
+
             queryResponse <- (storeManager ? SparqlSelectRequest(sparqlQuery)).mapTo[SparqlSelectResponse]
 
             rows: Seq[VariableResultsRow] = queryResponse.results.bindings
@@ -101,13 +103,12 @@ class SipiResponderADM(responderData: ResponderData) extends Responder(responder
 
             response <- permissionCode match {
 
-                case 1 => {
+                case 1 =>
                     for {
                         maybeRVSettings <- (responderManager ? ProjectRestrictedViewSettingsGetADM(ProjectIdentifierADM(shortcode = Some(request.projectID)), KnoraSystemInstances.Users.SystemUser)).mapTo[Option[ProjectRestrictedViewSettingsADM]]
 
                     } yield SipiFileInfoGetResponseADM(permissionCode = permissionCode, maybeRVSettings)
-                }
-                case other => FastFuture.successful(SipiFileInfoGetResponseADM(permissionCode = permissionCode, restrictedViewSettings = None))
+                case _ => FastFuture.successful(SipiFileInfoGetResponseADM(permissionCode = permissionCode, restrictedViewSettings = None))
             }
 
         } yield response

--- a/webapi/src/main/twirl/queries/sparql/admin/getFileValueGraphDB.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/admin/getFileValueGraphDB.scala.txt
@@ -43,6 +43,9 @@ WHERE {
     ?fileValue knora-base:internalFilename "@filename" ;
         knora-base:isDeleted false .
 
+    ?resource knora-base:hasFileValue ?fileValue ;
+        knora-base:isDeleted false .
+
     {
         GRAPH <http://www.ontotext.com/explicit> {
             ?fileValue ?objPred ?objObj .
@@ -54,9 +57,7 @@ WHERE {
     {
         @* Return the project of the resource that contains the value. *@
 
-        ?resource knora-base:hasFileValue ?fileValue ;
-            knora-base:isDeleted false ;
-            knora-base:attachedToProject ?resourceProject .
+        ?resource knora-base:attachedToProject ?resourceProject .
 
         BIND(knora-base:attachedToProject AS ?objPred)
         BIND(?resourceProject AS ?objObj)

--- a/webapi/src/main/twirl/queries/sparql/admin/getFileValueStandard.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/admin/getFileValueStandard.scala.txt
@@ -41,6 +41,10 @@ WHERE {
     ?fileValue knora-base:internalFilename "@filename" ;
         knora-base:isDeleted false .
 
+    ?prop rdfs:subPropertyOf* knora-base:hasFileValue .
+
+    ?resource ?prop ?fileValue ;
+        knora-base:isDeleted false .
 
     {
         ?fileValue ?objPred ?objObj .
@@ -50,10 +54,7 @@ WHERE {
     {
         @* Return the project of the resource that contains the value. *@
 
-        ?prop rdfs:subPropertyOf* knora-base:hasFileValue .
-        ?resource ?prop ?fileValue ;
-            knora-base:isDeleted false ;
-            knora-base:attachedToProject ?resourceProject .
+        ?resource knora-base:attachedToProject ?resourceProject .
 
         BIND(knora-base:attachedToProject AS ?objPred)
         BIND(?resourceProject AS ?objObj)

--- a/webapi/src/main/twirl/queries/sparql/v1/getFileValuesForResource.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getFileValuesForResource.scala.txt
@@ -49,8 +49,4 @@ WHERE {
 
     ?resIri ?p ?fileValueIri .
     ?p rdfs:subPropertyOf* knora-base:hasFileValue .
-
-    OPTIONAL {
-        ?fileValueIri knora-base:qualityLevel ?quality .
-    }
 }

--- a/webapi/src/main/twirl/queries/sparql/v1/getValueGraphDB.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getValueGraphDB.scala.txt
@@ -41,7 +41,8 @@ SELECT ?objPred ?objObj ?predStandoff ?objStandoff
 WHERE {
     BIND(IRI("@valueIri") AS ?obj)
 
-    ?resource knora-base:hasValue ?obj .
+    ?resource knora-base:hasValue ?obj ;
+        knora-base:isDeleted false .
 
     {
         ?obj knora-base:isDeleted false .

--- a/webapi/src/main/twirl/queries/sparql/v1/getValueStandard.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v1/getValueStandard.scala.txt
@@ -41,7 +41,9 @@ WHERE {
     ?resourceProp rdfs:subPropertyOf* knora-base:hasValue .
 
     {
-        ?resource ?resourceProp ?obj .
+        ?resource ?resourceProp ?obj ;
+            knora-base:isDeleted false .
+
         ?obj knora-base:isDeleted false .
         ?obj ?objPred ?objObj .
 
@@ -56,7 +58,9 @@ WHERE {
     {
         @* Return the project of the resource that contains the value. *@
 
-        ?resource ?resourceProp ?obj .
+        ?resource ?resourceProp ?obj ;
+            knora-base:isDeleted false .
+
         ?obj knora-base:isDeleted false .
         ?resource knora-base:attachedToProject ?resourceProject .
 

--- a/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForValueContent.scala.txt
+++ b/webapi/src/main/twirl/queries/sparql/v2/generateInsertStatementsForValueContent.scala.txt
@@ -158,10 +158,7 @@
                                      knora-base:internalFilename """@stillImageFileValue.fileValue.internalFilename""" ;
                                      knora-base:internalMimeType """@stillImageFileValue.fileValue.internalMimeType""" ;
                                      knora-base:dimX @stillImageFileValue.dimX ;
-                                     knora-base:dimY @stillImageFileValue.dimY ;
-                                     knora-base:isPreview false ; @* Remove for issue #1068 *@
-                                     knora-base:qualityLevel 100 ; @* Remove for issue #1068 *@
-                                     knora-base:valueHasQname "full" . @* Remove for issue #1068 *@
+                                     knora-base:dimY @stillImageFileValue.dimY .
             }
 
             case textFileValue: TextFileValueContentV2 => {

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
@@ -2370,12 +2370,6 @@
       }
     }, {
       "@type" : "owl:Restriction",
-      "owl:cardinality" : 1,
-      "owl:onProperty" : {
-        "@id" : "knora-api:movingImageFileValueHasQualityLevel"
-      }
-    }, {
-      "@type" : "owl:Restriction",
       "knora-api:isInherited" : true,
       "owl:cardinality" : 1,
       "owl:onProperty" : {
@@ -5846,20 +5840,6 @@
     },
     "rdfs:comment" : "The number of frames per second in a moving image file value.",
     "rdfs:label" : "Moving image file value has frames per second",
-    "rdfs:subPropertyOf" : {
-      "@id" : "knora-api:valueHas"
-    }
-  }, {
-    "@id" : "knora-api:movingImageFileValueHasQualityLevel",
-    "@type" : "owl:DatatypeProperty",
-    "knora-api:objectType" : {
-      "@id" : "xsd:integer"
-    },
-    "knora-api:subjectType" : {
-      "@id" : "knora-api:MovingImageFileValue"
-    },
-    "rdfs:comment" : "The quality level of a moving image file value.",
-    "rdfs:label" : "Moving image file value has quality level",
     "rdfs:subPropertyOf" : {
       "@id" : "knora-api:valueHas"
     }

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
@@ -18,50 +18,50 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic class for representing annotations</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b19"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Resource">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents something in the world, or an abstract thing</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Resource</rdfs:label>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b375"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b376"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b377"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b378"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b379"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b380"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b381"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b382"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b383"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b384"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b385"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b386"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b387"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b388"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b389"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b390"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b391"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b374"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b375"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b376"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b377"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b378"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b379"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b380"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b381"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b382"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b383"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b384"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b385"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b386"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b387"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b388"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b389"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b390"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b0">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -72,7 +72,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b1">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -83,7 +83,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b2">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -94,7 +94,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b3">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -105,7 +105,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b4">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -115,7 +115,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b5">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -125,7 +125,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b6">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -135,7 +135,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b7">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b7">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasComment">
@@ -150,7 +150,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b8">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -165,7 +165,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b9">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -174,7 +174,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b10">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -189,7 +189,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b11">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -204,7 +204,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b12">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b12">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOf">
@@ -218,7 +218,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b13">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b13">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOfValue">
@@ -231,7 +231,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b14">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b14">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -241,7 +241,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b15">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b15">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -250,7 +250,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b16">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b16">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -261,7 +261,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b17">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b17">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -272,7 +272,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b18">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b18">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -283,7 +283,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b19">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b19">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -292,42 +292,42 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an audio file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b32"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#FileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b175"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b176"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b177"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b178"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b179"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b180"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b181"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b182"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b183"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b184"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b185"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b186"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b175"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b176"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b177"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b178"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b179"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b180"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b181"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b182"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b183"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b184"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b185"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b186"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b20">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b20">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b21">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b21">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#audioFileValueHasDuration">
@@ -339,22 +339,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b22">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b22">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b23">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b23">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b24">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b24">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b25">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b25">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -367,7 +367,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b26">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b26">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -380,22 +380,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b27">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b27">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b28">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b28">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b29">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b29">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b30">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b30">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -406,7 +406,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b31">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b31">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -417,7 +417,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b32">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b32">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -434,85 +434,85 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containing audio data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Audio)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b35"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b50"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Representation">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can store a file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b357"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b358"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b359"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b360"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b361"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b362"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b363"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b364"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b365"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b366"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b367"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b368"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b369"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b370"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b371"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b372"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b373"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b374"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b356"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b357"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b358"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b359"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b360"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b361"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b362"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b363"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b364"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b365"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b366"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b367"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b368"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b369"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b370"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b371"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b372"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b373"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b33">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b33">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b34">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b34">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b35">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b35">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b36">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b36">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b37">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b37">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b38">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b38">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b39">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b39">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b40">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b40">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasAudioFileValue">
@@ -527,62 +527,62 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b41">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b41">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b42">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b42">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b43">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b43">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b44">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b44">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b45">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b45">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b46">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b46">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b47">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b47">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b48">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b48">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b49">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b49">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b50">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b50">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#BooleanBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b51"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b51">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b51">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean">
@@ -599,84 +599,84 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b53"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b62"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Value">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The base class of classes representing Knora values</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b612"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b613"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b614"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b615"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b616"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b617"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b618"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b619"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b620"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b621"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b611"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b612"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b613"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b614"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b615"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b616"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b617"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b618"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b619"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b620"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b52">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b52">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b53">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b53">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b54">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b54">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b55">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b55">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b56">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b56">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b57">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b57">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b58">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b58">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b59">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b59">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b60">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b60">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b61">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b61">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b62">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b62">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -684,7 +684,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ColorBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b63">
+		<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b63">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor">
@@ -703,69 +703,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in HTML format, e.g. "#33eeff"</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b66"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b68"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b71"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b74"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b64">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b64">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b65">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b65">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b66">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b66">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b67">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b67">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b68">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b68">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b69">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b69">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b70">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b70">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b71">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b71">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b72">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b72">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b73">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b73">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b74">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b74">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -774,75 +774,75 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This represents some 3D-object with mesh data, point cloud, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b77"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b79"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b81"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b83"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b84"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b85"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b86"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b85"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b86"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b75">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b75">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b76">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b76">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b77">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b77">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b78">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b78">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b79">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b79">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b80">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b80">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b81">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b81">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b82">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b82">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b83">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b83">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b84">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b84">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b85">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b85">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b86">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b86">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -852,61 +852,61 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containg 3D data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (3D)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b87"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b89"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b90"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b91"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b92"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b93"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b94"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b95"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b96"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b97"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b98"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b99"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b100"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b101"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b102"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b103"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b104"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b87"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b88"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b89"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b90"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b91"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b92"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b93"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b94"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b95"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b96"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b97"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b98"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b99"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b100"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b101"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b102"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b103"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b104"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b87">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b87">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b88">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b88">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b89">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b89">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b90">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b90">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b91">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b91">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b92">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b92">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b93">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b93">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b94">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b94">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDDDFileValue">
@@ -921,69 +921,69 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b95">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b95">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b96">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b96">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b97">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b97">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b98">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b98">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b99">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b99">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b100">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b100">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b101">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b101">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b102">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b102">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b103">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b103">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b104">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b104">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DateBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b105"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b106"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b107"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b108"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b109"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b110"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b111"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b112"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b113"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b105"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b106"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b107"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b108"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b109"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b110"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b111"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b112"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b113"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b105">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b105">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar">
@@ -995,7 +995,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b106">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b106">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay">
@@ -1007,7 +1007,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b107">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b107">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra">
@@ -1019,7 +1019,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b108">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b108">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth">
@@ -1031,7 +1031,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b109">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b109">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear">
@@ -1043,7 +1043,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b110">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b110">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay">
@@ -1055,7 +1055,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b111">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b111">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra">
@@ -1067,7 +1067,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b112">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b112">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth">
@@ -1079,7 +1079,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b113">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b113">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear">
@@ -1096,117 +1096,117 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Knora date value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b114"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b115"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b116"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b117"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b118"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b119"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b120"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b121"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b122"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b123"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b124"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b125"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b126"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b127"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b128"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b129"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b130"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b131"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b132"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b114"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b115"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b116"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b117"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b118"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b119"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b120"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b121"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b122"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b123"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b124"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b125"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b126"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b127"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b128"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b129"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b130"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b131"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b132"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b114">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b114">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b115">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b115">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b116">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b116">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b117">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b117">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b118">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b118">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b119">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b119">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b120">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b120">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b121">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b121">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b122">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b122">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b123">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b123">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b124">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b124">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b125">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b125">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b126">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b126">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b127">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b127">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b128">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b128">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b129">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b129">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b130">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b130">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b131">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b131">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b132">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b132">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1214,7 +1214,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DecimalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b133">
+		<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b133">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal">
@@ -1233,69 +1233,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary-precision decimal value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b134"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b135"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b136"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b137"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b138"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b139"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b140"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b141"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b142"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b143"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b144"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b134"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b135"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b136"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b137"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b138"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b139"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b140"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b141"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b142"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b143"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b144"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b134">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b134">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b135">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b135">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b136">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b136">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b137">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b137">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b138">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b138">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b139">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b139">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b140">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b140">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b141">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b141">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b142">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b142">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b143">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b143">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b144">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b144">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1303,75 +1303,75 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DocumentFileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b145"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b146"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b147"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b148"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b149"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b150"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b151"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b152"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b153"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b154"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b155"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b156"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b145"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b146"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b147"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b148"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b149"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b150"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b151"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b152"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b153"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b154"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b155"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b156"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b145">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b145">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b146">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b146">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b147">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b147">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b148">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b148">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b149">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b149">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b150">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b150">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b151">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b151">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b152">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b152">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b153">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b153">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b154">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b154">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b155">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b155">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b156">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b156">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1380,61 +1380,61 @@
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Document)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b157"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b158"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b159"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b160"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b161"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b162"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b163"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b164"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b165"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b166"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b167"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b168"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b169"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b170"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b171"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b172"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b173"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b174"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b157"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b158"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b159"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b160"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b161"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b162"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b163"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b164"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b165"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b166"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b167"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b168"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b169"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b170"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b171"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b172"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b173"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b174"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b157">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b157">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b158">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b158">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b159">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b159">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b160">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b160">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b161">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b161">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b162">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b162">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b163">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b163">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b164">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b164">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDocumentFileValue">
@@ -1449,110 +1449,110 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b165">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b165">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b166">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b166">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b167">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b167">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b168">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b168">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b169">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b169">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b170">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b170">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b171">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b171">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b172">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b172">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b173">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b173">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b174">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b174">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b175">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b175">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b176">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b176">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b177">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b177">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b178">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b178">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b179">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b179">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b180">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b180">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b181">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b181">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b182">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b182">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b183">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b183">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b184">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b184">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b185">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b185">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b186">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b186">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1562,110 +1562,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b187"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b188"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b189"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b190"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b191"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b192"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b193"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b194"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b195"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b196"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b197"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b198"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b199"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b200"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b201"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b202"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b203"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b204"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b187"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b188"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b189"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b190"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b191"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b192"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b193"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b194"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b195"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b196"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b197"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b198"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b199"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b200"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b201"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b202"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b203"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b204"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b187">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b187">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b188">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b188">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b189">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b189">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b190">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b190">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b191">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b191">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b192">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b192">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b193">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b193">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b194">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b194">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b195">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b195">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b196">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b196">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b197">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b197">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b198">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b198">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b199">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b199">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b200">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b200">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b201">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b201">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b202">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b202">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b203">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b203">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b204">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b204">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -1674,39 +1674,39 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometrical objects as JSON string</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b205"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b206"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b207"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b208"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b209"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b210"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b211"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b212"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b213"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b214"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b215"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b205"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b206"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b207"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b208"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b209"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b210"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b211"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b212"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b213"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b214"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b215"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b205">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b205">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b206">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b206">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b207">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b207">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b208">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b208">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b209">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b209">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geometryValueAsGeometry">
@@ -1718,32 +1718,32 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b210">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b210">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b211">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b211">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b212">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b212">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b213">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b213">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b214">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b214">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b215">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b215">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1751,39 +1751,39 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#GeonameValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b216"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b217"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b218"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b219"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b220"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b221"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b222"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b223"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b224"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b225"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b226"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b216"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b217"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b218"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b219"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b220"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b221"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b222"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b223"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b224"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b225"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b226"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b216">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b216">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b217">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b217">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b218">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b218">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b219">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b219">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b220">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b220">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geonameValueAsGeonameCode">
@@ -1795,32 +1795,32 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b221">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b221">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b222">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b222">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b223">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b223">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b224">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b224">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b225">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b225">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b226">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b226">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -1828,7 +1828,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b227">
+		<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b227">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intValueAsInt">
@@ -1847,79 +1847,79 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b228"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b229"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b230"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b231"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b232"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b233"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b234"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b235"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b236"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b237"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b238"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b228"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b229"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b230"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b231"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b232"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b233"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b234"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b235"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b236"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b237"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b238"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b228">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b228">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b229">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b229">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b230">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b230">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b231">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b231">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b232">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b232">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b233">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b233">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b234">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b234">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b235">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b235">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b236">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b236">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b237">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b237">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b238">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b238">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntervalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b239"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b240"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b239"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b240"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b239">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b239">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd">
@@ -1931,7 +1931,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b240">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b240">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart">
@@ -1948,75 +1948,75 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a time interval, e.g. in an audio recording</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b241"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b242"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b243"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b244"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b245"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b246"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b247"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b248"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b249"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b250"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b251"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b252"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b241"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b242"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b243"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b244"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b245"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b246"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b247"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b248"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b249"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b250"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b251"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b252"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b241">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b241">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b242">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b242">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b243">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b243">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b244">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b244">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b245">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b245">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b246">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b246">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b247">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b247">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b248">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b248">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b249">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b249">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b250">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b250">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b251">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b251">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b252">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b252">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2028,72 +2028,72 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a generic link object</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link Object</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b253"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b254"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b255"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b256"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b257"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b258"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b259"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b260"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b261"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b262"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b263"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b264"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b265"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b266"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b267"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b268"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b269"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b270"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b271"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b272"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b253"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b254"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b255"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b256"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b257"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b258"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b259"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b260"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b261"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b262"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b263"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b264"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b265"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b266"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b267"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b268"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b269"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b270"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b271"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b272"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b253">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b253">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b254">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b254">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b255">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b255">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b256">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b256">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b257">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b257">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b258">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b258">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b259">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b259">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b260">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b260">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b261">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b261">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b262">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b262">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkTo">
@@ -2108,7 +2108,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b263">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b263">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkToValue">
@@ -2123,47 +2123,47 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b264">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b264">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b265">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b265">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b266">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b266">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b267">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b267">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b268">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b268">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b269">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b269">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b270">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b270">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b271">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b271">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b272">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b272">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -2173,52 +2173,52 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A reification node that describes direct links between resources</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
 	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b273"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b274"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b275"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b276"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b277"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b278"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b279"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b280"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b281"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b282"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b283"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b284"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b285"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b286"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b273"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b274"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b275"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b276"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b277"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b278"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b279"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b280"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b281"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b282"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b283"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b284"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b285"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b286"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b273">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b273">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b274">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b274">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b275">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b275">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b276">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b276">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b277">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b277">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b278">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b278">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b279">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b279">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasSource">
@@ -2230,7 +2230,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b280">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b280">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasSourceIri">
@@ -2242,7 +2242,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b281">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b281">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasTarget">
@@ -2254,7 +2254,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b282">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b282">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasTargetIri">
@@ -2266,85 +2266,85 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b283">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b283">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b284">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b284">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b285">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b285">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b286">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b286">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListNode">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a flat or hierarchical list</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b287"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b288"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b287"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b288"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b287">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b287">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b288">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b288">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b289"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b290"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b291"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b292"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b293"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b294"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b295"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b296"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b297"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b298"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b299"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b289"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b290"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b291"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b292"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b293"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b294"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b295"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b296"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b297"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b298"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b299"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b289">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b289">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b290">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b290">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b291">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b291">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b292">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b292">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b293">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b293">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b294">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b294">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b295">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b295">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#listValueAsListNode">
@@ -2356,22 +2356,22 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b296">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b296">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b297">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b297">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b298">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b298">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b299">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b299">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2380,65 +2380,64 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a moving image file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b300"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b301"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b302"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b303"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b304"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b305"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b306"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b307"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b308"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b309"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b310"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b311"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b312"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b313"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b314"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b315"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b316"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b300"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b301"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b302"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b303"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b304"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b305"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b306"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b307"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b308"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b309"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b310"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b311"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b312"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b313"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b314"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b315"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b300">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b300">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b301">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b301">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b302">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b302">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b303">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b303">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b304">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b304">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b305">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b305">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b306">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b306">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b307">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b307">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b308">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b308">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimX">
@@ -2450,7 +2449,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b309">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b309">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimY">
@@ -2462,7 +2461,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b310">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b310">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDuration">
@@ -2474,7 +2473,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b311">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b311">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasFps">
@@ -2486,34 +2485,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b312">
-	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty>
-		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasQualityLevel">
-			<knora-api:objectType rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
-			<knora-api:subjectType rdf:resource="http://api.knora.org/ontology/knora-api/v2#MovingImageFileValue"/>
-			<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The quality level of a moving image file value.</rdfs:comment>
-			<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Moving image file value has quality level</rdfs:label>
-			<rdfs:subPropertyOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHas"/>
-		</owl:DatatypeProperty>
-	</owl:onProperty>
-</owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b313">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b312">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b314">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b313">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b315">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b314">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b316">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b315">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -2523,66 +2510,66 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing moving image data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Movie)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b317"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b318"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b319"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b320"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b321"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b322"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b323"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b324"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b325"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b326"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b327"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b328"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b329"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b330"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b331"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b332"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b333"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b334"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b316"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b317"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b318"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b319"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b320"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b321"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b322"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b323"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b324"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b325"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b326"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b327"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b328"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b329"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b330"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b331"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b332"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b333"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b317">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b316">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b318">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b317">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b319">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b318">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b320">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b319">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b321">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b320">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b322">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b321">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b323">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b322">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b324">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b323">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b325">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b324">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasMovingImageFileValue">
@@ -2597,47 +2584,47 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b326">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b325">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b327">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b326">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b328">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b327">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b329">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b328">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b330">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b329">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b331">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b330">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b332">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b331">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b333">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b332">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b334">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b333">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -2649,65 +2636,65 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometric region of a resource. The geometry is represented currently as JSON string.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b335"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b336"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b337"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b338"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b339"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b340"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b341"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b342"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b343"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b344"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b345"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b346"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b347"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b348"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b349"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b350"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b351"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b352"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b353"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b354"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b355"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b356"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b334"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b335"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b336"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b337"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b338"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b339"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b340"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b341"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b342"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b343"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b344"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b345"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b346"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b347"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b348"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b349"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b350"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b351"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b352"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b353"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b354"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b355"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b335">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b334">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b336">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b335">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b337">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b336">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b338">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b337">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b339">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b338">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b340">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b339">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b341">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b340">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b342">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b341">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasColor">
@@ -2723,11 +2710,11 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b343">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b342">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b344">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b343">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasGeometry">
@@ -2742,32 +2729,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b345">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b344">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b346">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b345">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b347">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b346">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b348">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b347">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b349">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b348">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b350">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b349">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOf">
@@ -2782,7 +2769,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b351">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b350">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOfValue">
@@ -2797,67 +2784,67 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b352">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b351">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b353">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b352">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b354">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b353">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b355">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b354">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b356">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b355">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b357">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b356">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b358">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b357">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b359">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b358">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b360">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b359">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b361">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b360">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b362">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b361">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b363">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b362">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b364">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b363">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasFileValue">
@@ -2871,121 +2858,121 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b365">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b364">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b366">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b365">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b367">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b366">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b368">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b367">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b369">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b368">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b370">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b369">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b371">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b370">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b372">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b371">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b373">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b372">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b374">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b373">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b375">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b374">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b376">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b375">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b377">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b376">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b378">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b377">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b379">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b378">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b380">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b379">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b381">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b380">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b382">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b381">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b383">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b382">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b384">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b383">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b385">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b384">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b386">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b385">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b387">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b386">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b388">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b387">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b389">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b388">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b390">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b389">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b391">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b390">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -2994,39 +2981,39 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b392"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b393"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b394"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b395"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b396"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b397"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b398"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b399"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b400"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b401"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b402"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b391"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b392"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b393"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b394"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b395"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b396"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b397"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b398"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b399"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b400"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b401"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a knora-base value type in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b414"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b415"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b416"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b417"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b418"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b419"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b420"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b421"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b422"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b423"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b413"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b414"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b415"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b416"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b417"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b418"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b419"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b420"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b421"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b422"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b392">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b391">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b393">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b392">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3036,7 +3023,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b394">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b393">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3046,7 +3033,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b395">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b394">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3056,7 +3043,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b396">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b395">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3068,7 +3055,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b397">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b396">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3078,7 +3065,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b398">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b397">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3088,7 +3075,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b399">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b398">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3098,7 +3085,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b400">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b399">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3109,7 +3096,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b401">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b400">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3121,7 +3108,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b402">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b401">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3136,69 +3123,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b403"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b404"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b405"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b406"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b407"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b408"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b409"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b410"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b411"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b412"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b413"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b402"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b403"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b404"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b405"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b406"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b407"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b408"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b409"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b410"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b411"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b412"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b403">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b402">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b404">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b403">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b405">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b404">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b406">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b405">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b407">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b406">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b408">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b407">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b409">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b408">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b410">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b409">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b411">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b410">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b412">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b411">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b413">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b412">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3206,63 +3193,63 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a standoff markup tag</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b499"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b500"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b501"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b502"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b503"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b504"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b505"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b506"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b507"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b508"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b498"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b499"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b500"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b501"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b502"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b503"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b504"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b505"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b506"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b507"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b414">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b413">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b415">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b414">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b416">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b415">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b417">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b416">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b418">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b417">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b419">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b418">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b420">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b419">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b421">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b420">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b422">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b421">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b423">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b422">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3272,117 +3259,117 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b424"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b425"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b426"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b427"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b428"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b429"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b430"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b431"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b432"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b433"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b434"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b435"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b436"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b437"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b438"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b439"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b440"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b441"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b442"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b423"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b424"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b425"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b426"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b427"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b428"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b429"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b430"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b431"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b432"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b433"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b434"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b435"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b436"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b437"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b438"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b439"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b440"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b441"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b424">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b423">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b425">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b424">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b426">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b425">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b427">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b426">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b428">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b427">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b429">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b428">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b430">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b429">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b431">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b430">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b432">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b431">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b433">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b432">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b434">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b433">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b435">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b434">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b436">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b435">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b437">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b436">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b438">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b437">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b439">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b438">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b440">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b439">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b441">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b440">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b442">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b441">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3392,69 +3379,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a decimal (floating point) value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b443"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b444"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b445"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b446"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b447"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b448"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b449"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b450"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b451"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b452"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b453"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b442"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b443"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b444"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b445"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b446"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b447"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b448"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b449"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b450"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b451"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b452"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b443">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b442">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b444">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b443">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b445">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b444">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b446">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b445">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b447">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b446">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b448">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b447">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b449">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b448">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b450">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b449">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b451">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b450">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b452">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b451">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b453">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b452">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3464,69 +3451,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b454"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b455"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b456"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b457"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b458"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b459"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b460"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b461"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b462"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b463"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b464"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b453"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b454"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b455"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b456"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b457"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b458"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b459"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b460"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b461"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b462"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b463"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b454">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b453">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b455">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b454">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b456">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b455">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b457">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b456">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b458">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b457">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b459">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b458">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b460">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b459">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b461">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b460">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b462">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b461">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b463">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b462">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b464">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b463">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3536,39 +3523,39 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an internal reference in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b465"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b466"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b467"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b468"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b469"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b470"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b471"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b472"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b473"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b474"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b475"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b464"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b465"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b466"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b467"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b468"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b469"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b470"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b471"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b472"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b473"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b474"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b465">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b464">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b466">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b465">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b467">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b466">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b468">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b467">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b469">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b468">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasInternalReference">
@@ -3577,32 +3564,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b470">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b469">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b471">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b470">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b472">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b471">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b473">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b472">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b474">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b473">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b475">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b474">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3612,75 +3599,75 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an interval in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b476"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b477"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b478"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b479"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b480"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b481"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b482"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b483"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b484"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b485"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b486"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b487"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b475"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b476"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b477"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b478"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b479"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b480"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b481"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b482"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b483"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b484"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b485"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b486"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b476">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b475">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b477">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b476">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b478">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b477">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b479">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b478">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b480">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b479">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b481">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b480">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b482">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b481">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b483">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b482">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b484">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b483">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b485">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b484">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b486">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b485">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b487">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b486">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3689,39 +3676,39 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a reference to a Knora resource in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b488"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b489"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b490"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b491"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b492"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b493"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b494"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b495"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b496"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b497"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b498"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b487"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b488"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b489"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b490"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b491"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b492"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b493"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b494"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b495"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b496"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b497"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b488">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b487">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b489">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b488">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b490">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b489">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b491">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b490">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b492">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b491">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasLink">
@@ -3730,73 +3717,73 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b493">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b492">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b494">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b493">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b495">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b494">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b496">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b495">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b497">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b496">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b498">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b497">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b499">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b498">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b500">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b499">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b501">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b500">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b502">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b501">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b503">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b502">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b504">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b503">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b505">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b504">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b506">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b505">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b507">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b506">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b508">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b507">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
@@ -3805,73 +3792,73 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary URI in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b509"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b510"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b511"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b512"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b513"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b514"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b515"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b516"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b517"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b518"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b519"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b508"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b509"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b510"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b511"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b512"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b513"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b514"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b515"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b516"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b517"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b518"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#UriBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b600"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b599"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b509">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b508">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b510">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b509">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b511">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b510">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b512">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b511">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b513">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b512">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b514">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b513">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b515">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b514">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b516">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b515">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b517">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b516">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b518">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b517">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b519">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b518">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3888,63 +3875,63 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A file containing a two-dimensional still image</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b520"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b521"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b522"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b523"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b524"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b525"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b526"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b527"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b528"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b529"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b530"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b531"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b532"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b533"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b534"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b519"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b520"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b521"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b522"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b523"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b524"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b525"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b526"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b527"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b528"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b529"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b530"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b531"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b532"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b533"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b520">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b519">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b521">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b520">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b522">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b521">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b523">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b522">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b524">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b523">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b525">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b524">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b526">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b525">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b527">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b526">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b528">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b527">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimX">
@@ -3956,7 +3943,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b529">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b528">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimY">
@@ -3968,7 +3955,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b530">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b529">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasIIIFBaseUrl">
@@ -3980,22 +3967,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b531">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b530">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b532">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b531">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b533">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b532">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b534">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b533">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -4005,81 +3992,81 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can contain a two-dimensional still image file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Image)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b535"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b536"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b537"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b538"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b539"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b540"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b541"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b542"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b543"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b544"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b545"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b546"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b547"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b548"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b549"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b550"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b551"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b552"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b534"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b535"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b536"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b537"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b538"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b539"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b540"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b541"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b542"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b543"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b544"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b545"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b546"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b547"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b548"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b549"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b550"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b551"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b535">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b534">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b536">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b535">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b537">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b536">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b538">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b537">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b539">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b538">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b540">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b539">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b541">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b540">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b542">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b541">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b543">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b542">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b544">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b543">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b545">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b544">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b546">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b545">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue">
@@ -4094,32 +4081,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b547">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b546">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b548">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b547">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b549">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b548">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b550">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b549">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b551">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b550">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b552">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b551">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -4128,75 +4115,75 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A text file such as plain Unicode text, LaTeX, TEI/XML, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b553"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b554"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b555"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b556"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b557"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b558"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b559"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b560"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b561"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b562"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b563"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b564"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b552"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b553"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b554"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b555"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b556"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b557"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b558"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b559"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b560"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b561"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b562"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b563"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b553">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b552">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b554">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b553">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b555">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b554">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b556">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b555">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b557">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b556">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b558">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b557">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b559">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b558">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b560">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b559">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b561">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b560">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b562">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b561">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b563">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b562">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b564">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b563">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
@@ -4206,81 +4193,81 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing a text file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Text)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b565"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b566"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b567"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b568"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b569"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b570"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b571"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b572"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b573"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b574"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b575"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b576"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b577"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b578"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b579"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b580"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b581"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b582"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b564"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b565"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b566"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b567"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b568"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b569"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b570"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b571"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b572"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b573"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b574"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b575"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b576"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b577"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b578"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b579"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b580"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b581"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b565">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b564">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b566">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b565">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b567">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b566">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b568">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b567">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b569">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b568">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b570">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b569">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b571">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b570">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b572">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b571">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b573">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b572">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b574">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b573">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b575">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b574">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b576">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b575">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue">
@@ -4295,32 +4282,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b577">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b576">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b578">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b577">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b579">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b578">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b580">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b579">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b581">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b580">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b582">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b581">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -4328,55 +4315,55 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#TextValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b583"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b584"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b585"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b586"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b587"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b588"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b589"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b590"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b591"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b592"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b593"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b594"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b595"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b596"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b597"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b598"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b599"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b582"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b583"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b584"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b585"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b586"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b587"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b588"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b589"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b590"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b591"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b592"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b593"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b594"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b595"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b596"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b597"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b598"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b583">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b582">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b584">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b583">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b585">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b584">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b586">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b585">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b587">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b586">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b588">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b587">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b589">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b588">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsHtml">
@@ -4388,7 +4375,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b590">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b589">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsXml">
@@ -4400,7 +4387,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b591">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b590">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasLanguage">
@@ -4412,7 +4399,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b592">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b591">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMapping">
@@ -4424,7 +4411,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b593">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b592">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMarkup">
@@ -4436,7 +4423,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b594">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b593">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMaxStandoffStartIndex">
@@ -4448,7 +4435,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b595">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b594">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasStandoff">
@@ -4460,27 +4447,27 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b596">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b595">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b597">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b596">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b598">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b597">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b599">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b598">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b600">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b599">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
@@ -4489,110 +4476,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a URI</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b601"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b602"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b603"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b604"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b605"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b606"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b607"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b608"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b609"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b610"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b611"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b600"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b601"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b602"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b603"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b604"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b605"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b606"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b607"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b608"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b609"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b610"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b601">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b600">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b602">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b601">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b603">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b602">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b604">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b603">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b605">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b604">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b606">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b605">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b607">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b606">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b608">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b607">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b609">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b608">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b610">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b609">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b611">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b610">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b612">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b611">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b613">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b612">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b614">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b613">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b615">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b614">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b616">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b615">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b617">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b616">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b618">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b617">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b619">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b618">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b620">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b619">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b621">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b620">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
@@ -4601,110 +4588,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff.  The transformation's result is ecptected to be HTML.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff. The transformation's result is ecptected to be HTML.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#TextRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b622"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b623"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b624"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b625"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b626"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b627"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b628"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b629"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b630"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b631"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b632"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b633"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b634"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b635"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b636"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b637"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b638"/>
-	<rdfs:subClassOf rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b639"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b621"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b622"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b623"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b624"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b625"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b626"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b627"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b628"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b629"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b630"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b631"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b632"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b633"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b634"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b635"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b636"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b637"/>
+	<rdfs:subClassOf rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b638"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b622">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b621">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b623">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b622">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b624">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b623">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b625">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b624">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b626">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b625">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b627">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b626">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b628">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b627">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b629">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b628">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b630">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b629">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b631">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b630">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b632">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b631">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b633">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b632">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b634">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b633">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b635">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b634">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b636">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b635">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b637">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b636">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b638">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b637">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-d9153e5e27054d7daa7425e85e3a7c81-b639">
+<owl:Restriction rdf:nodeID="genid-7624e994b8e84999931d0064f781a0d3-b638">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
@@ -1871,9 +1871,6 @@ knora-api:MovingImageFileValue a owl:Class;
       owl:cardinality 1;
       owl:onProperty knora-api:movingImageFileValueHasFps
     ], [ a owl:Restriction;
-      owl:cardinality 1;
-      owl:onProperty knora-api:movingImageFileValueHasQualityLevel
-    ], [ a owl:Restriction;
       knora-api:isInherited true;
       owl:cardinality 1;
       owl:onProperty knora-api:userHasPermission
@@ -1917,13 +1914,6 @@ knora-api:movingImageFileValueHasFps a owl:DatatypeProperty;
   knora-api:subjectType knora-api:MovingImageFileValue;
   rdfs:comment "The number of frames per second in a moving image file value.";
   rdfs:label "Moving image file value has frames per second";
-  rdfs:subPropertyOf knora-api:valueHas .
-
-knora-api:movingImageFileValueHasQualityLevel a owl:DatatypeProperty;
-  knora-api:objectType xsd:integer;
-  knora-api:subjectType knora-api:MovingImageFileValue;
-  rdfs:comment "The quality level of a moving image file value.";
-  rdfs:label "Moving image file value has quality level";
   rdfs:subPropertyOf knora-api:valueHas .
 
 knora-api:MovingImageRepresentation a owl:Class;

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/SipiADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/SipiADME2ESpec.scala
@@ -107,6 +107,15 @@ class SipiADME2ESpec extends E2ESpec(SipiADME2ESpec.config) with SessionJsonProt
 
             (fr.permissionCode === 1) should be (true)
         }
+
+        "return 404 Not Found if a file value is in a deleted resource" in {
+            val request = Get(baseApiUrl + s"/admin/files/0001/9hxmmrWh0a7-CnRCq0650ro.jpx?email=$normalUserEmailEnc&password=$testPass")
+            val response: HttpResponse = singleAwaitingRequest(request)
+
+            // println(response.toString)
+
+            assert(response.status == StatusCodes.NotFound)
+        }
     }
 
     "The Files Route ('admin/files') using session credentials" should {

--- a/webapi/src/test/scala/org/knora/webapi/store/triplestore/GraphDBConsistencyCheckingSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/store/triplestore/GraphDBConsistencyCheckingSpec.scala
@@ -203,9 +203,7 @@ object GraphDBConsistencyCheckingSpec {
           |                                     knora-base:internalFilename "full.jp2" ;
           |                                     knora-base:internalMimeType "image/jp2" ;
           |                                     knora-base:dimX 800 ;
-          |                                     knora-base:dimY 800 ;
-          |                                     knora-base:qualityLevel 100 ;
-          |                                     knora-base:valueHasQname "full" .
+          |                                     knora-base:dimY 800 .
           |
           |
           |
@@ -240,9 +238,7 @@ object GraphDBConsistencyCheckingSpec {
           |                                     knora-base:internalFilename "thumb.jpg" ;
           |                                     knora-base:internalMimeType "image/jpeg" ;
           |                                     knora-base:dimX 80 ;
-          |                                     knora-base:dimY 80 ;
-          |                                     knora-base:qualityLevel 10 ;
-          |                                     knora-base:valueHasQname "thumbnail" .
+          |                                     knora-base:dimY 80 .
           |
           |
           |                    ?newValue0_3 knora-base:isPreview true .


### PR DESCRIPTION
- [x] If Sipi requests information from Knora about a file in a deleted resource, return 404 Not Found.
- [x] Remove some obsolete things that should have been removed before.

Fixes #1328.
