### PR TITLE
test: Run unit and E2E tests separately on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ jobs:
         # - sbt knora-graphdb-free/docker:publish
         # - sbt knora-upgrade/docker:publish
         # - sbt knora-assets/docker:publish
-    # unit and e2e tests
+    # unit tests
     - stage: test
       script:
         # prepare needed graphdb-se files
@@ -85,7 +85,24 @@ jobs:
         # hit graphdb with a request "waking-it-up"
         - curl http://localhost:7200/rest/repositories
         # start the built-in webapi server tests
-        - cd $TRAVIS_BUILD_DIR/ && sbt webapi/clean coverage webapi/test webapi/coverageReport
+        - cd $TRAVIS_BUILD_DIR/ && sbt webapi/clean coverage webapi/testOnly -- -l org.knora.webapi.testing.tags.E2ETest webapi/coverageReport
+        # upload code coverage report
+        # - sbt codacyCoverage
+    # e2e tests
+    - stage: test
+      script:
+        # prepare needed graphdb-se files
+        - mkdir -p $TRAVIS_BUILD_DIR/graphdb
+        - cp $TRAVIS_BUILD_DIR/travis/graphdb.license $TRAVIS_BUILD_DIR/graphdb/graphdb.license
+        - cp $TRAVIS_BUILD_DIR/webapi/scripts/KnoraRules.pie $TRAVIS_BUILD_DIR/graphdb
+        # start and initialize graphdb-se
+        - docker run -d -p 127.0.0.1:7200:7200 -v $TRAVIS_BUILD_DIR/graphdb:/graphdb -e GDB_HEAP_SIZE=$GDB_HEAP_SIZE ontotext/graphdb:$GRAPHDB_VERSION -Dgraphdb.license.file=/graphdb/graphdb.license
+        - sleep 15
+        - cd $TRAVIS_BUILD_DIR/webapi/scripts && ./graphdb-se-docker-init-knora-test-unit.sh
+        # hit graphdb with a request "waking-it-up"
+        - curl http://localhost:7200/rest/repositories
+        # start the built-in webapi server tests
+        - cd $TRAVIS_BUILD_DIR/ && sbt webapi/clean coverage webapi/testOnly -- -n org.knora.webapi.testing.tags.E2ETest webapi/coverageReport
         # upload code coverage report
         # - sbt codacyCoverage
     # integration tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ jobs:
         # hit graphdb with a request "waking-it-up"
         - curl http://localhost:7200/rest/repositories
         # start the built-in webapi server tests
-        - cd $TRAVIS_BUILD_DIR/ && sbt webapi/clean coverage webapi/testOnly -- -l org.knora.webapi.testing.tags.E2ETest webapi/coverageReport
+        - cd $TRAVIS_BUILD_DIR/ && sbt webapi/clean coverage 'webapi/testOnly -- -l org.knora.webapi.testing.tags.E2ETest' webapi/coverageReport
         # upload code coverage report
         # - sbt codacyCoverage
     # e2e tests
@@ -102,7 +102,7 @@ jobs:
         # hit graphdb with a request "waking-it-up"
         - curl http://localhost:7200/rest/repositories
         # start the built-in webapi server tests
-        - cd $TRAVIS_BUILD_DIR/ && sbt webapi/clean coverage webapi/testOnly -- -n org.knora.webapi.testing.tags.E2ETest webapi/coverageReport
+        - cd $TRAVIS_BUILD_DIR/ && sbt webapi/clean coverage 'webapi/testOnly -- -n org.knora.webapi.testing.tags.E2ETest' webapi/coverageReport
         # upload code coverage report
         # - sbt codacyCoverage
     # integration tests

--- a/webapi/src/test/scala/org/knora/webapi/e2e/ClientApiRouteE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/ClientApiRouteE2ESpec.scala
@@ -31,6 +31,7 @@ import org.knora.webapi.util.FileUtil
 import scala.concurrent.duration._
 import sys.process._
 import org.apache.commons.io.FileUtils
