### PR TITLE
fix(gravsearch): Fix generation of variable name for link value

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/SparqlTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/SparqlTransformer.scala
@@ -143,4 +143,17 @@ object SparqlTransformer {
         }
     }
 
+    /**
+      * Create a unique variable from a whole statement.
+      *
+      * @param baseStatement the statement to be used to create the variable base name.
+      * @param suffix        the suffix to be appended to the base name.
+      * @return a unique variable.
+      */
+    def createUniqueVariableFromStatement(baseStatement: StatementPattern, suffix: String): QueryVariable = {
+        QueryVariable(SparqlTransformer.escapeEntityForVariable(baseStatement.subj) + "__" + SparqlTransformer.escapeEntityForVariable(baseStatement.pred) + "__" + SparqlTransformer.escapeEntityForVariable(baseStatement.obj) + "__" + suffix)
+    }
+
+
+
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/SparqlTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/SparqlTransformer.scala
@@ -154,6 +154,14 @@ object SparqlTransformer {
         QueryVariable(SparqlTransformer.escapeEntityForVariable(baseStatement.subj) + "__" + SparqlTransformer.escapeEntityForVariable(baseStatement.pred) + "__" + SparqlTransformer.escapeEntityForVariable(baseStatement.obj) + "__" + suffix)
     }
 
