### PR TITLE
chore(webapi): Fix logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     networks:
       - knora-net
     environment:
-    - GDB_HEAP_SIZE=3G
+    - GDB_HEAP_SIZE=4G
     - GDB_JAVA_OPTS=-Dgraphdb.license.file=/graphdb/GRAPHDB_SE.license -Dgraphdb.home=/opt/graphdb/home
     command: ["/graphdb/bin/graphdb"]
 

--- a/docs/src/paradox/05-internals/design/principles/design-overview.md
+++ b/docs/src/paradox/05-internals/design/principles/design-overview.md
@@ -315,3 +315,12 @@ routing utility: `RouteUtilV1`, `RouteUtilV2`, or `RouteUtilADM`.
 This utility function sends the message to `ResponderManager` (which
 forwards it to the relevant responder), returns a response to the client
 in the appropriate format, and handles any errors.
+
+## Logging
+
+Logging in Knora is configurable through `logback.xml`, allowing fine
+grain configuration of what classes / objects should be logged from which level.
+
+The Akka Actors use [Akka Logging](https://doc.akka.io/docs/akka/current/logging.html)
+while logging inside plain Scala Objects and Classes is done through
+[Scala Logging](https://github.com/lightbend/scala-logging).

--- a/webapi/src/it/scala/org/knora/webapi/ITKnoraLiveSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/ITKnoraLiveSpec.scala
@@ -20,22 +20,21 @@
 package org.knora.webapi
 
 import akka.actor.ActorSystem
-import akka.event.LoggingAdapter
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.ActorMaterializer
 import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.scalalogging.LazyLogging
 import org.knora.webapi.messages.app.appmessages.SetAllowReloadOverHTTPState
 import org.knora.webapi.messages.store.triplestoremessages.{RdfDataObject, TriplestoreJsonProtocol}
-import org.knora.webapi.util.{StartupUtils, StringFormatter}
 import org.knora.webapi.util.jsonld.{JsonLDDocument, JsonLDUtil}
+import org.knora.webapi.util.{StartupUtils, StringFormatter}
 import org.scalatest.{BeforeAndAfterAll, Matchers, Suite, WordSpecLike}
 import spray.json.{JsObject, _}
 
 import scala.concurrent.duration.{Duration, _}
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext}
 import scala.languageFeature.postfixOps
 
 object ITKnoraLiveSpec {
@@ -46,7 +45,7 @@ object ITKnoraLiveSpec {
   * This class can be used in End-to-End testing. It starts the Knora server and
   * provides access to settings and logging.
   */
-class ITKnoraLiveSpec(_system: ActorSystem) extends Core with KnoraService with StartupUtils with Suite with WordSpecLike with Matchers with BeforeAndAfterAll with RequestBuilding with TriplestoreJsonProtocol  {
+class ITKnoraLiveSpec(_system: ActorSystem) extends Core with KnoraService with StartupUtils with Suite with WordSpecLike with Matchers with BeforeAndAfterAll with RequestBuilding with TriplestoreJsonProtocol with LazyLogging {
 
     implicit lazy val settings: SettingsImpl = Settings(system)
 
@@ -66,9 +65,6 @@ class ITKnoraLiveSpec(_system: ActorSystem) extends Core with KnoraService with 
 
     /* needed by the core trait */
     implicit lazy val system: ActorSystem = _system
-
-    /* needed by the core trait */
-    override implicit lazy val log: LoggingAdapter = akka.event.Logging(system, this.getClass.getName)
 
     protected val baseApiUrl: String = settings.internalKnoraApiBaseUrl
     protected val baseSipiUrl: String = settings.internalSipiBaseUrl
@@ -125,7 +121,7 @@ class ITKnoraLiveSpec(_system: ActorSystem) extends Core with KnoraService with 
         val request = Get(baseApiUrl + "/health")
         val response = singleAwaitingRequest(request)
         assert(response.status == StatusCodes.OK, s"Knora is probably not running: ${response.status}")
-        if (response.status.isSuccess()) log.info("Knora is running.")
+        if (response.status.isSuccess()) logger.info("Knora is running.")
     }
 
     protected def loadTestData(rdfDataObjects: Seq[RdfDataObject]): Unit = {
@@ -138,7 +134,7 @@ class ITKnoraLiveSpec(_system: ActorSystem) extends Core with KnoraService with 
         val request = Get(baseSipiUrl + "/server/test.html")
         val response = singleAwaitingRequest(request)
         assert(response.status == StatusCodes.OK, s"Sipi is probably not running: ${response.status}")
-        if (response.status.isSuccess()) log.info("Sipi is running.")
+        if (response.status.isSuccess()) logger.info("Sipi is running.")
         response.entity.discardBytes()
     }
 

--- a/webapi/src/it/scala/org/knora/webapi/e2e/v2/KnoraSipiIntegrationV2ITSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/e2e/v2/KnoraSipiIntegrationV2ITSpec.scala
@@ -256,7 +256,7 @@ class KnoraSipiIntegrationV2ITSpec extends ITKnoraLiveSpec(KnoraSipiIntegrationV
 
             loginToken.nonEmpty should be(true)
 
-            log.debug("token: {}", loginToken)
+            logger.debug("token: {}", loginToken)
         }
 
         "change a still image file" in {

--- a/webapi/src/it/scala/org/knora/webapi/other/v1/DrawingsGodsV1ITSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/other/v1/DrawingsGodsV1ITSpec.scala
@@ -42,8 +42,6 @@ object DrawingsGodsV1ITSpec {
   */
 class DrawingsGodsV1ITSpec extends ITKnoraLiveSpec(DrawingsGodsV1ITSpec.config) with TriplestoreJsonProtocol {
 
-    implicit override lazy val log = akka.event.Logging(system, this.getClass())
-
     override lazy val rdfDataObjects: List[RdfDataObject] = List(
         RdfDataObject(path = "_test_data/other.v1.DrawingsGodsV1Spec/drawings-gods_admin-data.ttl", name = "http://www.knora.org/data/admin"),
         RdfDataObject(path = "_test_data/other.v1.DrawingsGodsV1Spec/drawings-gods_permissions-data.ttl", name = "http://www.knora.org/data/permissions"),
@@ -126,7 +124,7 @@ class DrawingsGodsV1ITSpec extends ITKnoraLiveSpec(DrawingsGodsV1ITSpec.config) 
 
                 case _ => throw InvalidApiJsonException("'resinfo' could not pe parsed correctly")
             }
-            log.debug("iiiURL: {}", iiifUrl)
+            logger.debug("iiiURL: {}", iiifUrl)
 
             // Request the image from Sipi.
             val sipiGetRequest = Get(iiifUrl) ~> addCredentials(BasicHttpCredentials(drawingsOfGodsUserEmail, testPass))

--- a/webapi/src/it/scala/org/knora/webapi/util/StartupUtils.scala
+++ b/webapi/src/it/scala/org/knora/webapi/util/StartupUtils.scala
@@ -20,6 +20,7 @@
 package org.knora.webapi.util
 
 import akka.pattern.{AskTimeoutException, ask}
+import com.typesafe.scalalogging.LazyLogging
 import org.knora.webapi.messages.app.appmessages.AppState.AppState
 import org.knora.webapi.messages.app.appmessages.{ActorReady, ActorReadyAck, AppState, GetAppState}
 import org.knora.webapi.{Core, KnoraService}
@@ -31,7 +32,7 @@ import scala.concurrent.{Await, Future}
   * This trait is only used for testing. It is necessary so that E2E tests will only start
   * after the KnoraService is ready.
   */
-trait StartupUtils {
+trait StartupUtils extends LazyLogging {
     this: Core with KnoraService =>
 
     /**

--- a/webapi/src/it/scala/org/knora/webapi/util/StartupUtils.scala
+++ b/webapi/src/it/scala/org/knora/webapi/util/StartupUtils.scala
@@ -41,7 +41,7 @@ trait StartupUtils {
 
         try {
             Await.result(applicationStateActor ? ActorReady(), 1.second).asInstanceOf[ActorReadyAck]
-            log.info("KnoraService - applicationStateActorReady")
+            logger.info("KnoraService - applicationStateActorReady")
         } catch {
             case e: AskTimeoutException => {
                 // if we are here, then the ask timed out, so we need to try again until the actor is ready

--- a/webapi/src/main/resources/logback.xml
+++ b/webapi/src/main/resources/logback.xml
@@ -29,7 +29,6 @@
     <logger name="akka.event.slf4j.Slf4jLogger" level="ERROR"/>
     <logger name="net.sf.ehcache.config" level="ERROR"/>
 
-
     <logger name="org.knora" level="INFO"/>
     <logger name="org.knora.webapi" level="INFO"/>
     <logger name="org.knora.webapi.util.cache" level="INFO"/>
@@ -47,9 +46,9 @@
     <logger name="org.knora.webapi.responders.v1.CkanResponderV1" level="INFO"/>
     <logger name="org.knora.webapi.responders.v1.UsersResponderV1" level="INFO"/>
     <logger name="org.knora.webapi.responders.v1.ProjectsResponderV1" level="INFO"/>
-    <logger name="org.knora.webapi.responders.v1.PermissionsResponderV1" level="INFO"/>
     <logger name="org.knora.webapi.responders.v1.ResourcesResponderV1" level="INFO"/>
     <logger name="org.knora.webapi.responders.v1.ValuesResponderV1" level="INFO"/>
+    <logger name="org.knora.webapi.responders.admin.PermissionsResponderADM" level="INFO"/>
     <logger name="org.knora.webapi.responders.admin.SipiResponderADM" level="INFO"/>
     <logger name="org.knora.webapi.responders.admin.StoresResponderADM" level="INFO"/>
     <logger name="org.knora.webapi.responders.admin.ListsResponderADM" level="INFO"/>

--- a/webapi/src/main/scala/org/knora/webapi/KnoraExceptionHandler.scala
+++ b/webapi/src/main/scala/org/knora/webapi/KnoraExceptionHandler.scala
@@ -1,9 +1,9 @@
 package org.knora.webapi
 
-import akka.event.LoggingAdapter
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.ExceptionHandler
+import com.typesafe.scalalogging.LazyLogging
 import org.knora.webapi.http.{ApiStatusCodesV1, ApiStatusCodesV2}
 import org.knora.webapi.util.jsonld.{JsonLDDocument, JsonLDObject, JsonLDString}
 import spray.json.{JsNumber, JsObject, JsString, JsValue}
@@ -12,12 +12,12 @@ import spray.json.{JsNumber, JsObject, JsString, JsValue}
   * The Knora exception handler is used by akka-http to convert any exceptions thrown during route processing
   * into HttpResponses. It is brought implicitly into scope at the top level [[KnoraService]].
   */
-object KnoraExceptionHandler {
+object KnoraExceptionHandler extends LazyLogging {
 
     // A generic error message that we return to clients when an internal server error occurs.
     private val GENERIC_INTERNAL_SERVER_ERROR_MESSAGE = "The request could not be completed because of an internal server error."
 
-    def apply(settingsImpl: SettingsImpl, log: LoggingAdapter): ExceptionHandler = ExceptionHandler {
+    def apply(settingsImpl: SettingsImpl): ExceptionHandler = ExceptionHandler {
 
         /* TODO: Find out which response format should be generated, by looking at what the client is requesting / accepting (issue #292) */
 
@@ -44,7 +44,7 @@ object KnoraExceptionHandler {
                 val url = uri.path.toString
 
                 // println(s"KnoraExceptionHandler - case: ise - url: $url")
-                log.error(ise, s"Unable to run route $url")
+                logger.error(s"Unable to run route $url", ise)
 
                 if (url.startsWith("/v1")) {
                     complete(exceptionToJsonHttpResponseV1(ise, settingsImpl))
@@ -62,8 +62,8 @@ object KnoraExceptionHandler {
                 val uri = request.uri
                 val url = uri.path.toString
 
-                log.debug(s"KnoraExceptionHandler - case: other - url: $url")
-                log.error(other, s"Unable to run route $url")
+                logger.debug(s"KnoraExceptionHandler - case: other - url: $url")
+                logger.error(s"Unable to run route $url", other)
 
                 if (url.startsWith("/v1")) {
                     complete(exceptionToJsonHttpResponseV1(other, settingsImpl))

--- a/webapi/src/main/scala/org/knora/webapi/http/CORSSupport.scala
+++ b/webapi/src/main/scala/org/knora/webapi/http/CORSSupport.scala
@@ -19,7 +19,6 @@
 
 package org.knora.webapi.http
 
-import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.headers.HttpOriginRange
 import akka.http.scaladsl.server.{Directives, RejectionHandler, Route}
@@ -27,11 +26,12 @@ import ch.megard.akka.http.cors.scaladsl.CorsDirectives
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives._
 import ch.megard.akka.http.cors.scaladsl.model.HttpHeaderRange
 import ch.megard.akka.http.cors.scaladsl.settings.CorsSettings
+import com.typesafe.scalalogging.LazyLogging
 import org.knora.webapi.{KnoraExceptionHandler, SettingsImpl}
 
 import scala.collection.immutable.Seq
 
-object CORSSupport extends Directives {
+object CORSSupport extends Directives with LazyLogging {
 
     val allowedMethods = Seq(GET, PUT, POST, DELETE, HEAD, OPTIONS)
     val exposedHeaders = Seq("Server")
@@ -54,11 +54,11 @@ object CORSSupport extends Directives {
       * @param route the route for which CORS support is enabled
       * @return the enabled route.
       */
-    def CORS(route: Route, settings: SettingsImpl, log: LoggingAdapter): Route = {
+    def CORS(route: Route, settings: SettingsImpl): Route = {
         handleRejections(CorsDirectives.corsRejectionHandler) {
             cors(corsSettings) {
                 handleRejections(RejectionHandler.default) {
-                    handleExceptions(KnoraExceptionHandler(settings, log)) {
+                    handleExceptions(KnoraExceptionHandler(settings)) {
                         route
                     }
                 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/Responder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/Responder.scala
@@ -20,9 +20,9 @@
 package org.knora.webapi.responders
 
 import akka.actor.{ActorRef, ActorSystem}
-import akka.event.LoggingAdapter
 import akka.http.scaladsl.util.FastFuture
 import akka.util.Timeout
+import com.typesafe.scalalogging.{LazyLogging, Logger}
 import org.knora.webapi.util.StringFormatter
 import org.knora.webapi.{KnoraDispatchers, Settings, SettingsImpl, UnexpectedMessageException}
 
@@ -38,10 +38,10 @@ object Responder {
       * An responder use this method to handle unexpected request messages in a consistent way.
       *
       * @param message the message that was received.
-      * @param log     a [[LoggingAdapter]].
+      * @param log     a [[Logger]].
       * @param who     the responder receiving the message.
       */
-    def handleUnexpectedMessage(message: Any, log: LoggingAdapter, who: String): Future[Nothing] = {
+    def handleUnexpectedMessage(message: Any, log: Logger, who: String): Future[Nothing] = {
         val unexpectedMessageException = UnexpectedMessageException(s"$who received an unexpected message $message of type ${message.getClass.getCanonicalName}")
         FastFuture.failed(unexpectedMessageException)
     }
@@ -61,7 +61,7 @@ case class ResponderData(system: ActorSystem, applicationStateActor: ActorRef, r
 /**
   * An abstract class providing values that are commonly used in Knora responders.
   */
-abstract class Responder(responderData: ResponderData) {
+abstract class Responder(responderData: ResponderData) extends LazyLogging {
 
     /**
       * The actor system.
@@ -106,7 +106,7 @@ abstract class Responder(responderData: ResponderData) {
     /**
       * Provides logging
       */
-    val log: LoggingAdapter = akka.event.Logging(system, this.getClass.getName)
+    val log: Logger = logger
 }
 
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourceUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourceUtilV2.scala
@@ -20,9 +20,9 @@
 package org.knora.webapi.responders.v2
 
 import akka.actor.ActorRef
-import akka.event.LoggingAdapter
 import akka.pattern._
 import akka.util.Timeout
+import com.typesafe.scalalogging.Logger
 import org.knora.webapi.messages.admin.responder.permissionsmessages.{DefaultObjectAccessPermissionsStringForPropertyGetADM, DefaultObjectAccessPermissionsStringResponseADM}
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.store.sipimessages.{DeleteTemporaryFileRequestV2, MoveTemporaryFileToPermanentStorageRequestV2}
@@ -151,7 +151,7 @@ object ResourceUtilV2 {
                                                      requestingUser: UserADM,
                                                      responderManager: ActorRef,
                                                      storeManager: ActorRef,
-                                                     log: LoggingAdapter)(implicit timeout: Timeout, executionContext: ExecutionContext): Future[T] = {
+                                                     log: Logger)(implicit timeout: Timeout, executionContext: ExecutionContext): Future[T] = {
         // Was this a file value update?
         valueContent match {
             case fileValueContent: FileValueContentV2 =>
@@ -185,7 +185,7 @@ object ResourceUtilV2 {
 
                             case Failure(sipiException) =>
                                 // No. Log Sipi's error, and return the future we were given.
-                                log.error(cause = sipiException, message = "Sipi error")
+                                log.error( "Sipi error", sipiException)
                                 updateFuture
                         }
                 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/AroundDirectives.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/AroundDirectives.scala
@@ -19,9 +19,9 @@
 
 package org.knora.webapi.routing
 
-import akka.event.LoggingAdapter
 import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.Directives._
+import com.typesafe.scalalogging.Logger
 
 /**
   * Akka HTTP directives which can be wrapped around a [[akka.http.scaladsl.server.Route]]].
@@ -31,13 +31,13 @@ object AroundDirectives {
     /**
       * When wrapped around a [[akka.http.scaladsl.server.Route]], logs the time it took for the route to run.
       *
-      * @param log the logging adapter
+      * @param logger the logger
       */
-    def logDuration(log: LoggingAdapter): Directive0 = extractRequestContext.flatMap { ctx =>
+    def logDuration(logger: Logger): Directive0 = extractRequestContext.flatMap { ctx =>
         val start = System.currentTimeMillis()
         mapResponse { resp =>
             val took = System.currentTimeMillis() - start
-            log.info(s"[${resp.status.intValue()}] ${ctx.request.method.name} " + s"${ctx.request.uri} took: ${took}ms")
+            logger.info(s"[${resp.status.intValue()}] ${ctx.request.method.name} " + s"${ctx.request.uri} took: ${took}ms")
             resp
         }
     }

--- a/webapi/src/main/scala/org/knora/webapi/util/FileUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/FileUtil.scala
@@ -25,6 +25,7 @@ import java.nio.file.{Files, Paths}
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import akka.event.LoggingAdapter
+import com.typesafe.scalalogging.Logger
 import org.knora.webapi.{FileWriteException, NotFoundException, SettingsImpl}
 import resource._
 
@@ -174,13 +175,13 @@ object FileUtil {
       * @param log a logging adapter.
       * @return `true` if the file was deleted by this method.
       */
-    def deleteFileFromTmpLocation(fileName: File, log: LoggingAdapter): Boolean = {
+    def deleteFileFromTmpLocation(fileName: File, log: Logger): Boolean = {
 
         val path = fileName.toPath
 
         if (!fileName.canWrite) {
             val ex = FileWriteException(s"File $path cannot be deleted.")
-            log.error(ex, ex.getMessage)
+            log.error(ex.getMessage, ex)
         }
 
         Files.deleteIfExists(path)

--- a/webapi/src/main/scala/org/knora/webapi/util/PermissionUtilADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/PermissionUtilADM.scala
@@ -22,7 +22,7 @@ package org.knora.webapi.util
 import akka.actor.ActorRef
 import akka.pattern._
 import akka.util.Timeout
-import com.typesafe.scalalogging.Logger
+import com.typesafe.scalalogging.LazyLogging
 import org.knora.webapi._
 import org.knora.webapi.messages.admin.responder.groupsmessages.{GroupGetResponseADM, MultipleGroupsGetRequestADM}
 import org.knora.webapi.messages.admin.responder.permissionsmessages.PermissionType.PermissionType
@@ -30,7 +30,6 @@ import org.knora.webapi.messages.admin.responder.permissionsmessages.{Permission
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.v1.responder.usermessages.UserProfileV1
 import org.knora.webapi.responders.v1.GroupedProps.{ValueLiterals, ValueProps}
-import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -38,7 +37,7 @@ import scala.concurrent.{ExecutionContext, Future}
 /**
   * A utility that responder actors use to determine a user's permissions on an RDF entity in the triplestore.
   */
-object PermissionUtilADM {
+object PermissionUtilADM extends LazyLogging {
 
     // TODO: unify EntityPermission with PermissionADM.
 
@@ -157,8 +156,6 @@ object PermissionUtilADM {
         OntologyConstants.KnoraBase.AttachedToProject,
         OntologyConstants.KnoraBase.HasPermissions
     )
-
-    private val log = Logger(LoggerFactory.getLogger(this.getClass))
 
     /**
       * Given the IRI of an RDF property, returns `true` if the property is relevant to calculating permissions. This
@@ -436,7 +433,7 @@ object PermissionUtilADM {
             case Some(permissionListStr) => {
                 val cleanedPermissionListStr = permissionListStr replaceAll("[<>]", "")
                 val permissions: Seq[String] = cleanedPermissionListStr.split(OntologyConstants.KnoraBase.PermissionListDelimiter)
-                log.debug(s"PermissionUtil.parsePermissionsWithType - split permissions: $permissions")
+                logger.debug(s"PermissionUtil.parsePermissionsWithType - split permissions: $permissions")
                 permissions.flatMap {
                     permission =>
                         val splitPermission = permission.split(' ')
@@ -483,7 +480,7 @@ object PermissionUtilADM {
 
             case OntologyConstants.KnoraAdmin.ProjectResourceCreateRestrictedPermission =>
                 if (iris.nonEmpty) {
-                    log.debug(s"buildPermissionObject - ProjectResourceCreateRestrictedPermission - iris: $iris")
+                    logger.debug(s"buildPermissionObject - ProjectResourceCreateRestrictedPermission - iris: $iris")
                     iris.map(iri => PermissionADM.projectResourceCreateRestrictedPermission(iri))
                 } else {
                     throw InconsistentTriplestoreDataException(s"Missing additional permission information.")

--- a/webapi/src/test/scala/org/knora/webapi/E2ESimSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/E2ESimSpec.scala
@@ -26,6 +26,7 @@ import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest, HttpResponse}
 import akka.stream.ActorMaterializer
 import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.scalalogging.LazyLogging
 import io.gatling.core.scenario.Simulation
 import org.knora.webapi.messages.app.appmessages.SetAllowReloadOverHTTPState
 import org.knora.webapi.messages.store.triplestoremessages.{RdfDataObject, TriplestoreJsonProtocol}
@@ -52,7 +53,7 @@ object E2ESimSpec {
   * This class can be used in End-to-End testing. It starts the Knora server and
   * provides access to settings and logging.
   */
-abstract class E2ESimSpec(_system: ActorSystem) extends Simulation with Core with KnoraService with TriplestoreJsonProtocol with RequestBuilding {
+abstract class E2ESimSpec(_system: ActorSystem) extends Simulation with Core with KnoraService with TriplestoreJsonProtocol with RequestBuilding with LazyLogging {
 
     /* needed by the core trait */
 
@@ -75,8 +76,6 @@ abstract class E2ESimSpec(_system: ActorSystem) extends Simulation with Core wit
     /* needed by the core trait */
     implicit lazy val system: ActorSystem = _system
 
-    override lazy val log: LoggingAdapter = akka.event.Logging(system, "PerfSpec")
-
     protected val baseApiUrl: String = settings.internalKnoraApiBaseUrl
 
     // needs to be overridden in subclass
@@ -84,7 +83,7 @@ abstract class E2ESimSpec(_system: ActorSystem) extends Simulation with Core wit
 
     before {
         /* Set the startup flags and start the Knora Server */
-        log.info(s"executing before setup started")
+        logger.info(s"executing before setup started")
 
         applicationStateActor ! SetAllowReloadOverHTTPState(true)
 
@@ -94,12 +93,12 @@ abstract class E2ESimSpec(_system: ActorSystem) extends Simulation with Core wit
         // loadTestData
         loadTestData(rdfDataObjects)
 
-        log.info(s"executing before setup finished")
+        logger.info(s"executing before setup finished")
     }
 
     after {
         /* Stop the server when everything else has finished */
-        log.info(s"executing after setup")
+        logger.info(s"executing after setup")
         stopService()
     }
 

--- a/webapi/src/test/scala/org/knora/webapi/E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/E2ESpec.scala
@@ -28,6 +28,7 @@ import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.scalalogging.LazyLogging
 import org.eclipse.rdf4j.model.Model
 import org.eclipse.rdf4j.rio.{RDFFormat, Rio}
 import org.knora.webapi.messages.app.appmessages.SetAllowReloadOverHTTPState
@@ -49,7 +50,7 @@ object E2ESpec {
   * This class can be used in End-to-End testing. It starts the Knora server and
   * provides access to settings and logging.
   */
-class E2ESpec(_system: ActorSystem) extends Core with KnoraService with StartupUtils with TriplestoreJsonProtocol with Suite with WordSpecLike with Matchers with BeforeAndAfterAll with RequestBuilding {
+class E2ESpec(_system: ActorSystem) extends Core with KnoraService with StartupUtils with TriplestoreJsonProtocol with Suite with WordSpecLike with Matchers with BeforeAndAfterAll with RequestBuilding with LazyLogging {
 
     /* needed by the core trait */
     implicit lazy val system: ActorSystem = _system
@@ -69,8 +70,6 @@ class E2ESpec(_system: ActorSystem) extends Core with KnoraService with StartupU
     def this(name: String) = this(ActorSystem(name, E2ESpec.defaultConfig))
 
     def this() = this(ActorSystem("E2ETest", E2ESpec.defaultConfig))
-
-    override lazy val log: LoggingAdapter = akka.event.Logging(system, this.getClass.getName)
 
     protected val baseApiUrl: String = settings.internalKnoraApiBaseUrl
 
@@ -108,7 +107,7 @@ class E2ESpec(_system: ActorSystem) extends Core with KnoraService with StartupU
         val request = Get(baseApiUrl + "/health")
         val response = singleAwaitingRequest(request)
         assert(response.status == StatusCodes.OK, s"Knora is probably not running: ${response.status}")
-        if (response.status.isSuccess()) log.info("Knora is running.")
+        if (response.status.isSuccess()) logger.info("Knora is running.")
     }
 
     protected def loadTestData(rdfDataObjects: Seq[RdfDataObject]): Unit = {

--- a/webapi/src/test/scala/org/knora/webapi/R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/R2RSpec.scala
@@ -22,12 +22,12 @@ package org.knora.webapi
 import java.io.{File, StringReader}
 
 import akka.actor.{ActorRef, ActorSystem, Props}
-import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.server.ExceptionHandler
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.pattern._
 import akka.util.Timeout
+import com.typesafe.scalalogging.LazyLogging
 import org.eclipse.rdf4j.model.Model
 import org.eclipse.rdf4j.rio.{RDFFormat, Rio}
 import org.knora.webapi.app.{APPLICATION_STATE_ACTOR_NAME, ApplicationStateActor}
@@ -35,7 +35,7 @@ import org.knora.webapi.messages.store.triplestoremessages.{RdfDataObject, Reset
 import org.knora.webapi.messages.v1.responder.ontologymessages.LoadOntologiesRequest
 import org.knora.webapi.responders.{MockableResponderManager, RESPONDER_MANAGER_ACTOR_NAME}
 import org.knora.webapi.routing.KnoraRouteData
-import org.knora.webapi.store.{MockableStoreManager, StoreManager, StoreManagerActorName}
+import org.knora.webapi.store.{MockableStoreManager, StoreManagerActorName}
 import org.knora.webapi.util.jsonld.{JsonLDDocument, JsonLDUtil}
 import org.knora.webapi.util.{CacheUtil, FileUtil, StringFormatter}
 import org.scalatest.{BeforeAndAfterAll, Matchers, Suite, WordSpecLike}
@@ -46,15 +46,14 @@ import scala.language.postfixOps
 /**
   * Created by subotic on 08.12.15.
   */
-class R2RSpec extends Suite with ScalatestRouteTest with WordSpecLike with Matchers with BeforeAndAfterAll {
+class R2RSpec extends Suite with ScalatestRouteTest with WordSpecLike with Matchers with BeforeAndAfterAll with LazyLogging {
 
     def actorRefFactory: ActorSystem = system
 
     val settings = Settings(system)
-    implicit val log: LoggingAdapter = akka.event.Logging(system, this.getClass)
     StringFormatter.initForTest()
 
-    implicit val knoraExceptionHandler: ExceptionHandler = KnoraExceptionHandler(settings, log)
+    implicit val knoraExceptionHandler: ExceptionHandler = KnoraExceptionHandler(settings)
 
     implicit val timeout: Timeout = Timeout(settings.defaultTimeout)
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/ExceptionHandlerR2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/ExceptionHandlerR2RSpec.scala
@@ -80,7 +80,7 @@ class ExceptionHandlerR2RSpec extends R2RSpec {
         }
     }
 
-    private val route: Route = Route.seal(handleExceptions(KnoraExceptionHandler(settings, log)) {
+    private val route: Route = Route.seal(handleExceptions(KnoraExceptionHandler(settings)) {
         nfe ~ fe ~ bce ~ dve ~ oce ~ ece ~ sse ~ unpe ~ ae
     })
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/HealthRouteE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/HealthRouteE2ESpec.scala
@@ -38,8 +38,6 @@ class HealthRouteE2ESpec extends E2ESpec(HealthRouteE2ESpec.config) {
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(settings.defaultTimeout)
 
-    implicit override lazy val log = akka.event.Logging(system, this.getClass)
-
     "The Health Route" should {
 
         "return 'OK' for state 'Running'" in {
@@ -57,7 +55,7 @@ class HealthRouteE2ESpec extends E2ESpec(HealthRouteE2ESpec.config) {
             val request = Get(baseApiUrl + s"/health")
             val response: HttpResponse = singleAwaitingRequest(request)
 
-            log.debug(response.toString())
+            logger.debug(response.toString())
 
             response.status should be(StatusCodes.ServiceUnavailable)
         }
@@ -68,7 +66,7 @@ class HealthRouteE2ESpec extends E2ESpec(HealthRouteE2ESpec.config) {
             val request = Get(baseApiUrl + s"/health")
             val response: HttpResponse = singleAwaitingRequest(request)
 
-            log.debug(response.toString())
+            logger.debug(response.toString())
 
             response.status should be(StatusCodes.ServiceUnavailable)
         }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/InstanceChecker.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/InstanceChecker.scala
@@ -21,7 +21,7 @@ package org.knora.webapi.e2e
 
 import java.net.URLEncoder
 
-import akka.event.LoggingAdapter
+import com.typesafe.scalalogging.LazyLogging
 import org.knora.webapi._
 import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality._
 import org.knora.webapi.messages.v2.responder.ontologymessages._
@@ -45,12 +45,12 @@ object InstanceChecker {
     /**
       * Returns an [[InstanceChecker]] for Knora responses in JSON format.
       */
-    def getJsonChecker(log: LoggingAdapter): InstanceChecker = new InstanceChecker(new JsonInstanceInspector, log)
+    def getJsonChecker(): InstanceChecker = new InstanceChecker(new JsonInstanceInspector)
 
     /**
       * Returns an [[InstanceChecker]] for Knora responses in JSON-LD format.
       */
-    def getJsonLDChecker(log: LoggingAdapter): InstanceChecker = new InstanceChecker(new JsonLDInstanceInspector, log)
+    def getJsonLDChecker(): InstanceChecker = new InstanceChecker(new JsonLDInstanceInspector)
 }
 
 /**
@@ -58,9 +58,8 @@ object InstanceChecker {
   * the class definition.
   *
   * @param instanceInspector an [[InstanceInspector]] for working with instances in a particular format.
-  * @param log               a [[LoggingAdapter]] for debugging.
   */
-class InstanceChecker(instanceInspector: InstanceInspector, log: LoggingAdapter) {
+class InstanceChecker(instanceInspector: InstanceInspector) extends LazyLogging {
 
     implicit private val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -97,7 +96,7 @@ class InstanceChecker(instanceInspector: InstanceInspector, log: LoggingAdapter)
       * @param msg the error message.
       */
     private def throwAndLogAssertionException(msg: String): Nothing = {
-        log.debug(msg)
+        logger.debug(msg)
         throw AssertionException(msg)
     }
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/InstanceCheckerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/InstanceCheckerSpec.scala
@@ -20,7 +20,6 @@
 package org.knora.webapi.e2e
 
 import akka.actor.ActorSystem
-import akka.event.LoggingAdapter
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import com.typesafe.config.{Config, ConfigFactory}
 import org.knora.webapi.util.IriConversions._
@@ -37,12 +36,10 @@ class InstanceCheckerSpec extends E2ESpec(InstanceCheckerSpec.config) {
 
     implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(settings.defaultTimeout)
 
-    implicit override lazy val log: LoggingAdapter = akka.event.Logging(system, this.getClass)
-
     implicit val ec: ExecutionContextExecutor = system.dispatcher
 
-    private val jsonLDInstanceChecker: InstanceChecker = InstanceChecker.getJsonLDChecker(log)
-    private val jsonInstanceChecker: InstanceChecker = InstanceChecker.getJsonChecker(log)
+    private val jsonLDInstanceChecker: InstanceChecker = InstanceChecker.getJsonLDChecker()
+    private val jsonInstanceChecker: InstanceChecker = InstanceChecker.getJsonChecker()
 
     "The InstanceChecker" should {
         "reject a JSON-LD instance of anything:Thing (in the complex schema) with an extra property" in {

--- a/webapi/src/test/scala/org/knora/webapi/e2e/RejectingRouteE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/RejectingRouteE2ESpec.scala
@@ -38,8 +38,6 @@ class RejectingRouteE2ESpec extends E2ESpec(RejectingRouteE2ESpec.config) {
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(settings.defaultTimeout)
 
-    override lazy val log = akka.event.Logging(system, this.getClass())
-
     "The Rejecting Route" should {
 
         "reject the 'v1/test' path" in {

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/GroupsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/GroupsADME2ESpec.scala
@@ -48,8 +48,6 @@ class GroupsADME2ESpec extends E2ESpec(GroupsADME2ESpec.config) with GroupsADMJs
 
     implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(30.seconds)
 
-    implicit override lazy val log: LoggingAdapter = akka.event.Logging(system, this.getClass)
-
     private val rootEmail = SharedTestDataADM.rootUser.email
     private val rootEmailEnc = java.net.URLEncoder.encode(rootEmail, "utf-8")
     private val imagesUser01Email = SharedTestDataADM.imagesUser01.email
@@ -129,7 +127,7 @@ class GroupsADME2ESpec extends E2ESpec(GroupsADME2ESpec.config) with GroupsADMJs
                 val groupIriEnc = java.net.URLEncoder.encode(newGroupIri.get, "utf-8")
                 val request = Put(baseApiUrl + "/admin/groups/" + groupIriEnc, HttpEntity(ContentTypes.`application/json`, params)) ~> addCredentials(BasicHttpCredentials(imagesUser01Email, testPass))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                log.debug(s"response: {}", response)
+                logger.debug(s"response: {}", response)
                 response.status should be (StatusCodes.OK)
 
                 val groupInfo: GroupADM = AkkaHttpUtils.httpResponseToJson(response).fields("group").convertTo[GroupADM]
@@ -147,7 +145,7 @@ class GroupsADME2ESpec extends E2ESpec(GroupsADME2ESpec.config) with GroupsADMJs
                 val groupIriEnc = java.net.URLEncoder.encode(newGroupIri.get, "utf-8")
                 val request = Delete(baseApiUrl + "/admin/groups/" + groupIriEnc) ~> addCredentials(BasicHttpCredentials(imagesUser01Email, testPass))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                log.debug(s"response: {}", response)
+                logger.debug(s"response: {}", response)
                 response.status should be (StatusCodes.OK)
 
                 val groupInfo: GroupADM = AkkaHttpUtils.httpResponseToJson(response).fields("group").convertTo[GroupADM]

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/ListsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/ListsADME2ESpec.scala
@@ -49,8 +49,6 @@ class ListsADME2ESpec extends E2ESpec(ListsADME2ESpec.config) with SessionJsonPr
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(5.seconds)
 
-    implicit override lazy val log = akka.event.Logging(system, this.getClass())
-
     override lazy val rdfDataObjects = List(
         RdfDataObject(path = "_test_data/demo_data/images-demo-data.ttl", name = "http://www.knora.org/data/00FF/images"),
         RdfDataObject(path = "_test_data/all_data/anything-data.ttl", name = "http://www.knora.org/data/0001/anything")

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
@@ -49,7 +49,7 @@ class PermissionsADME2ESpec extends E2ESpec(PermissionsADME2ESpec.config) with T
 
             val request = Get(baseApiUrl + s"/admin/permissions/$projectIri/$groupIri")
             val response = singleAwaitingRequest(request, 1.seconds)
-            log.debug("==>> " + response.toString)
+            logger.debug("==>> " + response.toString)
             assert(response.status === StatusCodes.OK)
         }
     }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESpec.scala
@@ -50,8 +50,6 @@ class ProjectsADME2ESpec extends E2ESpec(ProjectsADME2ESpec.config) with Session
 
     private implicit def default(implicit system: ActorSystem) = RouteTestTimeout(30.seconds)
 
-    implicit override lazy val log = akka.event.Logging(system, this.getClass())
-
     private val rootEmail = SharedTestDataADM.rootUser.email
     private val rootEmailEnc = java.net.URLEncoder.encode(rootEmail, "utf-8")
     private val testPass = java.net.URLEncoder.encode("test", "utf-8")
@@ -101,7 +99,7 @@ class ProjectsADME2ESpec extends E2ESpec(ProjectsADME2ESpec.config) with Session
             "return the project's restricted view settings" in {
                 val request = Get(baseApiUrl + s"/admin/projects/iri/$projectIriEnc/RestrictedViewSettings") ~> addCredentials(BasicHttpCredentials(rootEmail, testPass))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                log.debug(s"response: {}", response)
+                logger.debug(s"response: {}", response)
                 assert(response.status === StatusCodes.OK)
 
                 val settings: ProjectRestrictedViewSettingsADM = AkkaHttpUtils.httpResponseToJson(response).fields("settings").convertTo[ProjectRestrictedViewSettingsADM]
@@ -133,7 +131,7 @@ class ProjectsADME2ESpec extends E2ESpec(ProjectsADME2ESpec.config) with Session
 
                 val request = Post(baseApiUrl + s"/admin/projects", HttpEntity(ContentTypes.`application/json`, params)) ~> addCredentials(BasicHttpCredentials(rootEmail, testPass))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                log.debug(s"response: {}", response)
+                logger.debug(s"response: {}", response)
                 response.status should be (StatusCodes.OK)
 
                 val result = AkkaHttpUtils.httpResponseToJson(response).fields("project").convertTo[ProjectADM]

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/StoreRouteADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/StoreRouteADME2ESpec.scala
@@ -73,9 +73,9 @@ class StoreRouteADME2ESpec extends E2ESpec(StoreRouteADME2ESpec.config) with Tri
               * curl -H "Content-Type: application/json" -X POST -d '[{"path":"../knora-ontologies/knora-base.ttl","name":"http://www.knora.org/ontology/knora-base"}]' http://localhost:3333/admin/store/ResetTriplestoreContent
               */
 
-            log.debug("==>>")
+            logger.debug("==>>")
 			applicationStateActor ! SetAllowReloadOverHTTPState(true)
-            log.debug("==>>")
+            logger.debug("==>>")
             val request = Post(baseApiUrl + "/admin/store/ResetTriplestoreContent", HttpEntity(ContentTypes.`application/json`, rdfDataObjects.toJson.compactPrint))
             val response = singleAwaitingRequest(request, 300.seconds)
             // log.debug("==>> " + response.toString)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/UsersADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/UsersADME2ESpec.scala
@@ -52,8 +52,6 @@ class UsersADME2ESpec extends E2ESpec(UsersADME2ESpec.config) with ProjectsADMJs
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(30.seconds)
 
-    implicit override lazy val log = akka.event.Logging(system, this.getClass())
-
     val rootCreds = CredentialsV1(
         SharedTestDataADM.rootUser.id,
         SharedTestDataADM.rootUser.email,
@@ -138,7 +136,7 @@ class UsersADME2ESpec extends E2ESpec(UsersADME2ESpec.config) with ProjectsADMJs
             "return all users" in {
                 val request = Get(baseApiUrl + s"/admin/users") ~> addCredentials(BasicHttpCredentials(rootCreds.email, rootCreds.password))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                log.debug(s"response: ${response.toString}")
+                logger.debug(s"response: ${response.toString}")
                 response.status should be(StatusCodes.OK)
             }
 
@@ -322,7 +320,7 @@ class UsersADME2ESpec extends E2ESpec(UsersADME2ESpec.config) with ProjectsADMJs
 
                 val request1 = Put(baseApiUrl + s"/admin/users/iri/${normalUserCreds.urlEncodedIri}/Password", HttpEntity(ContentTypes.`application/json`, params01)) ~> addCredentials(BasicHttpCredentials(normalUserCreds.email, "test")) // requester's password
                 val response1: HttpResponse = singleAwaitingRequest(request1)
-                log.debug(s"response: ${response1.toString}")
+                logger.debug(s"response: ${response1.toString}")
                 response1.status should be(StatusCodes.OK)
 
                 // check if the password was changed, i.e. if the new one is accepted
@@ -344,7 +342,7 @@ class UsersADME2ESpec extends E2ESpec(UsersADME2ESpec.config) with ProjectsADMJs
 
                 val request1 = Put(baseApiUrl + s"/admin/users/iri/${normalUserCreds.urlEncodedIri}/Password", HttpEntity(ContentTypes.`application/json`, params01)) ~> addCredentials(BasicHttpCredentials(rootCreds.email, "test")) // requester's password
                 val response1: HttpResponse = singleAwaitingRequest(request1)
-                log.debug(s"response: ${response1.toString}")
+                logger.debug(s"response: ${response1.toString}")
                 response1.status should be(StatusCodes.OK)
 
                 // check if the password was changed, i.e. if the new one is accepted

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/AuthenticationV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/AuthenticationV1E2ESpec.scala
@@ -67,7 +67,7 @@ class AuthenticationV1E2ESpec extends E2ESpec(AuthenticationV1E2ESpec.config) wi
             /* Correct username and password */
             val request = Get(baseApiUrl + s"/v1/authenticate?email=$rootEmailEnc&password=$testPass")
             val response: HttpResponse = singleAwaitingRequest(request)
-            log.debug(s"response: ${response.toString}")
+            logger.debug(s"response: ${response.toString}")
             assert(response.status === StatusCodes.OK)
         }
 
@@ -75,14 +75,14 @@ class AuthenticationV1E2ESpec extends E2ESpec(AuthenticationV1E2ESpec.config) wi
             /* Correct email / wrong password */
             val request = Get(baseApiUrl + s"/v1/authenticate?email=$rootEmail&password=$wrongPass")
             val response: HttpResponse = singleAwaitingRequest(request)
-            log.debug(s"response: ${response.toString}")
+            logger.debug(s"response: ${response.toString}")
             assert(response.status === StatusCodes.Unauthorized)
         }
         "fail authentication if the user is set as 'not active' " in {
             /* User not active */
             val request = Get(baseApiUrl + s"/v1/authenticate?email=$inactiveUserEmailEnc&password=$testPass")
             val response: HttpResponse = singleAwaitingRequest(request)
-            log.debug(s"response: ${response.toString}")
+            logger.debug(s"response: ${response.toString}")
             assert(response.status === StatusCodes.Unauthorized)
         }
     }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ListsV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ListsV1E2ESpec.scala
@@ -45,8 +45,6 @@ class ListsV1E2ESpec extends E2ESpec(ListsV1E2ESpec.config) with SessionJsonProt
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(5.seconds)
 
-    implicit override lazy val log = akka.event.Logging(system, this.getClass())
-
     override lazy val rdfDataObjects = List(
         RdfDataObject(path = "_test_data/demo_data/images-demo-data.ttl", name = "http://www.knora.org/data/00FF/images"),
         RdfDataObject(path = "_test_data/all_data/anything-data.ttl", name = "http://www.knora.org/data/0001/anything")

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ProjectsV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ProjectsV1E2ESpec.scala
@@ -50,8 +50,6 @@ class ProjectsV1E2ESpec extends E2ESpec(ProjectsV1E2ESpec.config) with SessionJs
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(30.seconds)
 
-    implicit override lazy val log = akka.event.Logging(system, this.getClass())
-
     private val rootEmail = SharedTestDataV1.rootUser.userData.email.get
     private val rootEmailEnc = java.net.URLEncoder.encode(rootEmail, "utf-8")
     private val testPass = java.net.URLEncoder.encode("test", "utf-8")
@@ -67,10 +65,10 @@ class ProjectsV1E2ESpec extends E2ESpec(ProjectsV1E2ESpec.config) with SessionJs
             "return all projects" in {
                 val request = Get(baseApiUrl + s"/v1/projects") ~> addCredentials(BasicHttpCredentials(rootEmail, testPass))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                // log.debug(s"response: {}", response)
+                // logger.debug(s"response: {}", response)
                 assert(response.status === StatusCodes.OK)
 
-                // log.debug("projects as objects: {}", AkkaHttpUtils.httpResponseToJson(response).fields("projects").convertTo[Seq[ProjectInfoV1]])
+                // logger.debug("projects as objects: {}", AkkaHttpUtils.httpResponseToJson(response).fields("projects").convertTo[Seq[ProjectInfoV1]])
 
                 val projects: Seq[ProjectInfoV1] = AkkaHttpUtils.httpResponseToJson(response).fields("projects").convertTo[Seq[ProjectInfoV1]]
 
@@ -81,14 +79,14 @@ class ProjectsV1E2ESpec extends E2ESpec(ProjectsV1E2ESpec.config) with SessionJs
             "return the information for a single project identified by iri" in {
                 val request = Get(baseApiUrl + s"/v1/projects/$projectIriEnc") ~> addCredentials(BasicHttpCredentials(rootEmail, testPass))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                // log.debug(s"response: {}", response)
+                // logger.debug(s"response: {}", response)
                 assert(response.status === StatusCodes.OK)
             }
 
             "return the information for a single project identified by shortname" in {
                 val request = Get(baseApiUrl + s"/v1/projects/$projectShortnameEnc?identifier=shortname") ~> addCredentials(BasicHttpCredentials(rootEmail, testPass))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                // log.debug(s"response: {}", response)
+                // logger.debug(s"response: {}", response)
                 assert(response.status === StatusCodes.OK)
             }
         }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/UsersV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/UsersV1E2ESpec.scala
@@ -47,8 +47,6 @@ class UsersV1E2ESpec extends E2ESpec(UsersV1E2ESpec.config) with SessionJsonProt
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(30.seconds)
 
-    implicit override lazy val log = akka.event.Logging(system, this.getClass())
-
     val rootCreds = CredentialsV1(
         SharedTestDataV1.rootUser.userData.user_id.get,
         SharedTestDataV1.rootUser.userData.email.get,
@@ -125,7 +123,7 @@ class UsersV1E2ESpec extends E2ESpec(UsersV1E2ESpec.config) with SessionJsonProt
             "return all users" in {
                 val request = Get(baseApiUrl + s"/v1/users") ~> addCredentials(BasicHttpCredentials(rootCreds.email, rootCreds.password))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                // log.debug(s"response: ${response.toString}")
+                // logger.debug(s"response: ${response.toString}")
                 response.status should be(StatusCodes.OK)
             }
 
@@ -133,7 +131,7 @@ class UsersV1E2ESpec extends E2ESpec(UsersV1E2ESpec.config) with SessionJsonProt
                 /* Correct username and password */
                 val request = Get(baseApiUrl + s"/v1/users/${rootCreds.urlEncodedIri}") ~> addCredentials(BasicHttpCredentials(rootCreds.email, rootCreds.password))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                // log.debug(s"response: ${response.toString}")
+                // logger.debug(s"response: ${response.toString}")
                 response.status should be(StatusCodes.OK)
             }
 
@@ -141,7 +139,7 @@ class UsersV1E2ESpec extends E2ESpec(UsersV1E2ESpec.config) with SessionJsonProt
                 /* Correct username and password */
                 val request = Get(baseApiUrl + s"/v1/users/${rootCreds.urlEncodedEmail}?identifier=email") ~> addCredentials(BasicHttpCredentials(rootCreds.email, rootCreds.password))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                // log.debug(s"response: ${response.toString}")
+                // logger.debug(s"response: ${response.toString}")
                 response.status should be(StatusCodes.OK)
             }
 
@@ -152,7 +150,7 @@ class UsersV1E2ESpec extends E2ESpec(UsersV1E2ESpec.config) with SessionJsonProt
             "return all projects the user is a member of" in {
                 val request = Get(baseApiUrl + s"/v1/users/projects/$multiUserIriEnc") ~> addCredentials(BasicHttpCredentials(rootCreds.email, rootCreds.password))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                log.debug(s"response: ${response.toString}")
+                logger.debug(s"response: ${response.toString}")
                 assert(response.status === StatusCodes.OK)
 
                 val projects: Seq[IRI] = AkkaHttpUtils.httpResponseToJson(response).fields("projects").convertTo[List[IRI]]
@@ -168,7 +166,7 @@ class UsersV1E2ESpec extends E2ESpec(UsersV1E2ESpec.config) with SessionJsonProt
             "return all projects the user is a member of the project admin group" in {
                 val request = Get(baseApiUrl + s"/v1/users/projects-admin/$multiUserIriEnc") ~> addCredentials(BasicHttpCredentials(rootCreds.email, rootCreds.password))
                 val response: HttpResponse = singleAwaitingRequest(request)
-                log.debug(s"response: ${response.toString}")
+                logger.debug(s"response: ${response.toString}")
                 assert(response.status === StatusCodes.OK)
 
                 val projects: Seq[IRI] = AkkaHttpUtils.httpResponseToJson(response).fields("projects").convertTo[List[IRI]]

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/AuthenticationV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/AuthenticationV2E2ESpec.scala
@@ -52,8 +52,6 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
 
     private implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(settings.defaultTimeout)
 
-    implicit override lazy val log: LoggingAdapter = akka.event.Logging(system, this.getClass)
-
     private val rootIri = SharedTestDataADM.rootUser.id
     private val rootIriEnc = java.net.URLEncoder.encode(rootIri, "utf-8")
     private val rootUsername = SharedTestDataADM.rootUser.username
@@ -73,7 +71,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             /* Correct username and password */
             val request = Get(baseApiUrl + s"/v2/authentication?iri=$rootIriEnc&password=$testPass")
             val response: HttpResponse = singleAwaitingRequest(request)
-            log.debug(s"response: ${response.toString}")
+            logger.debug(s"response: ${response.toString}")
             assert(response.status === StatusCodes.OK)
         }
 
@@ -81,7 +79,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             /* Correct username and password */
             val request = Get(baseApiUrl + s"/v2/authentication?email=$rootEmailEnc&password=$testPass")
             val response: HttpResponse = singleAwaitingRequest(request)
-            log.debug(s"response: ${response.toString}")
+            logger.debug(s"response: ${response.toString}")
             assert(response.status === StatusCodes.OK)
         }
 
@@ -89,7 +87,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             /* Correct username and password */
             val request = Get(baseApiUrl + s"/v2/authentication?username=$rootUsernameEnc&password=$testPass")
             val response: HttpResponse = singleAwaitingRequest(request)
-            log.debug(s"response: ${response.toString}")
+            logger.debug(s"response: ${response.toString}")
             assert(response.status === StatusCodes.OK)
         }
 
@@ -97,14 +95,14 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             /* Correct email / wrong password */
             val request = Get(baseApiUrl + s"/v2/authentication?email=$rootEmail&password=$wrongPass")
             val response: HttpResponse = singleAwaitingRequest(request)
-            log.debug(s"response: ${response.toString}")
+            logger.debug(s"response: ${response.toString}")
             assert(response.status === StatusCodes.Unauthorized)
         }
         "fail authentication with the user set as 'not active' " in {
             /* User not active */
             val request = Get(baseApiUrl + s"/v2/authentication?email=$inactiveUserEmailEnc&password=$testPass")
             val response: HttpResponse = singleAwaitingRequest(request)
-            log.debug(s"response: ${response.toString}")
+            logger.debug(s"response: ${response.toString}")
             assert(response.status === StatusCodes.Unauthorized)
         }
     }
@@ -129,7 +127,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             /* User not active */
             val request = Get(baseApiUrl + s"/v2/authentication") ~> addCredentials(BasicHttpCredentials(inactiveUserEmail, testPass))
             val response: HttpResponse = singleAwaitingRequest(request)
-            log.debug(s"response: ${response.toString}")
+            logger.debug(s"response: ${response.toString}")
             assert(response.status === StatusCodes.Unauthorized)
         }
     }
@@ -152,12 +150,12 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             val response: HttpResponse = singleAwaitingRequest(request)
             assert(response.status == StatusCodes.OK)
 
-            //println(response.toString)
+            // println(response.toString)
 
             val lr: LoginResponse = Await.result(Unmarshal(response.entity).to[LoginResponse], 1.seconds)
 
             lr.token.nonEmpty should be (true)
-            log.debug("token: {}", lr.token)
+            logger.debug("token: {}", lr.token)
 
             token.set(lr.token)
         }
@@ -176,12 +174,12 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             val response: HttpResponse = singleAwaitingRequest(request)
             assert(response.status == StatusCodes.OK)
 
-            //println(response.toString)
+            // println(response.toString)
 
             val lr: LoginResponse = Await.result(Unmarshal(response.entity).to[LoginResponse], 1.seconds)
 
             lr.token.nonEmpty should be (true)
-            log.debug("token: {}", lr.token)
+            logger.debug("token: {}", lr.token)
         }
 
         "login with username" in {
@@ -198,19 +196,19 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             val response: HttpResponse = singleAwaitingRequest(request)
             assert(response.status == StatusCodes.OK)
 
-            //println(response.toString)
+            // println(response.toString)
 
             val lr: LoginResponse = Await.result(Unmarshal(response.entity).to[LoginResponse], 1.seconds)
 
             lr.token.nonEmpty should be (true)
-            log.debug("token: {}", lr.token)
+            logger.debug("token: {}", lr.token)
         }
 
         "authenticate with token in header" in {
             // authenticate by calling '/v2/authenticate' without parameters but by providing token (from earlier login) in authorization header
             val request = Get(baseApiUrl + "/v2/authentication") ~> addCredentials(GenericHttpCredentials("Bearer", token.get))
             val response = singleAwaitingRequest(request)
-            log.debug("response: {}", response.toString())
+            logger.debug("response: {}", response.toString())
             assert(response.status === StatusCodes.OK)
         }
 
@@ -218,7 +216,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             // authenticate by calling '/v2/authenticate' with parameters providing the token (from earlier login)
             val request = Get(baseApiUrl + s"/v2/authentication?token=${token.get}")
             val response = singleAwaitingRequest(request)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             assert(response.status === StatusCodes.OK)
         }
 
@@ -226,7 +224,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             // do logout with stored token
             val request = Delete(baseApiUrl + "/v2/authentication?") ~> addCredentials(GenericHttpCredentials("Bearer", token.get))
             val response = singleAwaitingRequest(request)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             assert(response.status === StatusCodes.OK)
         }
 
@@ -247,14 +245,14 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
 
             val request2 = Delete(baseApiUrl + s"/v2/authentication?token=$token")
             val response2 = singleAwaitingRequest(request2)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             assert(response2.status === StatusCodes.OK)
         }
 
         "fail with authentication when providing the token after logout" in {
             val request = Get(baseApiUrl + "/v2/authentication") ~> addCredentials(GenericHttpCredentials("Bearer", token.get))
             val response = singleAwaitingRequest(request)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             assert(response.status === StatusCodes.Unauthorized)
         }
 
@@ -333,7 +331,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             val lr: LoginResponse = Await.result(Unmarshal(response.entity).to[LoginResponse], 1.seconds)
 
             lr.token.nonEmpty should be (true)
-            log.debug("token: {}", lr.token)
+            logger.debug("token: {}", lr.token)
 
             token.set(lr.token)
         }
@@ -342,7 +340,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             /* Correct email / correct password */
             val request = Get(baseApiUrl + s"/v1/users/$rootIriEnc?token=${token.get}")
             val response = singleAwaitingRequest(request)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             assert(response.status === StatusCodes.OK)
         }
 
@@ -351,7 +349,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             val request = Get(baseApiUrl + s"/v1/users/$rootIriEnc?token=wrong")
 
             val response = singleAwaitingRequest(request)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             assert(response.status === StatusCodes.Unauthorized)
         }
 
@@ -359,7 +357,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             /* Correct email / correct password */
             val request = Get(baseApiUrl + s"/v1/users/$rootIriEnc") ~> addCredentials(GenericHttpCredentials("Bearer", token.get))
             val response = singleAwaitingRequest(request)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             assert(response.status === StatusCodes.OK)
         }
 
@@ -367,14 +365,14 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             /* Correct email / wrong password */
             val request = Get(baseApiUrl + s"/v1/users/$rootIriEnc") ~> addCredentials(GenericHttpCredentials("Bearer", "123456"))
             val response = singleAwaitingRequest(request)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             assert(response.status === StatusCodes.Unauthorized)
         }
 
         "not return sensitive information (token, password) in the response " in {
             val request = Get(baseApiUrl + s"/v1/users/$rootIriEnc?token=${token.get}")
             val response = singleAwaitingRequest(request)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             // assert(status === StatusCodes.OK)
 
             /* check for sensitive information leakage */
@@ -408,7 +406,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             val lr: LoginResponse = Await.result(Unmarshal(response.entity).to[LoginResponse], 1.seconds)
 
             lr.token.nonEmpty should be (true)
-            // log.debug("token: {}", lr.token)
+            // logger.debug("token: {}", lr.token)
 
             token.set(lr.token)
         }
@@ -417,7 +415,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             /* Correct token */
             val request = Get(baseApiUrl + s"/admin/users/iri/$rootIriEnc?token=${token.get}")
             val response = singleAwaitingRequest(request)
-            // log.debug(response.toString())
+            // logger.debug(response.toString())
             assert(response.status === StatusCodes.OK)
         }
 
@@ -426,7 +424,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             val request = Get(baseApiUrl + s"/admin/users/iri/$rootIriEnc?token=wrong")
 
             val response = singleAwaitingRequest(request)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             assert(response.status === StatusCodes.Unauthorized)
         }
 
@@ -434,7 +432,7 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             /* Correct token */
             val request = Get(baseApiUrl + s"/admin/users/iri/$rootIriEnc") ~> addCredentials(GenericHttpCredentials("Bearer", token.get))
             val response = singleAwaitingRequest(request)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             assert(response.status === StatusCodes.OK)
         }
 
@@ -442,14 +440,14 @@ class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) wi
             /* Wrong token */
             val request = Get(baseApiUrl + s"/admin/users/iri/$rootIriEnc") ~> addCredentials(GenericHttpCredentials("Bearer", "123456"))
             val response = singleAwaitingRequest(request)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             assert(response.status === StatusCodes.Unauthorized)
         }
 
         "not return sensitive information (token, password) in the response " in {
             val request = Get(baseApiUrl + s"/admin/users/iri/$rootIriEnc?token=${token.get}")
             val response = singleAwaitingRequest(request)
-            //log.debug("==>> " + responseAs[String])
+            // logger.debug("==>> " + responseAs[String])
             // assert(status === StatusCodes.OK)
 
             /* check for sensitive information leakage */

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -67,7 +67,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
 
     )
 
-    private val instanceChecker: InstanceChecker = InstanceChecker.getJsonLDChecker(log)
+    private val instanceChecker: InstanceChecker = InstanceChecker.getJsonLDChecker()
 
     "The resources v2 endpoint" should {
         "perform a resource request for the book 'Reise ins Heilige Land' using the complex schema in JSON-LD" in {

--- a/webapi/src/test/scala/org/knora/webapi/http/CORSSupportV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/http/CORSSupportV1R2RSpec.scala
@@ -48,7 +48,7 @@ class CORSSupportV1R2RSpec extends R2RSpec {
         "accept valid pre-flight requests" in {
 
             Options() ~> Origin(exampleOrigin) ~> `Access-Control-Request-Method`(GET) ~> {
-                addServerHeader(CORS(sealedResourcesRoute, settings, log))
+                addServerHeader(CORS(sealedResourcesRoute, settings))
             } ~> check {
                 responseAs[String] shouldBe empty
                 status shouldBe StatusCodes.OK
@@ -66,7 +66,7 @@ class CORSSupportV1R2RSpec extends R2RSpec {
 
             val invalidMethod = PATCH
             Options() ~> Origin(exampleOrigin) ~> `Access-Control-Request-Method`(invalidMethod) ~> {
-                CORS(sealedResourcesRoute, settings, log)
+                CORS(sealedResourcesRoute, settings)
             } ~> check {
                 status shouldBe StatusCodes.BadRequest
                 entityAs[String] should equal("CORS: invalid method 'PATCH'")

--- a/webapi/src/test/scala/org/knora/webapi/http/ServerVersionE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/http/ServerVersionE2ESpec.scala
@@ -37,14 +37,12 @@ class ServerVersionE2ESpec extends E2ESpec(ServerVersionE2ESpec.config) {
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(settings.defaultTimeout)
 
-    override lazy val log = akka.event.Logging(system, this.getClass)
-
     "The Server" should {
 
         "return the custom 'Server' header with every response" in {
             val request = Get(baseApiUrl + s"/admin/projects")
             val response: HttpResponse = singleAwaitingRequest(request)
-            // log.debug(s"response: ${response.toString}")
+            // logger.debug(s"response: ${response.toString}")
             response.headers should contain (ServerVersion.getServerVersionHeader())
             response.status should be(StatusCodes.OK)
         }

--- a/webapi/src/test/scala/org/knora/webapi/other/v1/DrawingsGodsV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/other/v1/DrawingsGodsV1E2ESpec.scala
@@ -41,8 +41,6 @@ object DrawingsGodsV1E2ESpec {
   */
 class DrawingsGodsV1E2ESpec extends E2ESpec(DrawingsGodsV1E2ESpec.config) with TriplestoreJsonProtocol {
 
-    implicit override lazy val log = akka.event.Logging(system, this.getClass())
-
     override lazy val rdfDataObjects: List[RdfDataObject] = List(
         RdfDataObject(path = "_test_data/other.v1.DrawingsGodsV1E2ESpec/rvp-admin-data.ttl", name = "http://www.knora.org/data/admin"),
         RdfDataObject(path = "_test_data/other.v1.DrawingsGodsV1E2ESpec/rvp-permissions-data.ttl", name = "http://www.knora.org/data/permissions"),
@@ -87,7 +85,7 @@ class DrawingsGodsV1E2ESpec extends E2ESpec(DrawingsGodsV1E2ESpec.config) with T
             val resId = ResourceResponseExtractorMethods.getResIriFromJsonResponse(response)
 
             thingIri.set(resId)
-            log.debug(s"1a. thingIri: ${thingIri.get}")
+            logger.debug(s"1a. thingIri: ${thingIri.get}")
         }
 
 
@@ -108,7 +106,7 @@ class DrawingsGodsV1E2ESpec extends E2ESpec(DrawingsGodsV1E2ESpec.config) with T
             val valId = ValuesResponseExtractorMethods.getNewValueIriFromJsonResponse(response)
 
             firstValueIri.set(valId)
-            log.debug(s"1b. firstValueIri: ${firstValueIri.get}")
+            logger.debug(s"1b. firstValueIri: ${firstValueIri.get}")
         }
 
         "allow the drawings-gods user to change the existing value (2a)" in {
@@ -129,7 +127,7 @@ class DrawingsGodsV1E2ESpec extends E2ESpec(DrawingsGodsV1E2ESpec.config) with T
             val valId = ValuesResponseExtractorMethods.getNewValueIriFromJsonResponse(response)
 
             firstValueIri.set(valId)
-            log.debug(s"2a. firstValueIri: ${firstValueIri.get}")
+            logger.debug(s"2a. firstValueIri: ${firstValueIri.get}")
         }
 
         "allow the drawings-gods user to create a new value inside the parole-religieuse project (2b)" in {
@@ -150,7 +148,7 @@ class DrawingsGodsV1E2ESpec extends E2ESpec(DrawingsGodsV1E2ESpec.config) with T
             val valId = ValuesResponseExtractorMethods.getNewValueIriFromJsonResponse(response)
 
             secondValueIri.set(valId)
-            log.debug(s"2b. secondValueIri: ${secondValueIri.get}")
+            logger.debug(s"2b. secondValueIri: ${secondValueIri.get}")
         }
     }
 

--- a/webapi/src/test/scala/org/knora/webapi/other/v2/LumieresLausanneV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/other/v2/LumieresLausanneV2E2ESpec.scala
@@ -39,8 +39,6 @@ object LumieresLausanneV2E2ESpec {
   */
 class LumieresLausanneV2E2ESpec extends E2ESpec(LumieresLausanneV2E2ESpec.config) with TriplestoreJsonProtocol {
 
-    implicit override lazy val log: LoggingAdapter = akka.event.Logging(system, this.getClass)
-
     override lazy val rdfDataObjects: List[RdfDataObject] = List(
         RdfDataObject(path = "_test_data/other.v2.LumieresLausanneV2E2ESpec/lumieres-lausanne_admin.ttl", name = "http://www.knora.org/data/admin"),
         RdfDataObject(path = "_test_data/other.v2.LumieresLausanneV2E2ESpec/lumieres-lausanne_permissions.ttl", name = "http://www.knora.org/data/permissions"),

--- a/webapi/src/test/scala/org/knora/webapi/util/AkkaHttpUtils.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/AkkaHttpUtils.scala
@@ -30,6 +30,7 @@ import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import com.github.jsonldjava.core.{JsonLdOptions, JsonLdProcessor}
 import com.github.jsonldjava.utils.JsonUtils
+import com.typesafe.scalalogging.LazyLogging
 import spray.json._
 
 import scala.concurrent.duration._
@@ -38,7 +39,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 /**
   * Object containing methods for dealing with [[HttpResponse]]
   */
-object AkkaHttpUtils {
+object AkkaHttpUtils extends LazyLogging {
 
     /**
       * Given an [[HttpResponse]] containing json, return the said json.
@@ -46,7 +47,7 @@ object AkkaHttpUtils {
       * @param response the [[HttpResponse]] containing json
       * @return an [[JsObject]]
       */
-    def httpResponseToJson(response: HttpResponse)(implicit ec: ExecutionContext, system: ActorSystem, log: LoggingAdapter): JsObject = {
+    def httpResponseToJson(response: HttpResponse)(implicit ec: ExecutionContext, system: ActorSystem): JsObject = {
 
         import DefaultJsonProtocol._
         import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._

--- a/webapi/src/test/scala/org/knora/webapi/util/StartupUtils.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/StartupUtils.scala
@@ -20,6 +20,7 @@
 package org.knora.webapi.util
 
 import akka.pattern.{AskTimeoutException, ask}
+import com.typesafe.scalalogging.LazyLogging
 import org.knora.webapi.messages.app.appmessages.AppState.AppState
 import org.knora.webapi.messages.app.appmessages.{ActorReady, ActorReadyAck, AppState, GetAppState}
 import org.knora.webapi.{Core, KnoraService}
@@ -31,7 +32,7 @@ import scala.concurrent.{Await, Future}
   * This trait is only used for testing. It is necessary so that E2E tests will only start
   * after the KnoraService is ready.
   */
-trait StartupUtils {
+trait StartupUtils extends LazyLogging {
     this: Core with KnoraService =>
 
     /**
@@ -41,7 +42,7 @@ trait StartupUtils {
 
         try {
             Await.result(applicationStateActor ? ActorReady(), 1.second).asInstanceOf[ActorReadyAck]
-            log.info("KnoraService - applicationStateActorReady")
+            logger.info("KnoraService - applicationStateActorReady")
         } catch {
             case e: AskTimeoutException => {
                 // if we are here, then the ask timed out, so we need to try again until the actor is ready

--- a/webapi/src/test/scala/org/knora/webapi/util/TestExtractorMethods.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/TestExtractorMethods.scala
@@ -20,7 +20,6 @@
 package org.knora.webapi.util
 
 import akka.actor.ActorSystem
-import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.HttpResponse
 import org.knora.webapi.InvalidApiJsonException
 import spray.json.JsString
@@ -38,7 +37,7 @@ object ResourceResponseExtractorMethods {
       * @param response the response sent back from the API.
       * @return the value of `res_id`.
       */
-    def getResIriFromJsonResponse(response: HttpResponse)(implicit ec: ExecutionContext, system: ActorSystem, log: LoggingAdapter) = {
+    def getResIriFromJsonResponse(response: HttpResponse)(implicit ec: ExecutionContext, system: ActorSystem) = {
 
         AkkaHttpUtils.httpResponseToJson(response).fields.get("res_id") match {
             case Some(JsString(resourceId)) => resourceId
@@ -58,7 +57,7 @@ object ValuesResponseExtractorMethods {
       * @param response the response sent back from the API.
       * @return the value of `res_id`.
       */
-    def getNewValueIriFromJsonResponse(response: HttpResponse)(implicit ec: ExecutionContext, system: ActorSystem, log: LoggingAdapter) = {
+    def getNewValueIriFromJsonResponse(response: HttpResponse)(implicit ec: ExecutionContext, system: ActorSystem) = {
 
         AkkaHttpUtils.httpResponseToJson(response).fields.get("id") match {
             case Some(JsString(resourceId)) => resourceId


### PR DESCRIPTION
Using Akka logging in non-actors does not work (for me at least). This PR adds plain Scala Logging to plain Scala objects and classes.