### PR TITLE
fix(api-v2): Fix checking of label of newly created resource

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -1036,7 +1036,10 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
                 throw AssertionException(s"Resource <$resourceIri> was saved, but it has the wrong permissions")
             }
 
-            _ = if (resource.label != resourceReadyToCreate.sparqlTemplateResourceToCreate.resourceLabel) {
+            // Undo any escapes in the submitted rdfs:label to compare it with the saved one.
+            unescapedLabel: String = stringFormatter.fromSparqlEncodedString(resourceReadyToCreate.sparqlTemplateResourceToCreate.resourceLabel)
+
+            _ = if (resource.label != unescapedLabel) {
                 throw AssertionException(s"Resource <$resourceIri> was saved, but it has the wrong label")
             }
 

--- a/webapi/src/main/scala/org/knora/webapi/util/jsonld/JsonLDUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/jsonld/JsonLDUtil.scala
@@ -762,8 +762,15 @@ object JsonLDUtil {
       * @return a JSON-LD object containing `@value` and `@type` predicates.
       */
     def datatypeValueToJsonLDObject(value: String, datatype: SmartIri): JsonLDObject = {
+        // Normalise the formatting of decimal values to ensure consistency in tests.
+        val strValue: String = if (datatype.toString == OntologyConstants.Xsd.Decimal) {
+            BigDecimal(value).underlying.stripTrailingZeros.toPlainString
+        } else {
+            value
+        }
+
         JsonLDObject(Map(
-            JsonLDConstants.VALUE -> JsonLDString(value),
+            JsonLDConstants.VALUE -> JsonLDString(strValue),
             JsonLDConstants.TYPE -> JsonLDString(datatype.toString)
         ))
     }

--- a/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithUnicodeEscape.jsonld
+++ b/webapi/src/test/resources/test-data/resourcesR2RV2/ThingWithUnicodeEscape.jsonld
@@ -1,0 +1,14 @@
+{
+  "@type" : "anything:Thing",
+  "knora-api:attachedToProject" : {
+    "@id" : "http://rdfh.ch/projects/0001"
+  },
+  "rdfs:label": "Pr\u00e9sentation du projet à \"Lausanne\"",
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+  }
+}

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -638,6 +638,16 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             assert(text == "this is text with standoff")
         }
 
+        "create a resource whose label contains a Unicode escape and quotation marks" in {
+            val jsonLDEntity: String = FileUtil.readTextFile(new File("src/test/resources/test-data/resourcesR2RV2/ThingWithUnicodeEscape.jsonld"))
+            val request = Post(s"$baseApiUrl/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
+            val response: HttpResponse = singleAwaitingRequest(request)
+            assert(response.status == StatusCodes.OK, response.toString)
+            val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)
+            val resourceIri: IRI = responseJsonDoc.body.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.validateAndEscapeIri)
+            assert(resourceIri.toSmartIri.isKnoraDataIri)
+        }
+
         "create a resource with a custom creation date" in {
             val creationDate: Instant = Instant.parse("2019-01-09T15:45:54.502951Z")
 


### PR DESCRIPTION
If a resource is created with an `rdfs:label` containing escaped characters, these need to be unescaped when comparing the label in the request with the label in the saved resource.

Fixes #1452.