-
+    /**
+      * Create a unique variable name from a whole statement for a link value.
+      *
+      * @param baseStatement the statement to be used to create the variable base name.
+      * @return a unique variable for a link value.
+      */
+    def createUniqueVariableFromStatementForLinkValue(baseStatement: StatementPattern): QueryVariable = {
+        createUniqueVariableFromStatement(baseStatement, "LinkValue")
+    }
 
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/mainquery/GravsearchMainQueryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/mainquery/GravsearchMainQueryGenerator.scala
@@ -133,9 +133,8 @@ object GravsearchMainQueryGenerator {
                         // linking prop: get value object var and information which values are requested for dependent resource
 
                         // link value object variable
-                        val valObjVar = SparqlTransformer.createUniqueVariableFromStatement(
-                            baseStatement = statementPattern,
-                            suffix = "LinkValue"
+                        val valObjVar = SparqlTransformer.createUniqueVariableFromStatementForLinkValue(
+                            baseStatement = statementPattern
                         )
 
                         // return link value object variable and value objects requested for the dependent resource

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/mainquery/GravsearchMainQueryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/mainquery/GravsearchMainQueryGenerator.scala
@@ -133,7 +133,10 @@ object GravsearchMainQueryGenerator {
                         // linking prop: get value object var and information which values are requested for dependent resource
 
                         // link value object variable
-                        val valObjVar = SparqlTransformer.createUniqueVariableNameFromEntityAndProperty(statementPattern.obj, OntologyConstants.KnoraBase.LinkValue)
+                        val valObjVar = SparqlTransformer.createUniqueVariableFromStatement(
+                            baseStatement = statementPattern,
+                            suffix = "LinkValue"
+                        )
 
                         // return link value object variable and value objects requested for the dependent resource
                         Set(QueryVariable(valObjVar.variableName + variableConcatSuffix))

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
@@ -136,17 +136,6 @@ abstract class AbstractPrequeryGenerator(typeInspectionResult: GravsearchTypeIns
     protected val standoffMarkedUpVariables = mutable.Set.empty[QueryVariable]
 
     /**
-      * Create a unique variable from a whole statement.
-      *
-      * @param baseStatement the statement to be used to create the variable base name.
-      * @param suffix        the suffix to be appended to the base name.
-      * @return a unique variable.
-      */
-    protected def createUniqueVariableFromStatement(baseStatement: StatementPattern, suffix: String): QueryVariable = {
-        QueryVariable(SparqlTransformer.escapeEntityForVariable(baseStatement.subj) + "__" + SparqlTransformer.escapeEntityForVariable(baseStatement.pred) + "__" + SparqlTransformer.escapeEntityForVariable(baseStatement.obj) + "__" + suffix)
-    }
-
-    /**
       * Checks if a statement represents the knora-base:isMainResource statement and returns the query variable representing the main resource if so.
       *
       * @param statementPattern the statement pattern to be checked.
@@ -230,7 +219,7 @@ abstract class AbstractPrequeryGenerator(typeInspectionResult: GravsearchTypeIns
       */
     private def generateStatementsForLinkValue(linkSource: Entity, linkPred: Entity, linkTarget: Entity): Seq[StatementPattern] = {
         // Generate a variable name representing the link value
-        val linkValueObjVar: QueryVariable = createUniqueVariableFromStatement(
+        val linkValueObjVar: QueryVariable = SparqlTransformer.createUniqueVariableFromStatement(
             baseStatement = StatementPattern(
                 subj = linkSource,
                 pred = linkPred,
@@ -304,7 +293,7 @@ abstract class AbstractPrequeryGenerator(typeInspectionResult: GravsearchTypeIns
             val listNode: Entity = statementPattern.obj
 
             // variable representing the list node to match for
-            val listNodeVar: QueryVariable = createUniqueVariableFromStatement(
+            val listNodeVar: QueryVariable = SparqlTransformer.createUniqueVariableFromStatement(
                 baseStatement = statementPattern,
                 suffix = "listNodeVar"
             )

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
@@ -230,9 +230,13 @@ abstract class AbstractPrequeryGenerator(typeInspectionResult: GravsearchTypeIns
       */
     private def generateStatementsForLinkValue(linkSource: Entity, linkPred: Entity, linkTarget: Entity): Seq[StatementPattern] = {
         // Generate a variable name representing the link value
-        val linkValueObjVar: QueryVariable = SparqlTransformer.createUniqueVariableNameFromEntityAndProperty(
-            base = linkTarget,
-            propertyIri = OntologyConstants.KnoraBase.LinkValue
+        val linkValueObjVar: QueryVariable = createUniqueVariableFromStatement(
+            baseStatement = StatementPattern(
+                subj = linkSource,
+                pred = linkPred,
+                obj = linkTarget
+            ),
+            suffix = "LinkValue"
         )
 
         // add variable to collection representing value objects

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
@@ -219,13 +219,12 @@ abstract class AbstractPrequeryGenerator(typeInspectionResult: GravsearchTypeIns
       */
     private def generateStatementsForLinkValue(linkSource: Entity, linkPred: Entity, linkTarget: Entity): Seq[StatementPattern] = {
         // Generate a variable name representing the link value
-        val linkValueObjVar: QueryVariable = SparqlTransformer.createUniqueVariableFromStatement(
+        val linkValueObjVar: QueryVariable = SparqlTransformer.createUniqueVariableFromStatementForLinkValue(
             baseStatement = StatementPattern(
                 subj = linkSource,
                 pred = linkPred,
                 obj = linkTarget
-            ),
-            suffix = "LinkValue"
+            )
         )
 
         // add variable to collection representing value objects

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -7891,5 +7891,122 @@ class SearchRouteV2R2RSpec extends R2RSpec {
                 xmlDiff.hasDifferences should be(false)
             }
         }
+
+        "find a resource with two different incoming links" in {
+            // Create the target resource.
+
+            val targetResource: String =
+                """{
+                  |  "@type" : "anything:BlueThing",
+                  |  "knora-api:attachedToProject" : {
+                  |    "@id" : "http://rdfh.ch/projects/0001"
+                  |  },
+                  |  "rdfs:label" : "blue thing with incoming links",
+                  |  "@context" : {
+                  |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                  |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+                  |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+                  |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+                  |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+                  |  }
+                  |}""".stripMargin
+
+            val targetResourceIri: IRI = Post(s"/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, targetResource)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> resourcePath ~> check {
+                val createTargetResourceResponseStr = responseAs[String]
+                assert(response.status == StatusCodes.OK, createTargetResourceResponseStr)
+                val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)
+                responseJsonDoc.body.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.validateAndEscapeIri)
+            }
+
+            assert(targetResourceIri.toSmartIri.isKnoraDataIri)
+
+            val sourceResource1: String =
+                s"""{
+                   |  "@type" : "anything:BlueThing",
+                   |  "knora-api:attachedToProject" : {
+                   |    "@id" : "http://rdfh.ch/projects/0001"
+                   |  },
+                   |    "anything:hasBlueThingValue" : {
+                   |    "@type" : "knora-api:LinkValue",
+                   |        "knora-api:linkValueHasTargetIri" : {
+                   |        "@id" : "$targetResourceIri"
+                   |    }
+                   |  },
+                   |  "rdfs:label" : "blue thing with link to other blue thing",
+                   |  "@context" : {
+                   |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                   |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+                   |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+                   |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+                   |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+                   |  }
+                   |}""".stripMargin
+
+            val sourceResource1Iri: IRI = Post(s"/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, sourceResource1)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> resourcePath ~> check {
+                val createSourceResource1ResponseStr = responseAs[String]
+                assert(response.status == StatusCodes.OK, createSourceResource1ResponseStr)
+                val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)
+                responseJsonDoc.body.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.validateAndEscapeIri)
+            }
+
+            assert(sourceResource1Iri.toSmartIri.isKnoraDataIri)
+
+            val sourceResource2: String =
+                s"""{
+                   |  "@type" : "anything:Thing",
+                   |  "knora-api:attachedToProject" : {
+                   |    "@id" : "http://rdfh.ch/projects/0001"
+                   |  },
+                   |    "anything:hasOtherThingValue" : {
+                   |    "@type" : "knora-api:LinkValue",
+                   |        "knora-api:linkValueHasTargetIri" : {
+                   |        "@id" : "$targetResourceIri"
+                   |    }
+                   |  },
+                   |  "rdfs:label" : "thing with link to blue thing",
+                   |  "@context" : {
+                   |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                   |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+                   |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+                   |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+                   |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+                   |  }
+                   |}""".stripMargin
+
+            val sourceResource2Iri: IRI = Post(s"/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, sourceResource2)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> resourcePath ~> check {
+                val createSourceResource2ResponseStr = responseAs[String]
+                assert(response.status == StatusCodes.OK, createSourceResource2ResponseStr)
+                val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)
+                responseJsonDoc.body.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.validateAndEscapeIri)
+            }
+
+            assert(sourceResource2Iri.toSmartIri.isKnoraDataIri)
+
+            val gravsearchQuery =
+                s"""
+                   |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+                   |PREFIX standoff: <http://api.knora.org/ontology/standoff/v2#>
+                   |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/v2#>
+                   |
+                   |CONSTRUCT {
+                   |    ?targetThing knora-api:isMainResource true .
+                   |    ?firstIncoming anything:hasBlueThing ?targetThing .
+                   |    ?secondIncoming anything:hasOtherThing ?targetThing .
+                   |} WHERE {
+                   |    ?targetThing a anything:BlueThing .
+                   |    ?firstIncoming anything:hasBlueThing ?targetThing .
+                   |    ?secondIncoming anything:hasOtherThing ?targetThing .
+                   |}
+                """.stripMargin
+
+            val searchResultIri: IRI = Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)
+                responseJsonDoc.body.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.validateAndEscapeIri)
+            }
+
+            assert(searchResultIri == targetResourceIri)
+        }
     }
 }


### PR DESCRIPTION
This fixes a bug in the generation of a unique variable name for a `LinkValue` in the SPARQL prequery generated from a Gravsearch query.

Fixes #1416.

@gfoo could you please test this?