+import org.knora.webapi.testing.tags.E2ETest
 
 object ClientApiRouteE2ESpec {
     val config: Config = ConfigFactory.parseString(
@@ -40,6 +41,7 @@ object ClientApiRouteE2ESpec {
         """.stripMargin)
 }
 
+@E2ETest
 class ClientApiRouteE2ESpec extends E2ESpec(ClientApiRouteE2ESpec.config) {
     implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(settings.defaultTimeout)
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/ExampleE2ESimSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/ExampleE2ESimSpec.scala
@@ -23,6 +23,7 @@ import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import org.knora.webapi.E2ESimSpec
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.testing.tags.E2ETest
 
 import scala.concurrent.duration._
 
@@ -31,7 +32,8 @@ import scala.concurrent.duration._
   *
   * This simulation scenario accesses the users endpoint with
   * 1000 users concurrently.
-  * */
+  */
+@E2ETest
 class ExampleE2ESimSpec extends E2ESimSpec {
 
     override lazy val rdfDataObjects: Seq[RdfDataObject] = Seq.empty[RdfDataObject]

--- a/webapi/src/test/scala/org/knora/webapi/e2e/ExceptionHandlerR2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/ExceptionHandlerR2RSpec.scala
@@ -19,11 +19,13 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives.{get, path, _}
 import akka.http.scaladsl.server.Route
 import org.knora.webapi._
+import org.knora.webapi.testing.tags.E2ETest
 
 
 /**
   * Route (R2R) test specification for testing exception handling.
   */
+@E2ETest
 class ExceptionHandlerR2RSpec extends R2RSpec {
 
     private val nfe = path( ("v1" | "v2" | "admin") / "nfe") {

--- a/webapi/src/test/scala/org/knora/webapi/e2e/HealthRouteE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/HealthRouteE2ESpec.scala
@@ -21,6 +21,7 @@ import akka.http.scaladsl.testkit.RouteTestTimeout
 import com.typesafe.config.ConfigFactory
 import org.knora.webapi.E2ESpec
 import org.knora.webapi.messages.app.appmessages.{AppState, SetAppState}
+import org.knora.webapi.testing.tags.E2ETest
 
 
 object HealthRouteE2ESpec {
@@ -34,6 +35,7 @@ object HealthRouteE2ESpec {
 /**
   * End-to-End (E2E) test specification for testing route rejections.
   */
+@E2ETest
 class HealthRouteE2ESpec extends E2ESpec(HealthRouteE2ESpec.config) {
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(settings.defaultTimeout)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/InstanceCheckerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/InstanceCheckerSpec.scala
@@ -22,6 +22,7 @@ package org.knora.webapi.e2e
 import akka.actor.ActorSystem
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import com.typesafe.config.{Config, ConfigFactory}
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.StringFormatter
 import org.knora.webapi.{AssertionException, E2ESpec}
@@ -31,6 +32,7 @@ import scala.concurrent.ExecutionContextExecutor
 /**
   * Tests [[InstanceChecker]].
   */
+@E2ETest
 class InstanceCheckerSpec extends E2ESpec(InstanceCheckerSpec.config) {
     private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/RejectingRouteE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/RejectingRouteE2ESpec.scala
@@ -20,6 +20,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import com.typesafe.config.ConfigFactory
 import org.knora.webapi.E2ESpec
+import org.knora.webapi.testing.tags.E2ETest
 
 
 object RejectingRouteE2ESpec {
@@ -34,6 +35,7 @@ object RejectingRouteE2ESpec {
 /**
   * End-to-End (E2E) test specification for testing route rejections.
   */
+@E2ETest
 class RejectingRouteE2ESpec extends E2ESpec(RejectingRouteE2ESpec.config) {
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(settings.defaultTimeout)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/AdminMixE2ESimSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/AdminMixE2ESimSpec.scala
@@ -23,6 +23,7 @@ import io.gatling.core.Predef.{forAll, global, rampUsers, scenario, _}
 import io.gatling.http.Predef.{http, status}
 import org.knora.webapi.E2ESimSpec
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.testing.tags.E2ETest
 
 import scala.concurrent.duration._
 
@@ -31,6 +32,7 @@ import scala.concurrent.duration._
   *
   * This simulation scenario accesses the users, groups, and projects endpoint.
   */
+@E2ETest
 class AdminMixE2ESimSpec extends E2ESimSpec {
 
     override lazy val rdfDataObjects: Seq[RdfDataObject] = Seq.empty[RdfDataObject]

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/GroupsADME2ESimSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/GroupsADME2ESimSpec.scala
@@ -23,6 +23,7 @@ import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import org.knora.webapi.E2ESimSpec
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.testing.tags.E2ETest
 
 import scala.concurrent.duration._
 
@@ -32,6 +33,7 @@ import scala.concurrent.duration._
   * This simulation scenario accesses the groups endpoint with
   * 1000 users concurrently.
   */
+@E2ETest
 class GroupsADME2ESimSpec extends E2ESimSpec {
 
     override lazy val rdfDataObjects: Seq[RdfDataObject] = Seq.empty[RdfDataObject]

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/GroupsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/GroupsADME2ESpec.scala
@@ -26,6 +26,7 @@ import akka.http.scaladsl.testkit.RouteTestTimeout
 import com.typesafe.config.{Config, ConfigFactory}
 import org.knora.webapi.messages.admin.responder.groupsmessages.{GroupADM, GroupsADMJsonProtocol}
 import org.knora.webapi.messages.v1.responder.sessionmessages.SessionJsonProtocol
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.{AkkaHttpUtils, MutableTestIri}
 import org.knora.webapi.{E2ESpec, SharedTestDataADM}
 
@@ -43,6 +44,7 @@ object GroupsADME2ESpec {
 /**
   * End-to-End (E2E) test specification for testing groups endpoint.
   */
+@E2ETest
 class GroupsADME2ESpec extends E2ESpec(GroupsADME2ESpec.config) with GroupsADMJsonProtocol with SessionJsonProtocol {
 
     implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(30.seconds)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/ListsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/ListsADME2ESpec.scala
@@ -29,6 +29,7 @@ import org.knora.webapi.messages.admin.responder.listsmessages._
 import org.knora.webapi.messages.store.triplestoremessages.{RdfDataObject, StringLiteralV2, TriplestoreJsonProtocol}
 import org.knora.webapi.messages.v1.responder.sessionmessages.SessionJsonProtocol
 import org.knora.webapi.messages.v1.routing.authenticationmessages.CredentialsADM
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.{AkkaHttpUtils, MutableTestIri}
 import org.knora.webapi.{E2ESpec, SharedListsTestDataADM, SharedTestDataADM, SharedTestDataV1}
 
@@ -45,6 +46,7 @@ object ListsADME2ESpec {
 /**
   * End-to-End (E2E) test specification for testing users endpoint.
   */
+@E2ETest
 class ListsADME2ESpec extends E2ESpec(ListsADME2ESpec.config) with SessionJsonProtocol with TriplestoreJsonProtocol with ListADMJsonProtocol {
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(5.seconds)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
@@ -22,6 +22,7 @@ package org.knora.webapi.e2e.admin
 import akka.http.scaladsl.model.StatusCodes
 import com.typesafe.config.ConfigFactory
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.{E2ESpec, OntologyConstants, SharedTestDataV1}
 
 import scala.concurrent.duration._
@@ -39,6 +40,7 @@ object PermissionsADME2ESpec {
   *
   * This spec tests the 'v1/store' route.
   */
+@E2ETest
 class PermissionsADME2ESpec extends E2ESpec(PermissionsADME2ESpec.config) with TriplestoreJsonProtocol {
 
     "The Permissions Route ('admin/permissions/projectIri/groupIri')" should {

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESimSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESimSpec.scala
@@ -23,6 +23,7 @@ import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import org.knora.webapi.E2ESimSpec
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.testing.tags.E2ETest
 
 import scala.concurrent.duration._
 
@@ -32,6 +33,7 @@ import scala.concurrent.duration._
   * This simulation scenario accesses the projects endpoint with
   * 1000 users concurrently.
   */
+@E2ETest
 class ProjectsADME2ESimSpec extends E2ESimSpec {
 
     override lazy val rdfDataObjects: Seq[RdfDataObject] = Seq.empty[RdfDataObject]

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESpec.scala
@@ -34,6 +34,7 @@ import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.admin.responder.usersmessages.UsersADMJsonProtocol._
 import org.knora.webapi.messages.store.triplestoremessages.{StringLiteralV2, TriplestoreJsonProtocol}
 import org.knora.webapi.messages.v1.responder.sessionmessages.SessionJsonProtocol
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.{AkkaHttpUtils, MutableTestIri}
 import org.knora.webapi.{E2ESpec, IRI, SharedTestDataADM}
 
@@ -53,6 +54,7 @@ object ProjectsADME2ESpec {
 /**
   * End-to-End (E2E) test specification for testing groups endpoint.
   */
+@E2ETest
 class ProjectsADME2ESpec extends E2ESpec(ProjectsADME2ESpec.config) with SessionJsonProtocol with ProjectsADMJsonProtocol with TriplestoreJsonProtocol {
 
     private implicit def default(implicit system: ActorSystem) = RouteTestTimeout(30.seconds)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/SipiADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/SipiADME2ESpec.scala
@@ -30,6 +30,7 @@ import org.knora.webapi.messages.admin.responder.sipimessages.SipiResponderRespo
 import org.knora.webapi.messages.store.triplestoremessages.{RdfDataObject, TriplestoreJsonProtocol}
 import org.knora.webapi.messages.v1.responder.sessionmessages.{SessionJsonProtocol, SessionResponse}
 import org.knora.webapi.routing.Authenticator.KNORA_AUTHENTICATION_COOKIE_NAME
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.{E2ESpec, SharedTestDataV1}
 
 import scala.concurrent.Await
@@ -49,6 +50,7 @@ object SipiADME2ESpec {
   *
   * This spec tests the 'admin/files'.
   */
+@E2ETest
 class SipiADME2ESpec extends E2ESpec(SipiADME2ESpec.config) with SessionJsonProtocol with TriplestoreJsonProtocol {
 
     private implicit def default(implicit system: ActorSystem) = RouteTestTimeout(30.seconds)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/StoreRouteADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/StoreRouteADME2ESpec.scala
@@ -26,6 +26,7 @@ import com.typesafe.config.ConfigFactory
 import org.knora.webapi.E2ESpec
 import org.knora.webapi.messages.app.appmessages.SetAllowReloadOverHTTPState
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
+import org.knora.webapi.testing.tags.E2ETest
 import spray.json._
 
 import scala.concurrent.duration._
@@ -43,6 +44,7 @@ object StoreRouteADME2ESpec {
   *
   * This spec tests the 'v1/store' route.
   */
+@E2ETest
 class StoreRouteADME2ESpec extends E2ESpec(StoreRouteADME2ESpec.config) with TriplestoreJsonProtocol {
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(120.seconds)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/UsersADME2ESimSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/UsersADME2ESimSpec.scala
@@ -4,6 +4,7 @@ import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import org.knora.webapi.E2ESimSpec
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
+import org.knora.webapi.testing.tags.E2ETest
 
 import scala.concurrent.duration._
 import scala.util.Random
@@ -16,6 +17,7 @@ import scala.util.Random
   * while additional 20 users register themselves. The mean response time should be less
   * then 300 ms (according to a quick google search, 200 ms are standard).
   */
+@E2ETest
 class UsersADME2ESimSpec extends E2ESimSpec {
 
     // need to override this. before each test, the triplestore is automatically reloaded.

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/UsersADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/UsersADME2ESpec.scala
@@ -32,6 +32,7 @@ import org.knora.webapi.messages.admin.responder.usersmessages.UsersADMJsonProto
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
 import org.knora.webapi.messages.v1.responder.sessionmessages.SessionJsonProtocol
 import org.knora.webapi.messages.v1.routing.authenticationmessages.CredentialsV1
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.{AkkaHttpUtils, MutableTestIri}
 
 import scala.concurrent.duration._
@@ -48,6 +49,7 @@ object UsersADME2ESpec {
 /**
   * End-to-End (E2E) test specification for testing users endpoint.
   */
+@E2ETest
 class UsersADME2ESpec extends E2ESpec(UsersADME2ESpec.config) with ProjectsADMJsonProtocol with GroupsADMJsonProtocol with SessionJsonProtocol with TriplestoreJsonProtocol {
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(30.seconds)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/AuthenticationV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/AuthenticationV1E2ESpec.scala
@@ -28,6 +28,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
 import org.knora.webapi.messages.v1.responder.sessionmessages.{SessionJsonProtocol, SessionResponse}
 import org.knora.webapi.routing.Authenticator.KNORA_AUTHENTICATION_COOKIE_NAME
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.{E2ESpec, SharedTestDataV1}
 
 import scala.concurrent.Await
@@ -47,6 +48,7 @@ object AuthenticationV1E2ESpec {
   *
   * This spec tests the 'v1/authentication' and 'v1/session' route.
   */
+@E2ETest
 class AuthenticationV1E2ESpec extends E2ESpec(AuthenticationV1E2ESpec.config) with SessionJsonProtocol with TriplestoreJsonProtocol {
 
     private implicit def default(implicit system: ActorSystem) = RouteTestTimeout(30.seconds)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/CORSSupportV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/CORSSupportV1E2ESpec.scala
@@ -29,6 +29,7 @@ import com.typesafe.config.ConfigFactory
 import org.knora.webapi.E2ESpec
 import org.knora.webapi.http.CORSSupport
 import org.knora.webapi.messages.store.triplestoremessages.{RdfDataObject, TriplestoreJsonProtocol}
+import org.knora.webapi.testing.tags.E2ETest
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -44,6 +45,7 @@ object CORSSupportV1E2ESpec {
 /**
   * End-to-end test specification for testing [[CORSSupport]].
   */
+@E2ETest
 class CORSSupportV1E2ESpec extends E2ESpec(CORSSupportV1E2ESpec.config) with TriplestoreJsonProtocol {
 
     /* set the timeout for the route test */

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ErrorV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ErrorV1E2ESpec.scala
@@ -3,12 +3,14 @@ package org.knora.webapi.e2e.v1
 import akka.http.scaladsl.model.StatusCodes
 import org.knora.webapi.E2ESpec
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
+import org.knora.webapi.testing.tags.E2ETest
 
 import scala.concurrent.duration._
 
 /**
   * Causes an internal server error to see if logging is working correctly.
   */
+@E2ETest
 class ErrorV1E2ESpec extends E2ESpec with TriplestoreJsonProtocol {
 
     "Make a request that causes an internal server error (unit type message)" in {

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ListsV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ListsV1E2ESpec.scala
@@ -26,6 +26,7 @@ import org.knora.webapi.messages.store.triplestoremessages.{RdfDataObject, Tripl
 import org.knora.webapi.messages.v1.responder.listmessages._
 import org.knora.webapi.messages.v1.responder.sessionmessages.SessionJsonProtocol
 import org.knora.webapi.messages.v1.routing.authenticationmessages.CredentialsV1
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.{E2ESpec, SharedTestDataV1}
 
 import scala.concurrent.duration._
@@ -41,6 +42,7 @@ object ListsV1E2ESpec {
 /**
   * End-to-End (E2E) test specification for testing users endpoint.
   */
+@E2ETest
 class ListsV1E2ESpec extends E2ESpec(ListsV1E2ESpec.config) with SessionJsonProtocol with TriplestoreJsonProtocol with ListV1JsonProtocol {
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(5.seconds)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/PermissionsHandlingV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/PermissionsHandlingV1E2ESpec.scala
@@ -24,6 +24,7 @@ import akka.http.scaladsl.model.headers.BasicHttpCredentials
 import com.typesafe.config.ConfigFactory
 import org.knora.webapi._
 import org.knora.webapi.messages.store.triplestoremessages._
+import org.knora.webapi.testing.tags.E2ETest
 
 object PermissionsHandlingV1E2ESpec {
     val config = ConfigFactory.parseString(
@@ -36,6 +37,7 @@ object PermissionsHandlingV1E2ESpec {
 /**
   * End-to-end test specification for testing the handling of permissions.
   */
+@E2ETest
 class PermissionsHandlingV1E2ESpec extends E2ESpec(PermissionsHandlingV1E2ESpec.config) with TriplestoreJsonProtocol {
 
     private val rootUser = SharedTestDataV1.rootUser

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ProjectsV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ProjectsV1E2ESpec.scala
@@ -29,6 +29,7 @@ import org.knora.webapi.messages.v1.responder.projectmessages.{ProjectInfoV1, Pr
 import org.knora.webapi.messages.v1.responder.sessionmessages.SessionJsonProtocol
 import org.knora.webapi.messages.v1.responder.usermessages.UserDataV1
 import org.knora.webapi.messages.v1.responder.usermessages.UserV1JsonProtocol._
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.AkkaHttpUtils
 import org.knora.webapi.{E2ESpec, SharedTestDataV1}
 
@@ -46,6 +47,7 @@ object ProjectsV1E2ESpec {
 /**
   * End-to-End (E2E) test specification for testing groups endpoint.
   */
+@E2ETest
 class ProjectsV1E2ESpec extends E2ESpec(ProjectsV1E2ESpec.config) with SessionJsonProtocol with ProjectV1JsonProtocol with TriplestoreJsonProtocol {
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(30.seconds)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ResourcesV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ResourcesV1R2RSpec.scala
@@ -36,6 +36,7 @@ import org.knora.webapi.messages.v1.responder.resourcemessages.PropsGetForRegion
 import org.knora.webapi.messages.v1.responder.resourcemessages.ResourceV1JsonProtocol._
 import org.knora.webapi.routing.v1.{ResourcesRouteV1, ValuesRouteV1}
 import org.knora.webapi.routing.v2.ResourcesRouteV2
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.{AkkaHttpUtils, MutableTestIri}
 import org.xmlunit.builder.{DiffBuilder, Input}
 import org.xmlunit.diff.Diff
@@ -51,6 +52,7 @@ import scala.xml.{Node, NodeSeq, XML}
   * End-to-end test specification for the resources endpoint. This specification uses the Spray Testkit as documented
   * here: http://spray.io/documentation/1.2.2/spray-testkit/
   */
+@E2ETest
 class ResourcesV1R2RSpec extends R2RSpec {
 
     override def testConfigSource: String =

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/SearchV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/SearchV1R2RSpec.scala
@@ -25,6 +25,7 @@ import akka.http.scaladsl.testkit.RouteTestTimeout
 import org.knora.webapi._
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.routing.v1.SearchRouteV1
+import org.knora.webapi.testing.tags.E2ETest
 import org.scalatest.Assertion
 import spray.json._
 
@@ -34,6 +35,7 @@ import scala.concurrent.ExecutionContextExecutor
   * End-to-end test specification for the search endpoint. This specification uses the Spray Testkit as documented
   * here: http://spray.io/documentation/1.2.2/spray-testkit/
   */
+@E2ETest
 class SearchV1R2RSpec extends R2RSpec {
 
     override def testConfigSource: String =

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/SipiV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/SipiV1R2RSpec.scala
@@ -35,11 +35,13 @@ import org.knora.webapi.messages.v1.responder.resourcemessages.{CreateResourceAp
 import org.knora.webapi.messages.v1.responder.valuemessages.{ChangeFileValueApiRequestV1, CreateFileV1, CreateRichtextV1}
 import org.knora.webapi.routing.v1.{ResourcesRouteV1, ValuesRouteV1}
 import org.knora.webapi.store.iiif.SourcePath
+import org.knora.webapi.testing.tags.E2ETest
 
 /**
   * End-to-end test specification for the resources endpoint. This specification uses the Spray Testkit as documented
   * here: http://spray.io/documentation/1.2.2/spray-testkit/
   */
+@E2ETest
 class SipiV1R2RSpec extends R2RSpec {
 
     override def testConfigSource: String =

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/StandoffV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/StandoffV1R2RSpec.scala
@@ -30,6 +30,7 @@ import org.knora.webapi.SharedTestDataV1._
 import org.knora.webapi._
 import org.knora.webapi.messages.store.triplestoremessages._
 import org.knora.webapi.routing.v1.{StandoffRouteV1, ValuesRouteV1}
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.{AkkaHttpUtils, FileUtil, MutableTestIri}
 import org.xmlunit.builder.{DiffBuilder, Input}
 import org.xmlunit.diff.Diff
@@ -45,6 +46,7 @@ import scala.io.{Codec, Source}
   * End-to-end test specification for the standoff endpoint. This specification uses the Spray Testkit as documented
   * here: http://spray.io/documentation/1.2.2/spray-testkit/
   */
+@E2ETest
 class StandoffV1R2RSpec extends R2RSpec {
 
     override def testConfigSource =

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/UsersV1E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/UsersV1E2ESpec.scala
@@ -27,6 +27,7 @@ import com.typesafe.config.ConfigFactory
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
 import org.knora.webapi.messages.v1.responder.sessionmessages.SessionJsonProtocol
 import org.knora.webapi.messages.v1.routing.authenticationmessages.CredentialsV1
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.AkkaHttpUtils
 import org.knora.webapi.{E2ESpec, IRI, SharedTestDataV1}
 
@@ -43,6 +44,7 @@ object UsersV1E2ESpec {
 /**
   * End-to-End (E2E) test specification for testing users endpoint.
   */
+@E2ETest
 class UsersV1E2ESpec extends E2ESpec(UsersV1E2ESpec.config) with SessionJsonProtocol with TriplestoreJsonProtocol {
 
     implicit def default(implicit system: ActorSystem) = RouteTestTimeout(30.seconds)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v1/ValuesV1R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v1/ValuesV1R2RSpec.scala
@@ -29,12 +29,14 @@ import org.knora.webapi._
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.messages.v1.responder.valuemessages.ApiValueV1JsonProtocol._
 import org.knora.webapi.routing.v1.ValuesRouteV1
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.{AkkaHttpUtils, MutableTestIri}
 import spray.json._
 
 /**
   * Tests the values route.
   */
+@E2ETest
 class ValuesV1R2RSpec extends R2RSpec {
 
     override def testConfigSource: String =

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/AuthenticationV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/AuthenticationV2E2ESpec.scala
@@ -28,6 +28,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import com.typesafe.config.{Config, ConfigFactory}
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
 import org.knora.webapi.messages.v2.routing.authenticationmessages.{AuthenticationV2JsonProtocol, LoginResponse}
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.MutableTestString
 import org.knora.webapi.{E2ESpec, SharedTestDataADM}
 
@@ -48,6 +49,7 @@ object AuthenticationV2E2ESpec {
   *
   * This spec tests the 'v1/authentication' and 'v1/session' route.
   */
+@E2ETest
 class AuthenticationV2E2ESpec extends E2ESpec(AuthenticationV2E2ESpec.config) with AuthenticationV2JsonProtocol with TriplestoreJsonProtocol {
 
     private implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(settings.defaultTimeout)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/JSONLDHandlingV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/JSONLDHandlingV2R2RSpec.scala
@@ -30,6 +30,7 @@ import org.knora.webapi._
 import org.knora.webapi.e2e.v2.ResponseCheckerR2RV2._
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.routing.v2.ResourcesRouteV2
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.jsonld.JsonLDUtil
 import org.knora.webapi.util.{FileUtil, JavaUtil}
 
@@ -38,6 +39,7 @@ import scala.concurrent.ExecutionContextExecutor
 /**
   * End-to-end specification for the handling of JSONLD documents.
   */
+@E2ETest
 class JSONLDHandlingV2R2RSpec extends R2RSpec {
 
     override def testConfigSource: String =

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ListsRouteV2R2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ListsRouteV2R2Spec.scala
@@ -30,6 +30,7 @@ import org.eclipse.rdf4j.model.Model
 import org.knora.webapi._
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.routing.v2.ListsRouteV2
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.FileUtil
 import spray.json.{JsValue, JsonParser}
 
@@ -39,6 +40,7 @@ import scala.concurrent.ExecutionContextExecutor
   * End-to-end test specification for the lists endpoint. This specification uses the Spray Testkit as documented
   * here: http://spray.io/documentation/1.2.2/spray-testkit/
   */
+@E2ETest
 class ListsRouteV2R2Spec extends R2RSpec {
 
     override def testConfigSource: String =

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
@@ -12,6 +12,7 @@ import org.knora.webapi._
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.messages.v2.responder.ontologymessages.{InputOntologyV2, TestResponseParsingModeV2}
 import org.knora.webapi.routing.v2.OntologiesRouteV2
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util._
 import org.knora.webapi.util.jsonld._
@@ -36,6 +37,7 @@ object OntologyV2R2RSpec {
 /**
   * End-to-end test specification for API v2 ontology routes.
   */
+@E2ETest
 class OntologyV2R2RSpec extends R2RSpec {
 
     import OntologyV2R2RSpec._

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -33,6 +33,7 @@ import org.knora.webapi.e2e.InstanceChecker
 import org.knora.webapi.e2e.v2.ResponseCheckerR2RV2._
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.routing.RouteUtilV2
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.jsonld._
 import org.knora.webapi.util._
@@ -45,6 +46,7 @@ import scala.concurrent.ExecutionContextExecutor
 /**
   * Tests the API v2 resources route.
   */
+@E2ETest
 class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
     private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -34,6 +34,7 @@ import org.knora.webapi.responders.v2.search._
 import org.knora.webapi.routing.RouteUtilV2
 import org.knora.webapi.routing.v1.ValuesRouteV1
 import org.knora.webapi.routing.v2.{ResourcesRouteV2, SearchRouteV2, StandoffRouteV2}
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.{FileUtil, MutableTestIri, StringFormatter}
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.jsonld.{JsonLDConstants, JsonLDDocument, JsonLDUtil}
@@ -48,6 +49,7 @@ import scala.concurrent.ExecutionContextExecutor
   * End-to-end test specification for the search endpoint. This specification uses the Spray Testkit as documented
   * here: http://spray.io/documentation/1.2.2/spray-testkit/
   */
+@E2ETest
 class SearchRouteV2R2RSpec extends R2RSpec {
     private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/StandoffRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/StandoffRouteV2R2RSpec.scala
@@ -31,6 +31,7 @@ import org.knora.webapi._
 import org.knora.webapi.e2e.v2.ResponseCheckerR2RV2.compareJSONLDForMappingCreationResponse
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.routing.v2.StandoffRouteV2
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.FileUtil
 
 import scala.concurrent.ExecutionContextExecutor
@@ -40,6 +41,7 @@ import scala.concurrent.ExecutionContextExecutor
   * End-to-end test specification for the search endpoint. This specification uses the Spray Testkit as documented
   * here: http://spray.io/documentation/1.2.2/spray-testkit/
   */
+@E2ETest
 class StandoffRouteV2R2RSpec extends R2RSpec {
 
     override def testConfigSource: String =

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ValuesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ValuesRouteV2E2ESpec.scala
@@ -30,10 +30,12 @@ import akka.http.scaladsl.testkit.RouteTestTimeout
 import org.knora.webapi._
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.responders.v2.search.SparqlQueryConstants
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util._
 import org.knora.webapi.util.jsonld._
 
+@E2ETest
 class ValuesRouteV2E2ESpec extends E2ESpec {
 
     private implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(settings.defaultTimeout)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ValuesV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ValuesV2R2RSpec.scala
@@ -28,6 +28,7 @@ import org.knora.webapi.app.{APPLICATION_MANAGER_ACTOR_NAME, ApplicationActor}
 import org.knora.webapi.messages.store.triplestoremessages.RdfDataObject
 import org.knora.webapi.responders.v2.search.SparqlQueryConstants
 import org.knora.webapi.routing.v2.{SearchRouteV2, ValuesRouteV2}
+import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.jsonld._
 import org.knora.webapi.util.{MutableTestIri, SmartIri, StringFormatter}
@@ -37,6 +38,7 @@ import scala.concurrent.ExecutionContextExecutor
 /**
   * Tests creating a still image file value using a mock Sipi.
   */
+@E2ETest
 class ValuesV2R2RSpec extends R2RSpec {
     override def testConfigSource: String =
         """

--- a/webapi/src/test/scala/org/knora/webapi/testing/tagobjects/E2ETest.scala
+++ b/webapi/src/test/scala/org/knora/webapi/testing/tagobjects/E2ETest.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.testing.tagobjects
+
+import org.scalatest.Tag
+
+object E2ETest extends Tag("org.knora.webapi.testing.tags.E2ETest")

--- a/webapi/src/test/scala/org/knora/webapi/testing/tags/E2ETest.java
+++ b/webapi/src/test/scala/org/knora/webapi/testing/tags/E2ETest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.testing.tags;
+
+import java.lang.annotation.*;
+import org.scalatest.TagAnnotation;
+
+@TagAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface E2ETest {}


### PR DESCRIPTION
This adds a ScalaTest tag, `E2ETest`, tags all the E2E tests with it, and uses it to run them separately from the other tests on Travis.

Resolves #1410.
